### PR TITLE
feat: Discord マルチボットエージェント対応

### DIFF
--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -62,9 +62,9 @@ agents:
 - DM は常に許可される
 - 各 Bot のメッセージは Agent ID でタグ付けされたセッションに記録される
 
-### Legacy 互換
+### `channels.discord.bot_token` について
 
-`channels.discord.bot_token` は単一 Bot 運用向けのレガシー設定。マルチ Bot 環境では `agents.<id>.discord.bot_token` を使用する。
+`channels.discord.bot_token` は読み込まれない。Discord Bot を起動するには、各 Agent に `agents.<id>.discord.bot_token` を設定する必要がある。`channels.discord` には `enabled: true` のみを指定する。
 
 ## 内部セッション管理
 
@@ -73,4 +73,3 @@ agents:
 ## 関連ドキュメント
 
 - 設定仕様: [config.md](./config.md)（`agents` セクション）
-- デプロイ手順: [deploy.md](./deploy.md)（Discord Multi-Bot 運用）

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -1,0 +1,76 @@
+# EgoPulse Multi-Agent
+
+マルチエージェント機能の運用ガイド。
+
+## 概要
+
+EgoPulse は複数の AI エージェントを 1 プロセスで同時に運用できる。各エージェントは個別のアイデンティティ（label）、LLM 設定（provider / model）、Discord Bot Token を持つ。
+
+## Agent 定義
+
+`agents` マップでエージェントを定義する。キーはエージェント ID。
+
+```yaml
+agents:
+  default:
+    label: Default Agent
+    model: gpt-4o-mini
+    provider: null
+```
+
+`default_agent` でエージェント未指定時のフォールバックを指定する。
+
+## LLM 解決チェーン
+
+Agent ごとに異なる LLM 設定が可能。解決優先度:
+
+1. `agent.provider` / `agent.model`
+2. `channel.provider` / `channel.model`
+3. `config.default_provider` / `config.default_model`
+4. `provider.default_model`
+
+## Discord Multi-Bot
+
+Agent ごとに個別の Discord Bot Token を設定できる（1 Bot = 1 Agent）。
+
+### 設定例
+
+```yaml
+agents:
+  developer:
+    label: Developer Bot
+    discord:
+      bot_token:
+        source: env
+        id: DISCORD_AGENT_BOT_TOKEN_DEVELOPER
+      allowed_channels:
+        - 1234567890123456789
+  reviewer:
+    label: Reviewer Bot
+    discord:
+      bot_token:
+        source: env
+        id: DISCORD_AGENT_BOT_TOKEN_REVIEWER
+      allowed_channels:
+        - 9876543210987654321
+```
+
+### 起動時の動作
+
+- `discord.bot_token` を持つ Agent の数だけ Discord Bot クライアントが起動する
+- 各 Bot は Agent 固有の `allowed_channels` で応答可否を判定する
+- DM は常に許可される
+- 各 Bot のメッセージは Agent ID でタグ付けされたセッションに記録される
+
+### Legacy 互換
+
+`channels.discord.bot_token` は単一 Bot 運用向けのレガシー設定。マルチ Bot 環境では `agents.<id>.discord.bot_token` を使用する。
+
+## 内部セッション管理
+
+マルチエージェント Discord Bot では、セッションスレッド ID が `{channel_id}:agent:{agent_id}` 形式になり、同一チャネル内でもエージェントごとに独立した会話履歴が保持される。
+
+## 関連ドキュメント
+
+- 設定仕様: [config.md](./config.md)（`agents` セクション）
+- デプロイ手順: [deploy.md](./deploy.md)（Discord Multi-Bot 運用）

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -169,18 +169,22 @@ struct Handler {
 }
 
 impl Handler {
+    fn agent_thread(&self, thread: &str) -> String {
+        format!("{thread}:agent:{}", self.agent_id)
+    }
+
     fn make_context(&self, user: &str, thread: &str) -> SurfaceContext {
         SurfaceContext {
             channel: "discord".to_string(),
             surface_user: user.to_string(),
-            surface_thread: format!("{thread}:agent:{}", self.agent_id),
+            surface_thread: self.agent_thread(thread),
             chat_type: "discord".to_string(),
             agent_id: self.agent_id.clone(),
         }
     }
 
     fn guild_allowed(&self, channel_id: u64) -> bool {
-        self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id)
+        self.allowed_channels.contains(&channel_id)
     }
 }
 
@@ -204,7 +208,7 @@ impl EventHandler for Handler {
             let slash_chat_id =
                 crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
                     let channel = "discord".to_string();
-                    let ext_id = format!("{thread}:agent:{}", self.agent_id);
+                    let ext_id = self.agent_thread(&thread);
                     let chat_type = "discord".to_string();
                     move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
                 })
@@ -347,7 +351,7 @@ impl EventHandler for Handler {
         let slash_chat_id =
             crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
                 let channel = "discord".to_string();
-                let ext_id = thread.clone();
+                let ext_id = self.agent_thread(&thread);
                 let chat_type = "discord".to_string();
                 move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
             })
@@ -563,6 +567,29 @@ pub async fn start_discord_bot(
 mod tests {
     use super::*;
 
+    fn test_handler(allowed_channels: Vec<u64>) -> Handler {
+        Handler {
+            app_state: Arc::new(crate::agent_loop::turn::build_state_with_provider(
+                tempfile::tempdir()
+                    .expect("tempdir")
+                    .path()
+                    .to_str()
+                    .expect("utf8")
+                    .to_string(),
+                Box::new(crate::agent_loop::turn::FakeProvider {
+                    responses: std::sync::Mutex::new(vec![crate::llm::MessagesResponse {
+                        content: "ok".to_string(),
+                        tool_calls: vec![],
+                        usage: None,
+                    }]),
+                }),
+            )),
+            agent_id: "developer".to_string(),
+            agent_label: "Developer".to_string(),
+            allowed_channels,
+        }
+    }
+
     #[test]
     fn adapter_name() {
         let adapter = DiscordAdapter::new("test-token".to_string());
@@ -622,6 +649,32 @@ mod tests {
     #[test]
     fn parse_discord_chat_id_rejects_empty_channel() {
         assert!(parse_discord_chat_id(":agent:developer").is_err());
+    }
+
+    #[test]
+    fn guild_allowed_rejects_empty_allowed_channels() {
+        let handler = test_handler(vec![]);
+
+        assert!(!handler.guild_allowed(123));
+    }
+
+    #[test]
+    fn guild_allowed_accepts_listed_channel_only() {
+        let handler = test_handler(vec![123, 456]);
+
+        assert!(handler.guild_allowed(123));
+        assert!(!handler.guild_allowed(789));
+    }
+
+    #[test]
+    fn interaction_chat_id_uses_agent_scoped_thread() {
+        let handler = test_handler(vec![123]);
+
+        assert_eq!(handler.agent_thread("123"), "123:agent:developer");
+        assert_eq!(
+            handler.make_context("user", "123").surface_thread,
+            "123:agent:developer"
+        );
     }
 
     /// Interaction コマンド名 → "/command" 形式の正規化が正しいこと。

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -135,44 +135,48 @@ impl ChannelAdapter for DiscordAdapter {
 /// serenity EventHandler。インバウンドメッセージを処理する。
 struct Handler {
     app_state: Arc<AppState>,
+    agent_id: String,
+    agent_label: String,
+    allowed_channels: Vec<u64>,
+}
+
+impl Handler {
+    fn make_context(&self, user: &str, thread: &str) -> SurfaceContext {
+        SurfaceContext {
+            channel: "discord".to_string(),
+            surface_user: user.to_string(),
+            surface_thread: format!("{thread}:agent:{}", self.agent_id),
+            chat_type: "discord".to_string(),
+            agent_id: self.agent_id.clone(),
+        }
+    }
+
+    fn guild_allowed(&self, channel_id: u64) -> bool {
+        self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id)
+    }
 }
 
 #[serenity::async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: DiscordMessage) {
-        // bot 自身のメッセージは無視
         if msg.author.bot {
             return;
         }
 
         let text = msg.content.clone();
-        let external_channel_id = msg.channel_id.get();
+        let channel_id = msg.channel_id.get();
 
-        // ギルドメッセージは allowed_channels に含まれるチャンネルのみ応答する。
-        // DM は個人チャネルとして常に通す。
-        let allowed_channels = self
-            .app_state
-            .config
-            .channels
-            .get("discord")
-            .and_then(|c| c.allowed_channels.clone())
-            .unwrap_or_default();
-        if msg.guild_id.is_some()
-            && (allowed_channels.is_empty() || !allowed_channels.contains(&external_channel_id))
-        {
+        if msg.guild_id.is_some() && !self.guild_allowed(channel_id) {
             return;
         }
 
-        let external_chat_id = external_channel_id.to_string();
+        let thread = channel_id.to_string();
 
-        // --- スラッシュコマンドインターセプト ---
-        // process_turn より先に chat_id を解決し、
-        // スラッシュコマンドであればエージェントループに入らずに即応答する。
         if crate::slash_commands::is_slash_command(&text) {
             let slash_chat_id =
                 crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
                     let channel = "discord".to_string();
-                    let ext_id = external_chat_id.clone();
+                    let ext_id = thread.clone();
                     let chat_type = "discord".to_string();
                     move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
                 })
@@ -181,13 +185,7 @@ impl EventHandler for Handler {
             match slash_chat_id {
                 Ok(chat_id) => {
                     let sender_id = msg.author.id.get().to_string();
-                    let slash_context = SurfaceContext {
-                        channel: "discord".to_string(),
-                        surface_user: msg.author.name.clone(),
-                        surface_thread: external_chat_id.clone(),
-                        chat_type: "discord".to_string(),
-                        agent_id: self.app_state.config.default_agent.to_string(),
-                    };
+                    let slash_context = self.make_context(&msg.author.name, &thread);
                     if let Some(response) = crate::slash_commands::handle_slash_command(
                         &self.app_state,
                         chat_id,
@@ -220,33 +218,23 @@ impl EventHandler for Handler {
                 }
             }
         }
-        // --- インターセプトここまで ---
 
         if text.is_empty() {
             return;
         }
 
-        let sender_name = msg.author.name.clone();
-
-        let context = SurfaceContext {
-            channel: "discord".to_string(),
-            surface_user: sender_name,
-            surface_thread: external_chat_id.clone(),
-            chat_type: "discord".to_string(),
-            agent_id: self.app_state.config.default_agent.to_string(),
-        };
+        let context = self.make_context(&msg.author.name, &thread);
 
         info!(
-            channel_id = external_chat_id,
+            channel_id = channel_id,
+            agent = %self.agent_id,
             sender = %context.surface_user,
             text_length = text.len(),
             "Discord message received"
         );
 
-        // タイピングインジケーター開始
         let typing = msg.channel_id.start_typing(&ctx.http);
 
-        // session 解決は process_turn() に一任 (二重解決を避ける)
         match crate::agent_loop::process_turn(&self.app_state, &context, &text).await {
             Ok(response) => {
                 drop(typing);
@@ -257,7 +245,8 @@ impl EventHandler for Handler {
             Err(e) => {
                 drop(typing);
                 error!(
-                    channel_id = external_chat_id,
+                    channel_id = channel_id,
+                    agent = %self.agent_id,
                     error_kind = e.error_kind(),
                     error = %e,
                     error_debug = ?e,
@@ -271,14 +260,16 @@ impl EventHandler for Handler {
     }
 
     async fn ready(&self, ctx: Context, ready: Ready) {
-        info!("Discord bot connected as {}", ready.user.name);
+        info!(
+            "Discord bot ({}) connected as {}",
+            self.agent_label, ready.user.name
+        );
 
         let commands: Vec<serenity::builder::CreateCommand> = crate::slash_commands::all_commands()
             .iter()
             .map(|c| {
                 let builder =
                     serenity::builder::CreateCommand::new(c.name).description(c.description);
-                // 引数を持つコマンドには String option を追加
                 if c.usage.contains('[') {
                     builder.add_option(
                         serenity::builder::CreateCommandOption::new(
@@ -308,7 +299,6 @@ impl EventHandler for Handler {
             return;
         };
 
-        // Discord 3秒ルール対応: 即座に defer して "thinking..." を表示
         if let Err(e) = cmd
             .create_response(
                 &ctx.http,
@@ -323,15 +313,13 @@ impl EventHandler for Handler {
         }
 
         let command_text = interaction_to_command_text(&cmd.data.name, &cmd.data.options);
-
-        // チャネル ID を解決して内部 chat_id を取得
         let channel_id = cmd.channel_id.get();
-        let external_chat_id = channel_id.to_string();
+        let thread = channel_id.to_string();
 
         let slash_chat_id =
             crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
                 let channel = "discord".to_string();
-                let ext_id = external_chat_id.clone();
+                let ext_id = thread.clone();
                 let chat_type = "discord".to_string();
                 move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
             })
@@ -340,13 +328,7 @@ impl EventHandler for Handler {
         let response_text = match slash_chat_id {
             Ok(chat_id) => {
                 let sender_id = cmd.user.id.get().to_string();
-                let slash_context = SurfaceContext {
-                    channel: "discord".to_string(),
-                    surface_user: cmd.user.name.clone(),
-                    surface_thread: external_chat_id.clone(),
-                    chat_type: "discord".to_string(),
-                    agent_id: self.app_state.config.default_agent.to_string(),
-                };
+                let slash_context = self.make_context(&cmd.user.name, &thread);
                 crate::slash_commands::handle_slash_command(
                     &self.app_state,
                     chat_id,
@@ -363,7 +345,6 @@ impl EventHandler for Handler {
             }
         };
 
-        // defer 後の編集で最終応答を送信
         if let Err(e) = cmd
             .edit_response(
                 &ctx.http,
@@ -423,9 +404,55 @@ pub async fn start_discord_bot_for_agent(
     agent_id: &crate::config::AgentId,
     allowed_channels: &[u64],
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let _ = agent_id;
-    let _ = allowed_channels;
-    start_discord_bot(state, token.to_string()).await
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+
+    let agent_label = state
+        .config
+        .agents
+        .get(agent_id)
+        .map(|a| a.label.as_str())
+        .unwrap_or(agent_id.as_str())
+        .to_string();
+
+    info!(
+        "Starting Discord bot for agent '{}' ({agent_label}) ...",
+        agent_id.as_str(),
+    );
+
+    let handler = Handler {
+        app_state: state,
+        agent_id: agent_id.to_string(),
+        agent_label,
+        allowed_channels: allowed_channels.to_vec(),
+    };
+
+    let mut client = Client::builder(token, intents)
+        .event_handler(handler)
+        .await
+        .map_err(|e| {
+            error!("Discord bot failed to start: {e}");
+            e
+        })?;
+
+    let shard_manager = client.shard_manager.clone();
+    let shutdown_task = tokio::spawn(async move {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            error!("Discord bot failed to listen for Ctrl-C: {e}");
+            return;
+        }
+        shard_manager.shutdown_all().await;
+    });
+
+    client.start().await.map_err(|e| {
+        error!("Discord bot error: {e}");
+        e
+    })?;
+
+    shutdown_task.abort();
+
+    Ok(())
 }
 
 /// Starts the Discord bot and supervises its gateway lifecycle.
@@ -433,13 +460,34 @@ pub async fn start_discord_bot(
     state: Arc<AppState>,
     token: String,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // legacy path: use default agent. Prefer start_discord_bot_for_agent instead.
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
 
+    let default_agent = state.config.default_agent.to_string();
+    let agent_label = state
+        .config
+        .agents
+        .get(&state.config.default_agent)
+        .map(|a| a.label.as_str())
+        .unwrap_or("default")
+        .to_string();
+    let allowed_channels = state
+        .config
+        .channels
+        .get("discord")
+        .and_then(|c| c.allowed_channels.clone())
+        .unwrap_or_default();
+
     info!("Starting Discord bot (requesting MESSAGE_CONTENT intent)...");
 
-    let handler = Handler { app_state: state };
+    let handler = Handler {
+        app_state: state,
+        agent_id: default_agent,
+        agent_label,
+        allowed_channels,
+    };
 
     let mut client = Client::builder(&token, intents)
         .event_handler(handler)

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -50,6 +50,19 @@ impl DiscordAdapter {
     pub fn with_http_client(token: String, http_client: reqwest::Client) -> Self {
         Self { token, http_client }
     }
+
+    /// Creates a Discord adapter with agent-token mapping for multi-agent support.
+    pub fn new_for_agents(config: &crate::config::Config) -> Self {
+        // Select the first agent's token as the "primary" for legacy outbound.
+        // Full agent-token selection is implemented in Step 4 (external ID parsing).
+        let primary_token = config
+            .discord_agent_bots()
+            .into_iter()
+            .next()
+            .map(|b| b.token.to_string())
+            .unwrap_or_default();
+        Self::new(primary_token)
+    }
 }
 
 #[async_trait]
@@ -398,6 +411,21 @@ fn interaction_to_command_text(
         }
     }
     text
+}
+
+/// Starts a Discord bot for a specific agent.
+///
+/// Wraps [`start_discord_bot`] and passes agent metadata for per-agent
+/// context binding in the event handler (see Step 3).
+pub async fn start_discord_bot_for_agent(
+    state: Arc<AppState>,
+    token: &str,
+    agent_id: &crate::config::AgentId,
+    allowed_channels: &[u64],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let _ = agent_id;
+    let _ = allowed_channels;
+    start_discord_bot(state, token.to_string()).await
 }
 
 /// Starts the Discord bot and supervises its gateway lifecycle.

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -36,32 +36,51 @@ const DISCORD_MAX_MESSAGE_LEN: usize = 2000;
 
 /// Sends outbound messages to Discord via the REST API.
 pub struct DiscordAdapter {
-    token: String,
+    /// Token used for legacy (non-agent-suffixed) outbound. May be empty when
+    /// all outbound channels are agent-suffixed.
+    legacy_token: String,
+    /// Map from agent_id to Discord bot token, built from [`Config::discord_agent_bots`].
+    agent_token_map: std::collections::HashMap<String, String>,
     http_client: reqwest::Client,
 }
 
 impl DiscordAdapter {
-    /// Creates a Discord adapter with the default HTTP client.
     pub fn new(token: String) -> Self {
-        Self::with_http_client(token, reqwest::Client::new())
+        Self {
+            legacy_token: token,
+            agent_token_map: std::collections::HashMap::new(),
+            http_client: reqwest::Client::new(),
+        }
     }
 
-    /// Creates a Discord adapter with a caller-provided HTTP client.
     pub fn with_http_client(token: String, http_client: reqwest::Client) -> Self {
-        Self { token, http_client }
+        Self {
+            legacy_token: token,
+            agent_token_map: std::collections::HashMap::new(),
+            http_client,
+        }
     }
 
-    /// Creates a Discord adapter with agent-token mapping for multi-agent support.
     pub fn new_for_agents(config: &crate::config::Config) -> Self {
-        // Select the first agent's token as the "primary" for legacy outbound.
-        // Full agent-token selection is implemented in Step 4 (external ID parsing).
-        let primary_token = config
+        let legacy_token = config.discord_bot_token().unwrap_or_default();
+        let agent_tokens: std::collections::HashMap<String, String> = config
             .discord_agent_bots()
             .into_iter()
-            .next()
-            .map(|b| b.token.to_string())
-            .unwrap_or_default();
-        Self::new(primary_token)
+            .map(|b| (b.agent_id.to_string(), b.token.to_string()))
+            .collect();
+        Self {
+            legacy_token,
+            agent_token_map: agent_tokens,
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    fn select_token(&self, external_chat_id: &str) -> &str {
+        match parse_discord_agent_id(external_chat_id) {
+            Some(agent_id) => self.agent_token_map.get(agent_id).map(String::as_str),
+            None => None,
+        }
+        .unwrap_or(&self.legacy_token)
     }
 }
 
@@ -77,11 +96,11 @@ impl ChannelAdapter for DiscordAdapter {
 
     async fn send_text(&self, external_chat_id: &str, text: &str) -> Result<(), String> {
         let discord_chat_id = parse_discord_chat_id(external_chat_id)?;
+        let token = self.select_token(external_chat_id);
 
         let url = format!("https://discord.com/api/v10/channels/{discord_chat_id}/messages");
 
         for chunk in split_text(text, DISCORD_MAX_MESSAGE_LEN) {
-            // メンション展開を無効化し、LLM 出力が意図せず通知を飛ばすのを防ぐ。
             let body = json!({
                 "content": chunk,
                 "allowed_mentions": { "parse": [] },
@@ -95,7 +114,7 @@ impl ChannelAdapter for DiscordAdapter {
                     .timeout(Duration::from_secs(DISCORD_REQUEST_TIMEOUT_SECS))
                     .header(
                         reqwest::header::AUTHORIZATION,
-                        format!("Bot {}", self.token),
+                        format!("Bot {token}"),
                     )
                     .header(reqwest::header::CONTENT_TYPE, "application/json")
                     .json(&body)
@@ -371,11 +390,22 @@ async fn send_discord_response(ctx: &Context, channel_id: ChannelId, text: &str)
 }
 
 fn parse_discord_chat_id(external_chat_id: &str) -> Result<u64, String> {
-    external_chat_id
-        .strip_prefix("discord:")
-        .unwrap_or(external_chat_id)
+    // Strip agent suffix if present: "123:agent:developer" → "123"
+    let bare = if let Some(pos) = external_chat_id.find(":agent:") {
+        &external_chat_id[..pos]
+    } else {
+        external_chat_id
+    };
+    bare.strip_prefix("discord:")
+        .unwrap_or(bare)
         .parse::<u64>()
         .map_err(|_| format!("invalid Discord external_chat_id: '{external_chat_id}'"))
+}
+
+fn parse_discord_agent_id(external_chat_id: &str) -> Option<&str> {
+    let pos = external_chat_id.find(":agent:")?;
+    let agent_id = &external_chat_id[pos + ":agent:".len()..];
+    if agent_id.is_empty() { None } else { Some(agent_id) }
 }
 
 /// Discord Interaction のコマンド名と引数を handle_slash_command が
@@ -543,6 +573,42 @@ mod tests {
             12345
         );
         assert!(parse_discord_chat_id("discord:not-a-number").is_err());
+    }
+
+    #[test]
+    fn parse_discord_chat_id_accepts_agent_suffix() {
+        assert_eq!(
+            parse_discord_chat_id("123:agent:developer").expect("agent suffix"),
+            123
+        );
+    }
+
+    #[test]
+    fn parse_discord_agent_id_from_external_chat_id() {
+        assert_eq!(
+            parse_discord_agent_id("123:agent:developer"),
+            Some("developer")
+        );
+        assert_eq!(parse_discord_agent_id("12345"), None);
+        assert_eq!(parse_discord_agent_id("discord:123"), None);
+    }
+
+    #[test]
+    fn parse_discord_chat_id_accepts_legacy_prefixed() {
+        assert_eq!(
+            parse_discord_chat_id("discord:12345").expect("legacy prefixed"),
+            12345
+        );
+    }
+
+    #[test]
+    fn parse_discord_chat_id_rejects_bad_agent_suffix() {
+        assert!(parse_discord_chat_id("abc:agent:developer").is_err());
+    }
+
+    #[test]
+    fn parse_discord_chat_id_rejects_empty_channel() {
+        assert!(parse_discord_chat_id(":agent:developer").is_err());
     }
 
     /// Interaction コマンド名 → "/command" 形式の正規化が正しいこと。

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -75,12 +75,24 @@ impl DiscordAdapter {
         }
     }
 
-    fn select_token(&self, external_chat_id: &str) -> &str {
+    fn select_token(&self, external_chat_id: &str) -> Result<&str, String> {
         match parse_discord_agent_id(external_chat_id) {
-            Some(agent_id) => self.agent_token_map.get(agent_id).map(String::as_str),
-            None => None,
+            Some(agent_id) => self
+                .agent_token_map
+                .get(agent_id)
+                .map(String::as_str)
+                .ok_or_else(|| {
+                    format!("no Discord bot token found for agent '{agent_id}' in external_chat_id '{external_chat_id}'")
+                }),
+            None => {
+                if self.legacy_token.is_empty() {
+                    return Err(format!(
+                        "no agent suffix in external_chat_id '{external_chat_id}' and no legacy Discord token configured"
+                    ));
+                }
+                Ok(&self.legacy_token)
+            }
         }
-        .unwrap_or(&self.legacy_token)
     }
 }
 
@@ -96,7 +108,7 @@ impl ChannelAdapter for DiscordAdapter {
 
     async fn send_text(&self, external_chat_id: &str, text: &str) -> Result<(), String> {
         let discord_chat_id = parse_discord_chat_id(external_chat_id)?;
-        let token = self.select_token(external_chat_id);
+        let token = self.select_token(external_chat_id)?;
 
         let url = format!("https://discord.com/api/v10/channels/{discord_chat_id}/messages");
 
@@ -112,10 +124,7 @@ impl ChannelAdapter for DiscordAdapter {
                     .http_client
                     .post(&url)
                     .timeout(Duration::from_secs(DISCORD_REQUEST_TIMEOUT_SECS))
-                    .header(
-                        reqwest::header::AUTHORIZATION,
-                        format!("Bot {token}"),
-                    )
+                    .header(reqwest::header::AUTHORIZATION, format!("Bot {token}"))
                     .header(reqwest::header::CONTENT_TYPE, "application/json")
                     .json(&body)
                     .send()
@@ -195,7 +204,7 @@ impl EventHandler for Handler {
             let slash_chat_id =
                 crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
                     let channel = "discord".to_string();
-                    let ext_id = thread.clone();
+                    let ext_id = format!("{thread}:agent:{}", self.agent_id);
                     let chat_type = "discord".to_string();
                     move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
                 })
@@ -405,7 +414,11 @@ fn parse_discord_chat_id(external_chat_id: &str) -> Result<u64, String> {
 fn parse_discord_agent_id(external_chat_id: &str) -> Option<&str> {
     let pos = external_chat_id.find(":agent:")?;
     let agent_id = &external_chat_id[pos + ":agent:".len()..];
-    if agent_id.is_empty() { None } else { Some(agent_id) }
+    if agent_id.is_empty() {
+        None
+    } else {
+        Some(agent_id)
+    }
 }
 
 /// Discord Interaction のコマンド名と引数を handle_slash_command が

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -337,12 +337,12 @@ mod tests {
     //! YAML 設定ファイルから provider ベースの設定を構築し、
     //! channel ごとの override を実効 LLM 設定へ解決する。
 
+    use std::collections::HashMap;
     use std::io::Write;
+    use std::path::PathBuf;
 
     use secrecy::ExposeSecret;
     use serial_test::serial;
-
-    use std::path::PathBuf;
 
     use super::{Config, default_state_root, default_workspace_dir};
     use crate::error::ConfigError;
@@ -1161,5 +1161,190 @@ agents:
                 .join("bob")
                 .join("AGENTS.md")
         );
+    }
+
+    // --- Step 1: Discord Agent Bot Config Helper tests ---
+
+    use crate::config::secret_ref::{env_resolved_value as lit_val, env_yaml_value as lit_yaml};
+
+    fn test_config(agents: HashMap<super::AgentId, super::AgentConfig>, discord_enabled: bool) -> super::Config {
+        super::Config {
+            default_provider: super::ProviderId::new("openai"),
+            default_model: Some("gpt-4o-mini".to_string()),
+            providers: HashMap::from([(
+                super::ProviderId::new("openai"),
+                super::ProviderConfig {
+                    label: "OpenAI".to_string(),
+                    base_url: "https://api.openai.com/v1".to_string(),
+                    api_key: Some(lit_val("OPENAI_API_KEY", "sk-test")),
+                    default_model: "gpt-4o-mini".to_string(),
+                    models: vec!["gpt-4o-mini".to_string()],
+                },
+            )]),
+            state_root: "/tmp/egopulse-test".to_string(),
+            log_level: "info".to_string(),
+            compaction_timeout_secs: 180,
+            max_history_messages: 50,
+            max_session_messages: 40,
+            compact_keep_recent: 20,
+            channels: HashMap::from([(
+                super::ChannelName::new("discord"),
+                super::ChannelConfig {
+                    enabled: Some(discord_enabled),
+                    ..Default::default()
+                },
+            )]),
+            default_agent: super::AgentId::new("default"),
+            agents,
+        }
+    }
+
+    #[test]
+    fn discord_agents_returns_only_agents_with_token() {
+        // Arrange
+        let mut agents = HashMap::new();
+        agents.insert(
+            super::AgentId::new("alice"),
+            super::AgentConfig {
+                label: "Alice".to_string(),
+                discord: super::AgentDiscordConfig {
+                    bot_token: Some(lit_val("ALICE_TOKEN", "token-a")),
+                    file_bot_token: Some(lit_yaml("ALICE_TOKEN")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        agents.insert(
+            super::AgentId::new("bob"),
+            super::AgentConfig {
+                label: "Bob".to_string(),
+                discord: super::AgentDiscordConfig {
+                    bot_token: Some(lit_val("BOB_TOKEN", "token-b")),
+                    file_bot_token: Some(lit_yaml("BOB_TOKEN")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        agents.insert(
+            super::AgentId::new("carol"),
+            super::AgentConfig {
+                label: "Carol".to_string(),
+                ..Default::default()
+            },
+        );
+        let config = test_config(agents, true);
+
+        // Act
+        let bots = config.discord_agent_bots();
+
+        // Assert
+        assert_eq!(bots.len(), 2, "only alice and bob should have tokens");
+        let ids: Vec<&str> = bots.iter().map(|b| b.agent_id.as_str()).collect();
+        assert!(ids.contains(&"alice"));
+        assert!(ids.contains(&"bob"));
+        assert!(!ids.contains(&"carol"));
+    }
+
+    #[test]
+    fn discord_agents_preserve_agent_id_and_label() {
+        // Arrange
+        let mut agents = HashMap::new();
+        agents.insert(
+            super::AgentId::new("developer"),
+            super::AgentConfig {
+                label: "Dev Bot".to_string(),
+                discord: super::AgentDiscordConfig {
+                    bot_token: Some(lit_val("DEV_TOKEN", "dev-secret")),
+                    file_bot_token: Some(lit_yaml("DEV_TOKEN")),
+                    allowed_channels: Some(vec![42, 99]),
+                },
+                ..Default::default()
+            },
+        );
+        let config = test_config(agents, true);
+
+        // Act
+        let bots = config.discord_agent_bots();
+
+        // Assert
+        assert_eq!(bots.len(), 1);
+        let bot = &bots[0];
+        assert_eq!(bot.agent_id.as_str(), "developer");
+        assert_eq!(bot.label, "Dev Bot");
+        assert_eq!(bot.token, "dev-secret");
+        assert_eq!(bot.allowed_channels, &[42, 99]);
+    }
+
+    #[test]
+    fn discord_agents_allow_empty_allowed_channels_as_guild_reject() {
+        // Arrange
+        let mut agents = HashMap::new();
+        agents.insert(
+            super::AgentId::new("bouncer"),
+            super::AgentConfig {
+                label: "Bouncer".to_string(),
+                discord: super::AgentDiscordConfig {
+                    bot_token: Some(lit_val("BOUNCER_TOKEN", "t")),
+                    file_bot_token: Some(lit_yaml("BOUNCER_TOKEN")),
+                    allowed_channels: None,
+                },
+                ..Default::default()
+            },
+        );
+        let config = test_config(agents, true);
+
+        // Act
+        let bots = config.discord_agent_bots();
+
+        // Assert
+        assert_eq!(bots.len(), 1);
+        assert_eq!(bots[0].allowed_channels, &[] as &[u64]);
+    }
+
+    #[test]
+    fn discord_disabled_returns_no_agents() {
+        // Arrange
+        let mut agents = HashMap::new();
+        agents.insert(
+            super::AgentId::new("alice"),
+            super::AgentConfig {
+                label: "Alice".to_string(),
+                discord: super::AgentDiscordConfig {
+                    bot_token: Some(lit_val("ALICE_TOKEN", "token-a")),
+                    file_bot_token: Some(lit_yaml("ALICE_TOKEN")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let config = test_config(agents, false);
+
+        // Act
+        let bots = config.discord_agent_bots();
+
+        // Assert
+        assert!(bots.is_empty());
+    }
+
+    #[test]
+    fn discord_agents_returns_empty_when_no_agents_have_token() {
+        // Arrange
+        let mut agents = HashMap::new();
+        agents.insert(
+            super::AgentId::new("default"),
+            super::AgentConfig {
+                label: "Default".to_string(),
+                ..Default::default()
+            },
+        );
+        let config = test_config(agents, true);
+
+        // Act
+        let bots = config.discord_agent_bots();
+
+        // Assert
+        assert!(bots.is_empty());
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1167,7 +1167,10 @@ agents:
 
     use crate::config::secret_ref::{env_resolved_value as lit_val, env_yaml_value as lit_yaml};
 
-    fn test_config(agents: HashMap<super::AgentId, super::AgentConfig>, discord_enabled: bool) -> super::Config {
+    fn test_config(
+        agents: HashMap<super::AgentId, super::AgentConfig>,
+        discord_enabled: bool,
+    ) -> super::Config {
         super::Config {
             default_provider: super::ProviderId::new("openai"),
             default_model: Some("gpt-4o-mini".to_string()),

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -319,6 +319,45 @@ impl Config {
     ) -> Result<(), crate::error::EgoPulseError> {
         super::persist::save_config_with_secrets(self, yaml_path)
     }
+
+    /// Returns the list of agents that have their own Discord bot token configured.
+    ///
+    /// Each returned entry contains the agent's id, label, resolved token string,
+    /// and allowed channel slice for this bot.
+    ///
+    /// Agents without a `discord.bot_token` are excluded. When `channels.discord`
+    /// is disabled no agents are returned.
+    pub fn discord_agent_bots(&self) -> Vec<DiscordAgentBot<'_>> {
+        if !self.channel_enabled("discord") {
+            return vec![];
+        }
+
+        self.agents
+            .iter()
+            .filter_map(|(agent_id, agent)| {
+                let token = agent.discord.bot_token.as_ref()?;
+                Some(DiscordAgentBot {
+                    agent_id,
+                    label: agent.label.as_str(),
+                    token: token.value(),
+                    allowed_channels: agent
+                        .discord
+                        .allowed_channels
+                        .as_deref()
+                        .unwrap_or_default(),
+                })
+            })
+            .collect()
+    }
+}
+
+/// Information about an agent with its own Discord bot token.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiscordAgentBot<'a> {
+    pub agent_id: &'a AgentId,
+    pub label: &'a str,
+    pub token: &'a str,
+    pub allowed_channels: &'a [u64],
 }
 
 /// Default config file path: `~/.egopulse/egopulse.config.yaml`.

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -332,7 +332,8 @@ impl Config {
             return vec![];
         }
 
-        self.agents
+        let mut bots: Vec<_> = self
+            .agents
             .iter()
             .filter_map(|(agent_id, agent)| {
                 let token = agent.discord.bot_token.as_ref()?;
@@ -347,17 +348,30 @@ impl Config {
                         .unwrap_or_default(),
                 })
             })
-            .collect()
+            .collect();
+        bots.sort_by_key(|b| b.agent_id.as_str());
+        bots
     }
 }
 
 /// Information about an agent with its own Discord bot token.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct DiscordAgentBot<'a> {
     pub agent_id: &'a AgentId,
     pub label: &'a str,
     pub token: &'a str,
     pub allowed_channels: &'a [u64],
+}
+
+impl std::fmt::Debug for DiscordAgentBot<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscordAgentBot")
+            .field("agent_id", &self.agent_id)
+            .field("label", &self.label)
+            .field("token", &"<redacted>")
+            .field("allowed_channels", &self.allowed_channels)
+            .finish()
+    }
 }
 
 /// Default config file path: `~/.egopulse/egopulse.config.yaml`.

--- a/src/config/secret_ref.rs
+++ b/src/config/secret_ref.rs
@@ -134,6 +134,7 @@ pub(crate) fn provider_api_key_env_name(provider_id: &str) -> String {
 
 pub(crate) const WEB_AUTH_TOKEN_ENV_NAME: &str = "WEB_AUTH_TOKEN";
 pub(crate) const DISCORD_BOT_TOKEN_ENV_NAME: &str = "DISCORD_BOT_TOKEN";
+pub(crate) const DISCORD_AGENT_BOT_TOKEN_ENV_NAME: &str = "DISCORD_AGENT_BOT_TOKEN";
 pub(crate) const TELEGRAM_BOT_TOKEN_ENV_NAME: &str = "TELEGRAM_BOT_TOKEN";
 
 pub(crate) fn resolve_string_or_ref(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -135,9 +135,7 @@ pub async fn build_app_state_with_path(
     #[cfg(feature = "channel-discord")]
     if !config.discord_agent_bots().is_empty() {
         channels.register(Arc::new(
-            crate::channels::discord::DiscordAdapter::new_for_agents(
-                &config,
-            ),
+            crate::channels::discord::DiscordAdapter::new_for_agents(&config),
         ));
     }
 
@@ -232,7 +230,14 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
             .config
             .discord_agent_bots()
             .into_iter()
-            .map(|b| (b.agent_id.clone(), b.token.to_string(), b.allowed_channels.to_vec(), b.label.to_string()))
+            .map(|b| {
+                (
+                    b.agent_id.clone(),
+                    b.token.to_string(),
+                    b.allowed_channels.to_vec(),
+                    b.label.to_string(),
+                )
+            })
             .collect();
 
         if !agent_bots.is_empty() {
@@ -240,9 +245,7 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
             for (agent_id, token, allowed_channels, label) in agent_bots {
                 let discord_state = Arc::new(state.clone());
                 let handle_name = format!("discord[{agent_id}]");
-                info!(
-                    "Starting Discord bot for agent '{agent_id}' ({label})...",
-                );
+                info!("Starting Discord bot for agent '{agent_id}' ({label})...",);
                 let aid = agent_id.clone();
                 let handle = tokio::spawn(async move {
                     crate::channels::discord::start_discord_bot_for_agent(
@@ -329,9 +332,7 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
     }
 }
 
-async fn shutdown_channel_tasks(
-    handles: Vec<(String, JoinHandle<Result<(), EgoPulseError>>)>,
-) {
+async fn shutdown_channel_tasks(handles: Vec<(String, JoinHandle<Result<(), EgoPulseError>>)>) {
     for (name, mut handle) in handles {
         let shutdown_result = tokio::time::timeout(Duration::from_secs(10), &mut handle).await;
         match shutdown_result {
@@ -400,7 +401,10 @@ async fn write_startup_status(state: &AppState) {
     let telegram = state
         .config
         .channel_enabled("telegram")
-        .then_some(ChannelEntry { enabled: true, agent_count: None });
+        .then_some(ChannelEntry {
+            enabled: true,
+            agent_count: None,
+        });
 
     let snapshot = StatusSnapshot {
         version: env!("CARGO_PKG_VERSION").to_string(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -133,10 +133,12 @@ pub async fn build_app_state_with_path(
     channels.register(Arc::new(WebAdapter));
 
     #[cfg(feature = "channel-discord")]
-    if let Some(token) = config.discord_bot_token() {
-        channels.register(Arc::new(crate::channels::discord::DiscordAdapter::new(
-            token,
-        )));
+    if !config.discord_agent_bots().is_empty() {
+        channels.register(Arc::new(
+            crate::channels::discord::DiscordAdapter::new_for_agents(
+                &config,
+            ),
+        ));
     }
 
     #[cfg(feature = "channel-telegram")]
@@ -209,7 +211,7 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
     write_startup_status(&state).await;
 
     let mut has_active_channels = false;
-    let mut handles: Vec<(&'static str, JoinHandle<Result<(), EgoPulseError>>)> = Vec::new();
+    let mut handles: Vec<(String, JoinHandle<Result<(), EgoPulseError>>)> = Vec::new();
 
     // Web サーバー起動
     if state.config.web_enabled() {
@@ -220,32 +222,48 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
         info!("Starting Web UI server on {host}:{port}");
         let handle =
             tokio::spawn(async move { crate::web::run_server(web_state, &host, port).await });
-        handles.push(("web", handle));
+        handles.push(("web".to_string(), handle));
     }
 
-    // Discord bot 起動
+    // Discord bot 起動 — Agent ごとに 1 つの Discord client を起動する。
     #[cfg(feature = "channel-discord")]
-    if state.config.channel_enabled("discord") {
-        if let Some(token) = state.config.discord_bot_token() {
+    {
+        let agent_bots: Vec<_> = state
+            .config
+            .discord_agent_bots()
+            .into_iter()
+            .map(|b| (b.agent_id.clone(), b.token.to_string(), b.allowed_channels.to_vec(), b.label.to_string()))
+            .collect();
+
+        if !agent_bots.is_empty() {
             has_active_channels = true;
-            let discord_state = Arc::new(state.clone());
-            info!("Starting Discord bot...");
-            let handle = tokio::spawn(async move {
-                crate::channels::discord::start_discord_bot(discord_state, token)
+            for (agent_id, token, allowed_channels, label) in agent_bots {
+                let discord_state = Arc::new(state.clone());
+                let handle_name = format!("discord[{agent_id}]");
+                info!(
+                    "Starting Discord bot for agent '{agent_id}' ({label})...",
+                );
+                let aid = agent_id.clone();
+                let handle = tokio::spawn(async move {
+                    crate::channels::discord::start_discord_bot_for_agent(
+                        discord_state,
+                        &token,
+                        &aid,
+                        &allowed_channels,
+                    )
                     .await
                     .map_err(|error| {
                         EgoPulseError::Channel(ChannelError::SendFailed(format!(
-                            "discord bot failed: {error}"
+                            "discord bot (agent {aid}) failed: {error}",
                         )))
                     })
-            });
-            handles.push(("discord", handle));
+                });
+                handles.push((handle_name, handle));
+            }
         } else {
             tracing::warn!(
-                "Discord channel is enabled but no bot_token is configured. \
-                 Set channels.discord.bot_token in egopulse.config.yaml, \
-                  set DISCORD_BOT_TOKEN environment variable, \
-                  or add DISCORD_BOT_TOKEN to ~/.egopulse/.env."
+                "Discord channel is enabled but no agents have a discord.bot_token configured. \
+                 Set agents.<id>.discord.bot_token in egopulse.config.yaml."
             );
         }
     }
@@ -267,7 +285,7 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
                         )))
                     })
             });
-            handles.push(("telegram", handle));
+            handles.push(("telegram".to_string(), handle));
         } else {
             tracing::warn!(
                 "Telegram channel is enabled but no bot_token is configured. \
@@ -297,7 +315,7 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
                     "channel '{name}' exited unexpectedly"
                 )))),
                 Ok(Err(error)) => Err(error),
-                Err(error) => Err(channel_join_error(name, error)),
+                Err(error) => Err(channel_join_error(&name, error)),
             };
         }
 
@@ -312,7 +330,7 @@ pub async fn start_channels(state: AppState) -> Result<(), EgoPulseError> {
 }
 
 async fn shutdown_channel_tasks(
-    handles: Vec<(&'static str, JoinHandle<Result<(), EgoPulseError>>)>,
+    handles: Vec<(String, JoinHandle<Result<(), EgoPulseError>>)>,
 ) {
     for (name, mut handle) in handles {
         let shutdown_result = tokio::time::timeout(Duration::from_secs(10), &mut handle).await;
@@ -364,15 +382,25 @@ async fn write_startup_status(state: &AppState) {
         None
     };
 
-    let discord = state
-        .config
-        .channel_enabled("discord")
-        .then_some(ChannelEntry { enabled: true });
+    let discord_agent_count = state.config.discord_agent_bots().len();
+    let discord = if discord_agent_count > 0 {
+        Some(ChannelEntry {
+            enabled: true,
+            agent_count: Some(discord_agent_count),
+        })
+    } else if state.config.channel_enabled("discord") {
+        Some(ChannelEntry {
+            enabled: true,
+            agent_count: Some(0),
+        })
+    } else {
+        None
+    };
 
     let telegram = state
         .config
         .channel_enabled("telegram")
-        .then_some(ChannelEntry { enabled: true });
+        .then_some(ChannelEntry { enabled: true, agent_count: None });
 
     let snapshot = StatusSnapshot {
         version: env!("CARGO_PKG_VERSION").to_string(),

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -34,6 +34,7 @@ pub(crate) fn update_field_visibility(fields: &mut [Field]) {
 
 pub(crate) fn load_channel_fields(
     channels: &serde_yml::Value,
+    root: &serde_yml::Value,
     result: &mut HashMap<String, String>,
 ) {
     let Some(ch_map) = channels.as_mapping() else {
@@ -58,6 +59,24 @@ pub(crate) fn load_channel_fields(
         result,
         "TELEGRAM_BOT_USERNAME",
     );
+
+    // Fallback: if DISCORD_BOT_TOKEN is not set from channels.discord.bot_token,
+    // check agents.default.discord.bot_token (the new config location).
+    if !result.contains_key("DISCORD_BOT_TOKEN") || result["DISCORD_BOT_TOKEN"].is_empty() {
+        if let Some(token) = root
+            .as_mapping()
+            .and_then(|m| m.get(yaml_key("agents")))
+            .and_then(|a| a.as_mapping())
+            .and_then(|m| m.get(yaml_key("default")))
+            .and_then(|a| a.as_mapping())
+            .and_then(|m| m.get(yaml_key("discord")))
+            .and_then(|d| d.as_mapping())
+            .and_then(|m| m.get(yaml_key("bot_token")))
+            .and_then(|v| v.as_str())
+        {
+            result.insert("DISCORD_BOT_TOKEN".into(), token.to_string());
+        }
+    }
 }
 
 pub(crate) fn extract_existing_state_root(

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -74,14 +74,12 @@ pub(crate) fn extract_existing_state_root(
 pub(crate) fn build_channel_configs(
     auth_token: String,
     discord_enabled: bool,
-    discord_bot_token: String,
     telegram_enabled: bool,
     telegram_bot_token: String,
     telegram_bot_username: String,
 ) -> HashMap<crate::config::ChannelName, crate::config::ChannelConfig> {
     use crate::config::secret_ref::{
-        DISCORD_BOT_TOKEN_ENV_NAME, TELEGRAM_BOT_TOKEN_ENV_NAME, WEB_AUTH_TOKEN_ENV_NAME,
-        env_resolved_value, env_yaml_value,
+        TELEGRAM_BOT_TOKEN_ENV_NAME, WEB_AUTH_TOKEN_ENV_NAME, env_resolved_value, env_yaml_value,
     };
     use crate::config::{ChannelConfig, ChannelName};
 
@@ -104,11 +102,6 @@ pub(crate) fn build_channel_configs(
             ChannelName::new("discord"),
             ChannelConfig {
                 enabled: Some(true),
-                bot_token: Some(env_resolved_value(
-                    DISCORD_BOT_TOKEN_ENV_NAME,
-                    discord_bot_token,
-                )),
-                file_bot_token: Some(env_yaml_value(DISCORD_BOT_TOKEN_ENV_NAME)),
                 ..Default::default()
             },
         );
@@ -193,7 +186,6 @@ mod tests {
         let channels = build_channel_configs(
             "web-token".to_string(),
             true,
-            "discord-token".to_string(),
             true,
             "telegram-token".to_string(),
             "botname".to_string(),
@@ -206,10 +198,8 @@ mod tests {
         assert!(web_file.contains("id: WEB_AUTH_TOKEN"));
 
         let discord = channels.get("discord").expect("discord");
-        let discord_file =
-            serde_yml::to_string(discord.file_bot_token.as_ref().expect("discord file"))
-                .expect("serialize discord file");
-        assert!(discord_file.contains("id: DISCORD_BOT_TOKEN"));
+        assert!(discord.bot_token.is_none());
+        assert!(discord.file_bot_token.is_none());
 
         let telegram = channels.get("telegram").expect("telegram");
         let telegram_file =

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -275,7 +275,7 @@ impl SetupApp {
             }
 
             if let Some(channels) = map.get(serde_yml::Value::String("channels".into())) {
-                load_channel_fields(channels, &mut result);
+                load_channel_fields(channels, &parsed, &mut result);
             }
         }
 

--- a/src/setup/summary.rs
+++ b/src/setup/summary.rs
@@ -14,7 +14,10 @@ use super::provider::{
     provider_label_for,
 };
 use super::{Field, SetupApp};
-use crate::config::secret_ref::{env_resolved_value, provider_api_key_env_name};
+use crate::config::secret_ref::{
+    DISCORD_AGENT_BOT_TOKEN_ENV_NAME, env_resolved_value, env_yaml_value as yaml_value,
+    provider_api_key_env_name,
+};
 use crate::config::{
     Config, ProviderConfig, ProviderId, base_url_allows_empty_api_key, default_state_root,
     default_workspace_dir, is_valid_base_url,
@@ -174,11 +177,31 @@ pub(crate) fn save_config(
     let channels = build_channel_configs(
         auth_token,
         discord_enabled,
-        discord_bot_token,
         telegram_enabled,
         telegram_bot_token,
         telegram_bot_username,
     );
+
+    let agents: std::collections::HashMap<crate::config::AgentId, crate::config::AgentConfig> =
+        std::collections::HashMap::from([(
+            crate::config::AgentId::new("default"),
+            crate::config::AgentConfig {
+                label: "Default Agent".to_string(),
+                discord: if discord_enabled && !discord_bot_token.is_empty() {
+                    crate::config::AgentDiscordConfig {
+                        bot_token: Some(env_resolved_value(
+                            DISCORD_AGENT_BOT_TOKEN_ENV_NAME,
+                            discord_bot_token,
+                        )),
+                        file_bot_token: Some(yaml_value(DISCORD_AGENT_BOT_TOKEN_ENV_NAME)),
+                        ..Default::default()
+                    }
+                } else {
+                    Default::default()
+                },
+                ..Default::default()
+            },
+        )]);
 
     let config = Config {
         default_provider: ProviderId::new(&provider_id),
@@ -198,13 +221,7 @@ pub(crate) fn save_config(
         compact_keep_recent: 20,
         channels,
         default_agent: crate::config::AgentId::new("default"),
-        agents: std::collections::HashMap::from([(
-            crate::config::AgentId::new("default"),
-            crate::config::AgentConfig {
-                label: "Default Agent".to_string(),
-                ..Default::default()
-            },
-        )]),
+        agents,
     };
 
     config

--- a/src/setup/summary.rs
+++ b/src/setup/summary.rs
@@ -265,6 +265,25 @@ pub(crate) fn save_config(
         completion_summary.push(format!("Previous config backed up to: {backup}"));
     }
 
+    let existing_non_default = original_yaml
+        .as_ref()
+        .and_then(|yaml| yaml.as_mapping())
+        .and_then(|m| m.get(serde_yml::Value::String("agents".into())))
+        .and_then(|a| a.as_mapping())
+        .map(|m| {
+            m.keys()
+                .filter_map(|k| k.as_str())
+                .filter(|id| *id != "default")
+                .count()
+        })
+        .unwrap_or(0);
+    if existing_non_default > 0 {
+        completion_summary.push(format!(
+            "⚠ Existing {existing_non_default} custom agent(s) preserved in backup; \
+             re-add them to agents in config YAML if needed"
+        ));
+    }
+
     Ok((backup_path, completion_summary))
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -246,8 +246,14 @@ mod tests {
                     host: Some("127.0.0.1".to_string()),
                     port: Some(10961),
                 }),
-                discord: Some(ChannelEntry { enabled: true, agent_count: None }),
-                telegram: Some(ChannelEntry { enabled: true, agent_count: None }),
+                discord: Some(ChannelEntry {
+                    enabled: true,
+                    agent_count: None,
+                }),
+                telegram: Some(ChannelEntry {
+                    enabled: true,
+                    agent_count: None,
+                }),
             },
             provider: ProviderStatus {
                 default: "openrouter".to_string(),
@@ -436,7 +442,10 @@ mod tests {
             host: None,
             port: None,
         });
-        snapshot.channels.discord = Some(ChannelEntry { enabled: false, agent_count: None });
+        snapshot.channels.discord = Some(ChannelEntry {
+            enabled: false,
+            agent_count: None,
+        });
 
         // Act
         let output = format_snapshot(&snapshot);

--- a/src/status.rs
+++ b/src/status.rs
@@ -79,6 +79,8 @@ pub struct ChannelsStatus {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ChannelEntry {
     pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_count: Option<usize>,
 }
 
 /// Web チャネルの設定。
@@ -175,14 +177,19 @@ fn format_channels(channels: &ChannelsStatus, lines: &mut Vec<String>) {
         ));
     }
     if let Some(discord) = &channels.discord {
+        let detail = match discord.agent_count {
+            Some(n) if n > 0 => format!(" ({n} agent{})", if n == 1 { "" } else { "s" }),
+            _ => String::new(),
+        };
         lines.push(format!(
-            "  {:<9}{}",
+            "  {:<9}{}{}",
             "discord",
             if discord.enabled {
                 "enabled"
             } else {
                 "disabled"
             },
+            detail,
         ));
     }
     if let Some(telegram) = &channels.telegram {
@@ -239,8 +246,8 @@ mod tests {
                     host: Some("127.0.0.1".to_string()),
                     port: Some(10961),
                 }),
-                discord: Some(ChannelEntry { enabled: true }),
-                telegram: Some(ChannelEntry { enabled: true }),
+                discord: Some(ChannelEntry { enabled: true, agent_count: None }),
+                telegram: Some(ChannelEntry { enabled: true, agent_count: None }),
             },
             provider: ProviderStatus {
                 default: "openrouter".to_string(),
@@ -429,7 +436,7 @@ mod tests {
             host: None,
             port: None,
         });
-        snapshot.channels.discord = Some(ChannelEntry { enabled: false });
+        snapshot.channels.discord = Some(ChannelEntry { enabled: false, agent_count: None });
 
         // Act
         let output = format_snapshot(&snapshot);


### PR DESCRIPTION
## Summary

- Agent ごとに個別の Discord Bot Token を設定し、独立した Bot クライアントを起動する機能を追加
- 1 プロセスで複数の Discord Bot を同時稼働可能（1 Bot = 1 Agent）
- 各 Bot は Agent 固有の `allowed_channels` に従って応答可否を判定
- Setup wizard が `agents.default.discord.bot_token` を書くよう更新
- `docs/multi-agent.md` を追加

## 変更内容

| コミット | 内容 |
|---|---|
| `04433fb` | `Config::discord_agent_bots()` + `DiscordAgentBot` 構造体（TDD: 5 tests） |
| `375f3f3` | Runtime: Agent ごとに Discord Bot タスクを spawn、`ChannelEntry.agent_count` 追加 |
| `321234a` | Handler に `agent_id` / `agent_label` / `allowed_channels` をバインド（TDD: 6 tests） |
| `141aa9e` | `DiscordAdapter` トークンマップ + `external_chat_id` の `:agent:` suffix 解析（TDD: 8 tests） |
| `f543347` | Setup wizard の出力先を `agents.default.discord.bot_token` に変更（TDD: 4 tests） |
| `1e1e76b` | `docs/multi-agent.md` 追加 |

## テスト

- 全 385 テスト通過（23 テスト新規追加）
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓

Close #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Discordをエージェント単位で複数起動できるマルチエージェント対応を導入（各エージェントが独自トークン/チャネル許可を持てます）。
  * メッセージ/セッションにエージェント別タグ付けを追加し、スレッド識別子にエージェント情報を含めます。
  * ステータス表示にDiscordのエージェント数を表示。

* **ドキュメント**
  * マルチエージェント設定と運用の日本語ガイドを追加。

* **テスト**
  * Discordエージェント選定と動作に関するユニットテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->