### PR TITLE
fix: dedupe duplicate tool calls per response

### DIFF
--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -256,12 +256,19 @@ where
 }
 
 fn filter_valid_tool_calls(tool_calls: Vec<ToolCall>) -> Vec<ToolCall> {
+    let mut seen_ids = std::collections::HashSet::new();
     tool_calls
         .into_iter()
         .filter(|tc| {
             if tc.name.trim().is_empty() || tc.id.trim().is_empty() {
                 warn!(
                     "skipping malformed tool call (empty name or id): id='{}' name='{}'",
+                    tc.id, tc.name
+                );
+                false
+            } else if !seen_ids.insert(tc.id.clone()) {
+                warn!(
+                    "skipping duplicate tool call id in assistant response: id='{}' name='{}'",
                     tc.id, tc.name
                 );
                 false
@@ -1231,6 +1238,82 @@ mod tests {
         assert_eq!(tool_calls.len(), 2);
         assert!(tool_calls.iter().all(|call| call.id == "call-repeat"));
         assert!(tool_calls.iter().all(|call| call.tool_output.is_some()));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn duplicate_tool_call_ids_in_same_response_are_executed_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let relative_path = format!("tests/{}/duplicate.txt", uuid::Uuid::new_v4());
+        let provider = RecordingProvider::new(
+            vec![
+                Ok(MessagesResponse {
+                    content: "Reading.".to_string(),
+                    tool_calls: vec![
+                        ToolCall {
+                            id: "call-duplicate".to_string(),
+                            name: "read".to_string(),
+                            arguments: serde_json::json!({"path": relative_path.clone()}),
+                        },
+                        ToolCall {
+                            id: "call-duplicate".to_string(),
+                            name: "read".to_string(),
+                            arguments: serde_json::json!({"path": relative_path.clone()}),
+                        },
+                    ],
+                    usage: None,
+                }),
+                Ok(MessagesResponse {
+                    content: "Done.".to_string(),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                }),
+            ],
+            vec![0, 0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider.clone()),
+        );
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
+        let file_path = workspace.join(&relative_path);
+        std::fs::create_dir_all(file_path.parent().expect("file parent")).expect("workspace");
+        std::fs::write(&file_path, "duplicate content").expect("duplicate.txt");
+
+        let reply = process_turn(&state, &cli_context("duplicate-tool-call-id"), "read it")
+            .await
+            .expect("process turn");
+
+        assert_eq!(reply, "Done.");
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:duplicate-tool-call-id",
+                Some("duplicate-tool-call-id"),
+                "cli",
+            )
+        })
+        .await
+        .expect("chat id");
+        let tool_calls = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_tool_calls_for_chat(chat_id)
+        })
+        .await
+        .expect("tool calls");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call-duplicate");
+        assert!(tool_calls[0].tool_output.is_some());
+
+        let seen_messages = provider.seen_messages();
+        assert_eq!(seen_messages.len(), 2);
+        assert_eq!(seen_messages[1][1].role, "assistant");
+        assert_eq!(seen_messages[1][1].tool_calls.len(), 1);
+        assert_eq!(seen_messages[1][1].tool_calls[0].id, "call-duplicate");
+        assert_eq!(seen_messages[1][2].role, "tool");
+        assert_eq!(
+            seen_messages[1][2].tool_call_id.as_deref(),
+            Some("call-duplicate")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 概要

同一 assistant response 内に同じ `tool_call.id` が重複して含まれる場合、DB の `(id, chat_id, message_id)` 一意制約で落ちる問題を修正します。

## 変更内容

- `filter_valid_tool_calls` で同一 response 内の duplicate `tool_call.id` を除外
- 重複時は最初の1件だけ採用し、2件目以降は warning で skip
- DB に1件だけ残ることに加え、次回 LLM request の履歴にも duplicate tool call が残らないことを回帰テストで確認

## 影響

- 正常な異なる `tool_call.id` の複数 tool call は従来どおり実行されます
- 同じ response 内で同じ `tool_call.id` が複数出た壊れた応答では、2件目以降は実行しません
- DB schema の追加変更はありません

## 検証

- `cargo fmt --check`
- `cargo test duplicate_tool_call_ids_in_same_response_are_executed_once -- --nocapture`
- `cargo test repeated_provider_tool_call_ids_do_not_break_later_turns -- --nocapture`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 同じIDを持つツール呼び出しが重複する場合、最初のものだけを実行し、重複するものは警告ログで無視するようにしました。

* **テスト**
  * ツール呼び出しの重複シナリオを検証する統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->