### PR TITLE
[codex] Fix tool call persistence recovery

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -29,7 +29,7 @@ egopulse.db (SQLite / WAL mode)
 | テーブル数 | 7（データテーブル 5 + マイグレーション基盤テーブル 2） |
 | インデックス数 | 6 |
 | 外部キー制約 | 1（tool_calls.chat_id → chats.chat_id） |
-| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v2） |
+| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v3） |
 | DBライブラリ | rusqlite 0.37（bundled） |
 | DBファイル | `{data_dir}/egopulse.db` |
 | 接続ラッパー | `Mutex<Connection>` |
@@ -63,8 +63,10 @@ egopulse.db (SQLite / WAL mode)
         │       │  tool_calls      │
         │       │──────────────────│
         └───────│ chat_id (FK)     │
-                │ id (PK)          │
+                │ id               │
                 │ message_id       │
+                │ (id, chat_id,    │
+                │  message_id) PK  │
                 │ tool_name        │
                 │ tool_input       │
                 │ tool_output      │
@@ -205,13 +207,14 @@ LLM ツール/ファンクション呼び出しの実行記録。
 
 ```sql
 CREATE TABLE IF NOT EXISTS tool_calls (
-    id TEXT PRIMARY KEY,
+    id TEXT NOT NULL,
     chat_id INTEGER NOT NULL,
     message_id TEXT NOT NULL,
     tool_name TEXT NOT NULL,
     tool_input TEXT NOT NULL,
     tool_output TEXT,
     timestamp TEXT NOT NULL,
+    PRIMARY KEY (id, chat_id, message_id),
     FOREIGN KEY (chat_id) REFERENCES chats(chat_id)
 );
 
@@ -224,9 +227,9 @@ CREATE INDEX IF NOT EXISTS idx_tool_calls_chat_message_id
 
 | カラム | 型 | 制約 | 説明 |
 |--------|----|------|------|
-| id | TEXT | PK | ツール呼び出しID |
-| chat_id | INTEGER | NOT NULL, FK | chats.chat_id |
-| message_id | TEXT | NOT NULL | 対象メッセージID |
+| id | TEXT | NOT NULL, composite PK | プロバイダ由来のツール呼び出しID |
+| chat_id | INTEGER | NOT NULL, FK, composite PK | chats.chat_id |
+| message_id | TEXT | NOT NULL, composite PK | 対象 assistant メッセージID |
 | tool_name | TEXT | NOT NULL | ツール/ファンクション名 |
 | tool_input | TEXT | NOT NULL | 入力パラメータ（JSON） |
 | tool_output | TEXT | nullable | 出力結果（JSON） |
@@ -235,8 +238,13 @@ CREATE INDEX IF NOT EXISTS idx_tool_calls_chat_message_id
 **操作**:
 - `store_tool_call(tool_call)` — INSERT
 - `update_tool_call_output(id, output)` — 出力の事後更新
+- `update_tool_call_output_for_message(chat_id, message_id, id, output)` — assistant メッセージ単位でスコープした出力更新
 - `get_tool_calls_for_message(chat_id, message_id)` — メッセージ単位の呼び出し履歴
 - `get_tool_calls_for_chat(chat_id)` — チャット単位の全呼び出し履歴
+
+**設計ポイント**:
+- `id` は OpenAI/Codex などのプロバイダが返す call id であり、永続化上のグローバルIDではない
+- 同じプロバイダ call id が別 assistant メッセージで再利用されても履歴を保持できるよう、主キーは `(id, chat_id, message_id)`
 
 ---
 
@@ -356,39 +364,59 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 2. `schema_version(conn)` で `db_meta` テーブルから現在のバージョンを取得（未設定時は `0`）
 3. `if version < N` ブロックで未適用のマイグレーションを逐次実行
 4. 各マイグレーション適用後に `set_schema_version(conn, N, "note")` でバージョンを更新し `schema_migrations` に履歴を記録
-5. `SCHEMA_VERSION` 定数（現行 `2`）に到達したら完了。`debug_assert_eq!` で検証
+5. `SCHEMA_VERSION` 定数（現行 `3`）に到達したら完了。`debug_assert_eq!` で検証
 
 **新規マイグレーションの追加手順**:
-1. `SCHEMA_VERSION` 定数をインクリメント（例: `1` → `2`）
-2. `run_migrations()` に `if version < 2 { ... }` ブロックを追加
+1. `SCHEMA_VERSION` 定数をインクリメント（例: `3` → `4`）
+2. `run_migrations()` に `if version < 4 { ... }` ブロックを追加
 3. ブロック内で `conn.execute_batch("ALTER TABLE ...")` 等の DDL を実行
-4. `set_schema_version(conn, 2, "description")` を呼び出し
+4. 破壊的 DDL や複数ステートメントを伴う場合は transaction 内で実行する
+5. `set_schema_version(conn, 4, "description")` または transaction 用 helper を呼び出し
 
 ```rust
-// 既存のテンプレート（storage.rs 内）
-// if version < 2 {
-//     conn.execute_batch(
-//         "CREATE TABLE IF NOT EXISTS llm_usage_logs (
-//             id INTEGER PRIMARY KEY AUTOINCREMENT,
+// 現行の v2 -> v3 例（storage.rs 内）
+// if version < 3 {
+//     let tx = conn.unchecked_transaction()?;
+//     tx.execute_batch(
+//         "DROP INDEX IF EXISTS idx_tool_calls_chat_id;
+//         DROP INDEX IF EXISTS idx_tool_calls_chat_message_id;
+//
+//         CREATE TABLE IF NOT EXISTS tool_calls_v3 (
+//             id TEXT NOT NULL,
 //             chat_id INTEGER NOT NULL,
-//             caller_channel TEXT NOT NULL,
-//             provider TEXT NOT NULL,
-//             model TEXT NOT NULL,
-//             input_tokens INTEGER NOT NULL,
-//             output_tokens INTEGER NOT NULL,
-//             total_tokens INTEGER NOT NULL,
-//             request_kind TEXT NOT NULL DEFAULT 'agent_loop',
-//             created_at TEXT NOT NULL
+//             message_id TEXT NOT NULL,
+//             tool_name TEXT NOT NULL,
+//             tool_input TEXT NOT NULL,
+//             tool_output TEXT,
+//             timestamp TEXT NOT NULL,
+//             PRIMARY KEY (id, chat_id, message_id),
+//             FOREIGN KEY (chat_id) REFERENCES chats(chat_id)
 //         );
 //
-//         CREATE INDEX IF NOT EXISTS idx_llm_usage_chat_created
-//             ON llm_usage_logs(chat_id, created_at);
+//         INSERT OR IGNORE INTO tool_calls_v3
+//             (id, chat_id, message_id, tool_name, tool_input, tool_output, timestamp)
+//         SELECT
+//             id,
+//             COALESCE(chat_id, 0),
+//             COALESCE(message_id, ''),
+//             COALESCE(tool_name, ''),
+//             COALESCE(tool_input, ''),
+//             tool_output,
+//             COALESCE(timestamp, '')
+//         FROM tool_calls;
 //
-//         CREATE INDEX IF NOT EXISTS idx_llm_usage_created
-//             ON llm_usage_logs(created_at);",
+//         DROP TABLE tool_calls;
+//         ALTER TABLE tool_calls_v3 RENAME TO tool_calls;
+//
+//         CREATE INDEX IF NOT EXISTS idx_tool_calls_chat_id
+//             ON tool_calls(chat_id);
+//
+//         CREATE INDEX IF NOT EXISTS idx_tool_calls_chat_message_id
+//             ON tool_calls(chat_id, message_id);",
 //     )?;
-//     set_schema_version(conn, 2, "add llm_usage_logs table for LLM usage tracking")?;
-//     version = 2;
+//     set_schema_version_in_tx(&tx, 3, "scope tool call uniqueness to chat and assistant message")?;
+//     tx.commit()?;
+//     version = 3;
 // }
 ```
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -89,12 +89,14 @@ turn 開始時は次の順で session を復元する。
 1. `sessions.messages_json` があればそれを使う
 2. JSON を `Message` 配列へ戻す
 3. image は `input_image_ref` から asset store 経由で hydrate する
-4. snapshot が無い、または壊れている場合だけ `messages` テーブルから recent history を組み立てる
+4. assistant tool call に対応する tool output が欠けている場合は synthetic error tool output を補う
+5. snapshot が無い、または壊れている場合だけ `messages` テーブルから recent history を組み立てる
 
 原則:
 
 - 真の次ターン入力は `sessions.messages_json`
 - `messages` は fallback 用
+- LLM API に再送する履歴では、assistant の tool call と tool output の対応関係を必ず保つ
 
 ## 4. Turn 中の保存
 

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -197,7 +197,7 @@ async fn snapshot_to_loaded(
     };
 
     Ok(LoadedSession {
-        messages,
+        messages: repair_orphan_tool_outputs(messages),
         session_updated_at: snapshot.updated_at,
     })
 }
@@ -213,6 +213,53 @@ fn restored_messages_or_recent(
     }
 
     Some(messages)
+}
+
+fn repair_orphan_tool_outputs(messages: Vec<Message>) -> Vec<Message> {
+    let mut repaired = Vec::with_capacity(messages.len());
+    let mut iter = messages.into_iter().peekable();
+
+    while let Some(message) = iter.next() {
+        if message.role == "assistant" && !message.tool_calls.is_empty() {
+            let expected_ids = message
+                .tool_calls
+                .iter()
+                .map(|tool_call| tool_call.id.clone())
+                .collect::<Vec<_>>();
+            repaired.push(message);
+
+            let mut seen_ids = std::collections::HashSet::new();
+            while iter
+                .peek()
+                .is_some_and(|candidate| candidate.role == "tool")
+            {
+                let tool_message = iter.next().expect("peeked tool message exists");
+                if let Some(id) = &tool_message.tool_call_id {
+                    seen_ids.insert(id.clone());
+                }
+                repaired.push(tool_message);
+            }
+
+            for missing_id in expected_ids.into_iter().filter(|id| !seen_ids.contains(id)) {
+                repaired.push(orphan_tool_output_message(missing_id));
+            }
+        } else {
+            repaired.push(message);
+        }
+    }
+
+    repaired
+}
+
+fn orphan_tool_output_message(tool_call_id: String) -> Message {
+    Message {
+        role: "tool".to_string(),
+        content: MessageContent::text(
+            r#"{"status":"error","error":"tool output was missing from the restored session snapshot"}"#,
+        ),
+        tool_calls: Vec::new(),
+        tool_call_id: Some(tool_call_id),
+    }
 }
 
 fn loaded_from_recent(snapshot: &SessionSnapshot) -> LoadedSession {
@@ -388,7 +435,9 @@ mod tests {
     use crate::config::secret_ref::ResolvedValue;
     use crate::config::{Config, ProviderConfig};
     use crate::error::LlmError;
-    use crate::llm::{LlmProvider, Message, MessageContent, MessageContentPart, MessagesResponse};
+    use crate::llm::{
+        LlmProvider, Message, MessageContent, MessageContentPart, MessagesResponse, ToolCall,
+    };
     use crate::runtime::AppState;
     use crate::skills::SkillManager;
     use crate::storage::{Database, StoredMessage, call_blocking};
@@ -707,6 +756,60 @@ mod tests {
             }
             other => panic!("expected restored parts, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn load_messages_for_turn_repairs_orphan_tool_outputs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(FakeProvider {
+                response: "ok".to_string(),
+            }),
+        );
+        let context = cli_context("orphan-tool-output");
+        let chat_id = super::resolve_chat_id(&state, &context)
+            .await
+            .expect("chat id");
+        let snapshot = vec![
+            Message::text("user", "please inspect"),
+            Message {
+                role: "assistant".to_string(),
+                content: MessageContent::text("I will inspect."),
+                tool_calls: vec![ToolCall {
+                    id: "call-missing".to_string(),
+                    name: "read".to_string(),
+                    arguments: serde_json::json!({"path": "Cargo.toml"}),
+                }],
+                tool_call_id: None,
+            },
+            Message::text("user", "what happened?"),
+        ];
+        let snapshot_json = serde_json::to_string(&snapshot).expect("snapshot json");
+
+        call_blocking(Arc::clone(&state.db), move |db| {
+            db.save_session(chat_id, &snapshot_json)
+        })
+        .await
+        .expect("save snapshot");
+
+        let loaded = load_messages_for_turn(&state, chat_id)
+            .await
+            .expect("load messages");
+
+        assert_eq!(loaded.messages.len(), 4);
+        assert_eq!(loaded.messages[2].role, "tool");
+        assert_eq!(
+            loaded.messages[2].tool_call_id.as_deref(),
+            Some("call-missing")
+        );
+        assert!(
+            loaded.messages[2]
+                .content
+                .as_text_lossy()
+                .contains("tool output was missing")
+        );
+        assert_eq!(loaded.messages[3].content.as_text_lossy(), "what happened?");
     }
 
     #[tokio::test]

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -526,7 +526,14 @@ where
         .await;
     let duration_ms = tool_start.elapsed().as_millis();
     let tool_payload = format_tool_result(&tool_call, &result);
-    update_tool_call_output(state, &tool_call.id, &tool_payload).await?;
+    update_tool_call_output(
+        state,
+        tool_context.chat_id,
+        assistant_message_id,
+        &tool_call.id,
+        &tool_payload,
+    )
+    .await?;
 
     emit_event(
         on_event,
@@ -661,13 +668,16 @@ async fn store_pending_tool_call(
 
 async fn update_tool_call_output(
     state: &AppState,
+    chat_id: i64,
+    message_id: &str,
     tool_call_id: &str,
     output: &str,
 ) -> Result<(), EgoPulseError> {
+    let message_id = message_id.to_string();
     let tool_call_id = tool_call_id.to_string();
     let output = output.to_string();
     call_blocking(Arc::clone(&state.db), move |db| {
-        db.update_tool_call_output(&tool_call_id, &output)
+        db.update_tool_call_output_for_message(chat_id, &message_id, &tool_call_id, &output)
     })
     .await
     .map_err(EgoPulseError::from)
@@ -1146,6 +1156,81 @@ mod tests {
         .await
         .expect("process turn");
         assert_eq!(reply, "Done reading. Final answer.");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn repeated_provider_tool_call_ids_do_not_break_later_turns() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let relative_path = format!("tests/{}/repeat.txt", uuid::Uuid::new_v4());
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(FakeProvider {
+                responses: std::sync::Mutex::new(vec![
+                    MessagesResponse {
+                        content: "Reading once.".to_string(),
+                        tool_calls: vec![ToolCall {
+                            id: "call-repeat".to_string(),
+                            name: "read".to_string(),
+                            arguments: serde_json::json!({"path": relative_path.clone()}),
+                        }],
+                        usage: None,
+                    },
+                    MessagesResponse {
+                        content: "First done.".to_string(),
+                        tool_calls: Vec::new(),
+                        usage: None,
+                    },
+                    MessagesResponse {
+                        content: "Reading again.".to_string(),
+                        tool_calls: vec![ToolCall {
+                            id: "call-repeat".to_string(),
+                            name: "read".to_string(),
+                            arguments: serde_json::json!({"path": relative_path.clone()}),
+                        }],
+                        usage: None,
+                    },
+                    MessagesResponse {
+                        content: "Second done.".to_string(),
+                        tool_calls: Vec::new(),
+                        usage: None,
+                    },
+                ]),
+            }),
+        );
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
+        let file_path = workspace.join(&relative_path);
+        std::fs::create_dir_all(file_path.parent().expect("file parent")).expect("workspace");
+        std::fs::write(&file_path, "repeat content").expect("repeat.txt");
+
+        let context = cli_context("repeated-tool-call-id");
+        let first = process_turn(&state, &context, "read once")
+            .await
+            .expect("first turn");
+        let second = process_turn(&state, &context, "read again")
+            .await
+            .expect("second turn");
+
+        assert_eq!(first, "First done.");
+        assert_eq!(second, "Second done.");
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:repeated-tool-call-id",
+                Some("repeated-tool-call-id"),
+                "cli",
+            )
+        })
+        .await
+        .expect("chat id");
+        let tool_calls = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_tool_calls_for_chat(chat_id)
+        })
+        .await
+        .expect("tool calls");
+        assert_eq!(tool_calls.len(), 2);
+        assert!(tool_calls.iter().all(|call| call.id == "call-repeat"));
+        assert!(tool_calls.iter().all(|call| call.tool_output.is_some()));
     }
 
     #[tokio::test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -113,7 +113,7 @@ where
 ///
 /// 新しいマイグレーションを追加する際はこの値をインクリメントし、
 /// `run_migrations` に対応する `if version < N` ブロックを追加する。
-const SCHEMA_VERSION: i64 = 2;
+const SCHEMA_VERSION: i64 = 3;
 
 impl Database {
     /// Open (or create) the database at `db_path` and initialize schema.
@@ -197,6 +197,32 @@ fn set_schema_version(conn: &Connection, version: i64, note: &str) -> Result<(),
         [],
     )?;
     conn.execute(
+        "INSERT OR REPLACE INTO schema_migrations(version, applied_at, note)
+         VALUES(?1, ?2, ?3)",
+        params![version, chrono::Utc::now().to_rfc3339(), note],
+    )?;
+    Ok(())
+}
+
+fn set_schema_version_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    version: i64,
+    note: &str,
+) -> Result<(), StorageError> {
+    tx.execute(
+        "INSERT INTO db_meta(key, value) VALUES('schema_version', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![version.to_string()],
+    )?;
+    tx.execute(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL,
+            note TEXT
+        )",
+        [],
+    )?;
+    tx.execute(
         "INSERT OR REPLACE INTO schema_migrations(version, applied_at, note)
          VALUES(?1, ?2, ?3)",
         params![version, chrono::Utc::now().to_rfc3339(), note],
@@ -293,6 +319,54 @@ fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
         )?;
         set_schema_version(conn, 2, "add llm_usage_logs table for LLM usage tracking")?;
         version = 2;
+    }
+
+    if version < 3 {
+        let tx = conn.unchecked_transaction()?;
+        tx.execute_batch(
+            "DROP INDEX IF EXISTS idx_tool_calls_chat_id;
+            DROP INDEX IF EXISTS idx_tool_calls_chat_message_id;
+
+            CREATE TABLE IF NOT EXISTS tool_calls_v3 (
+                id TEXT NOT NULL,
+                chat_id INTEGER NOT NULL,
+                message_id TEXT NOT NULL,
+                tool_name TEXT NOT NULL,
+                tool_input TEXT NOT NULL,
+                tool_output TEXT,
+                timestamp TEXT NOT NULL,
+                PRIMARY KEY (id, chat_id, message_id),
+                FOREIGN KEY (chat_id) REFERENCES chats(chat_id)
+            );
+
+            INSERT OR IGNORE INTO tool_calls_v3
+                (id, chat_id, message_id, tool_name, tool_input, tool_output, timestamp)
+            SELECT
+                id,
+                COALESCE(chat_id, 0),
+                COALESCE(message_id, ''),
+                COALESCE(tool_name, ''),
+                COALESCE(tool_input, ''),
+                tool_output,
+                COALESCE(timestamp, '')
+            FROM tool_calls;
+
+            DROP TABLE tool_calls;
+            ALTER TABLE tool_calls_v3 RENAME TO tool_calls;
+
+            CREATE INDEX IF NOT EXISTS idx_tool_calls_chat_id
+                ON tool_calls(chat_id);
+
+            CREATE INDEX IF NOT EXISTS idx_tool_calls_chat_message_id
+                ON tool_calls(chat_id, message_id);",
+        )?;
+        set_schema_version_in_tx(
+            &tx,
+            3,
+            "scope tool call uniqueness to chat and assistant message",
+        )?;
+        tx.commit()?;
+        version = 3;
     }
 
     debug_assert_eq!(version, SCHEMA_VERSION, "all migrations applied");
@@ -672,15 +746,25 @@ impl Database {
         Ok(())
     }
 
-    /// Update the output of a tool call.
-    pub fn update_tool_call_output(&self, id: &str, output: &str) -> Result<(), StorageError> {
+    /// Update the output of a tool call scoped to the assistant message that emitted it.
+    pub fn update_tool_call_output_for_message(
+        &self,
+        chat_id: i64,
+        message_id: &str,
+        id: &str,
+        output: &str,
+    ) -> Result<(), StorageError> {
         let conn = self.lock_conn()?;
         let rows_updated = conn.execute(
-            "UPDATE tool_calls SET tool_output = ?1 WHERE id = ?2",
-            params![output, id],
+            "UPDATE tool_calls
+             SET tool_output = ?1
+             WHERE chat_id = ?2 AND message_id = ?3 AND id = ?4",
+            params![output, chat_id, message_id, id],
         )?;
         if rows_updated == 0 {
-            return Err(StorageError::NotFound(format!("tool_call:{id}")));
+            return Err(StorageError::NotFound(format!(
+                "tool_call:{chat_id}:{message_id}:{id}"
+            )));
         }
         Ok(())
     }
@@ -1122,9 +1206,17 @@ mod tests {
     #[test]
     fn update_tool_call_output_fails_when_tool_call_is_missing() {
         let (db, _dir) = test_db();
+        let chat_id = db
+            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web")
+            .expect("create chat");
 
         let error = db
-            .update_tool_call_output("missing-tool-call", "output")
+            .update_tool_call_output_for_message(
+                chat_id,
+                "message-1",
+                "missing-tool-call",
+                "output",
+            )
             .expect_err("missing tool call should fail");
 
         assert!(matches!(error, StorageError::NotFound(_)));
@@ -1147,7 +1239,7 @@ mod tests {
         };
 
         db.store_tool_call(&tool_call).expect("store tool call");
-        db.update_tool_call_output("tool-1", "done")
+        db.update_tool_call_output_for_message(chat_id, "message-1", "tool-1", "done")
             .expect("update tool call");
 
         let calls = db
@@ -1158,10 +1250,45 @@ mod tests {
     }
 
     #[test]
+    fn tool_call_ids_are_scoped_by_message() {
+        let (db, _dir) = test_db();
+        let chat_id = db
+            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web")
+            .expect("create chat");
+        let first = ToolCall {
+            id: "tool-1".to_string(),
+            chat_id,
+            message_id: "message-1".to_string(),
+            tool_name: "fetch".to_string(),
+            tool_input: "{}".to_string(),
+            tool_output: None,
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+        };
+        let second = ToolCall {
+            message_id: "message-2".to_string(),
+            timestamp: "2024-01-01T00:00:01Z".to_string(),
+            ..first.clone()
+        };
+
+        db.store_tool_call(&first).expect("store first tool call");
+        db.store_tool_call(&second)
+            .expect("store second tool call with duplicate provider id");
+        db.update_tool_call_output_for_message(chat_id, "message-2", "tool-1", "done")
+            .expect("update scoped output");
+
+        let calls = db
+            .get_tool_calls_for_chat(chat_id)
+            .expect("load tool calls");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].tool_output, None);
+        assert_eq!(calls[1].tool_output.as_deref(), Some("done"));
+    }
+
+    #[test]
     fn schema_version_is_tracked_on_init() {
         let (db, _dir) = test_db();
         let version = db.schema_version().expect("schema version");
-        assert_eq!(version, 2, "新規DBはスキーマバージョン2で初期化される");
+        assert_eq!(version, 3, "新規DBはスキーマバージョン3で初期化される");
     }
 
     #[test]
@@ -1179,11 +1306,13 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .expect("collect");
 
-        assert_eq!(rows.len(), 2, "v1・v2 マイグレーションが2件記録される");
+        assert_eq!(rows.len(), 3, "v1・v2・v3 マイグレーションが3件記録される");
         assert_eq!(rows[0].0, 1);
         assert!(rows[0].1.contains("initial schema"));
         assert_eq!(rows[1].0, 2);
         assert!(rows[1].1.contains("llm_usage_logs"));
+        assert_eq!(rows[2].0, 3);
+        assert!(rows[2].1.contains("tool call"));
     }
 
     #[test]
@@ -1203,7 +1332,7 @@ mod tests {
             first_version, second_version,
             "再起動してもバージョンは変わらない"
         );
-        assert_eq!(second_version, 2);
+        assert_eq!(second_version, 3);
     }
 
     #[test]
@@ -1558,14 +1687,22 @@ mod tests {
                  CREATE TABLE IF NOT EXISTS chats (chat_id INTEGER PRIMARY KEY);
                  CREATE TABLE IF NOT EXISTS messages (id TEXT NOT NULL, chat_id INTEGER NOT NULL, PRIMARY KEY (id, chat_id));
                  CREATE TABLE IF NOT EXISTS sessions (chat_id INTEGER PRIMARY KEY, messages_json TEXT NOT NULL, updated_at TEXT NOT NULL);
-                 CREATE TABLE IF NOT EXISTS tool_calls (id TEXT PRIMARY KEY);",
+                 CREATE TABLE IF NOT EXISTS tool_calls (
+                    id TEXT PRIMARY KEY,
+                    chat_id INTEGER NOT NULL,
+                    message_id TEXT NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    tool_input TEXT NOT NULL,
+                    tool_output TEXT,
+                    timestamp TEXT NOT NULL
+                 );",
             )
             .expect("create v1 schema");
         }
 
         let db = Database::new(&db_path).expect("reopen");
         let version = db.schema_version().expect("version");
-        assert_eq!(version, 2);
+        assert_eq!(version, 3);
 
         let conn = db.conn.lock().expect("lock");
         let table_exists: bool = conn
@@ -1579,12 +1716,12 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_increments_to_2() {
+    fn schema_version_increments_to_3() {
         let (db, _dir) = test_db();
         let version = db.schema_version().expect("version");
         assert_eq!(
-            version, 2,
-            "スキーマバージョンが2にインクリメントされていること"
+            version, 3,
+            "スキーマバージョンが3にインクリメントされていること"
         );
     }
 }


### PR DESCRIPTION
## 概要

Codex / Responses API の tool call 履歴で、`tool_calls.id` の重複により tool output 保存前に処理が中断し、次ターンで `No tool output found for function call ...` が発生する問題を修正します。

## 変更内容

- `tool_calls` の主キーを `id` 単体から `(id, chat_id, message_id)` に変更する v3 マイグレーションを追加
- tool output 更新を `chat_id + assistant message_id + tool_call_id` でスコープ
- 既に壊れた session snapshot に対して、欠けた tool output を synthetic error output として補う復元処理を追加
- DB / session lifecycle docs を更新
- call id 再利用と orphan tool output 修復の回帰テストを追加

## 原因

外部プロバイダ由来の tool call id を DB 全体の永続一意IDとして扱っていたため、同じ call id が再利用または再処理された場合に `UNIQUE constraint failed: tool_calls.id` が発生していました。その時点で assistant の function_call だけが session snapshot に残り、対応する tool output が欠けた履歴を次回 API に送って 400 になっていました。

## 影響

意図した影響は次の2点です。

- 別 assistant message で同じ provider call id が出ても tool call 履歴を保存できる
- 壊れた snapshot は 400 で停止せず、欠落を error tool output としてモデルへ渡して継続できる

通常の正常な tool flow、LLM に渡す call id、tool call id の値自体は変更していません。

## 検証

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * セッション復元時にツール出力が欠落している場合の処理を強化し、エラー応答を自動的に補完するよう改善しました。

* **ドキュメント**
  * データベーススキーマとセッション復元処理のドキュメントを更新しました。

* **Chores**
  * 内部的なツール呼び出し管理を改善し、複数のターンにおける正確な出力追跡を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->