### PR TITLE
[codex] Fix Responses tool call history handling

### DIFF
--- a/docs/openai-codex.md
+++ b/docs/openai-codex.md
@@ -15,6 +15,7 @@ Responses API に似ているが完全互換ではないため、通常の OpenA
 | `response.completed.response.output` が空でも本文が生成されていることがある | 中間 SSE event の `response.output_text.delta` / `response.output_text.done` / `response.output_item.done` から本文や item を復元する |
 | text-only message を parts 配列にすると挙動差が出やすい | text-only は `content: "..."`、画像などがある場合だけ parts 配列にする |
 | tools 指定時の選択挙動を backend 任せにすると不安定になり得る | tools がある場合は `tool_choice: "auto"` を明示する |
+| `function_call_output` は同じ input 内の `function_call` と対応している必要がある | 孤立 tool output は `function_call_output` にせず履歴 context message として渡す。compaction は assistant tool call と直後の tool outputs を分断しない |
 | 空応答の原因が見えにくい | `status`, `output_items`, `input_tokens`, `output_tokens`, `reasoning_tokens`, `incomplete_reason` をエラー文に含める |
 
 ## Request Shape

--- a/src/agent_loop/compaction.rs
+++ b/src/agent_loop/compaction.rs
@@ -58,7 +58,7 @@ async fn summarize_and_compact(
         return Ok(messages.to_vec());
     }
 
-    let split_at = messages.len() - keep_recent;
+    let split_at = tool_safe_split_at(messages, messages.len() - keep_recent);
     let old_messages = &messages[..split_at];
     let recent_messages = &messages[split_at..];
 
@@ -235,6 +235,40 @@ pub(crate) fn truncate_compaction_summary_input(mut summary_input: String) -> St
     summary_input
 }
 
+pub(crate) fn tool_safe_split_at(messages: &[Message], preferred_split_at: usize) -> usize {
+    let mut split_at = preferred_split_at.min(messages.len());
+
+    while split_at < messages.len() && messages[split_at].role == "tool" {
+        let Some(tool_call_id) = messages[split_at].tool_call_id.as_deref() else {
+            split_at += 1;
+            continue;
+        };
+
+        let Some(parent_index) = find_tool_call_parent(messages, split_at, tool_call_id) else {
+            split_at += 1;
+            continue;
+        };
+
+        split_at = parent_index;
+    }
+
+    split_at
+}
+
+fn find_tool_call_parent(
+    messages: &[Message],
+    before_index: usize,
+    tool_call_id: &str,
+) -> Option<usize> {
+    messages[..before_index].iter().rposition(|message| {
+        message.role == "assistant"
+            && message
+                .tool_calls
+                .iter()
+                .any(|tool_call| tool_call.id == tool_call_id)
+    })
+}
+
 pub(crate) fn append_compacted_message(compacted: &mut Vec<Message>, message: &Message) {
     let Some(last) = compacted.last_mut() else {
         compacted.push(message.clone());
@@ -272,7 +306,7 @@ mod tests {
         RecordingProvider, build_state, cli_context, test_config_with_compaction,
     };
     use crate::error::LlmError;
-    use crate::llm::{Message, MessagesResponse};
+    use crate::llm::{Message, MessagesResponse, ToolCall};
     use crate::storage::call_blocking;
     use serial_test::serial;
     use std::sync::Arc;
@@ -292,6 +326,80 @@ mod tests {
 
         let expected = format!("{}\n... (truncated)", "a".repeat(19_999) + "あ");
         assert_eq!(truncated, expected);
+    }
+
+    #[test]
+    fn tool_safe_split_at_rewinds_from_tool_output_to_parent_call() {
+        let messages = vec![
+            Message::text("user", "old"),
+            assistant_tool_call("call_1"),
+            tool_output("call_1"),
+            Message::text("user", "next"),
+        ];
+
+        assert_eq!(tool_safe_split_at(&messages, 2), 1);
+    }
+
+    #[test]
+    fn tool_safe_split_at_keeps_multi_tool_call_block_together() {
+        let messages = vec![
+            Message::text("user", "old"),
+            Message {
+                role: "assistant".to_string(),
+                content: crate::llm::MessageContent::text(""),
+                tool_calls: vec![
+                    ToolCall {
+                        id: "call_a".to_string(),
+                        name: "read".to_string(),
+                        arguments: serde_json::json!({}),
+                    },
+                    ToolCall {
+                        id: "call_b".to_string(),
+                        name: "grep".to_string(),
+                        arguments: serde_json::json!({}),
+                    },
+                ],
+                tool_call_id: None,
+            },
+            tool_output("call_a"),
+            tool_output("call_b"),
+            Message::text("assistant", "done"),
+        ];
+
+        assert_eq!(tool_safe_split_at(&messages, 3), 1);
+    }
+
+    #[test]
+    fn tool_safe_split_at_skips_orphan_tool_outputs() {
+        let messages = vec![
+            Message::text("user", "old"),
+            tool_output("call_missing"),
+            Message::text("user", "next"),
+        ];
+
+        assert_eq!(tool_safe_split_at(&messages, 1), 2);
+    }
+
+    fn assistant_tool_call(id: &str) -> Message {
+        Message {
+            role: "assistant".to_string(),
+            content: crate::llm::MessageContent::text(""),
+            tool_calls: vec![ToolCall {
+                id: id.to_string(),
+                name: "read".to_string(),
+                arguments: serde_json::json!({}),
+            }],
+            tool_call_id: None,
+        }
+    }
+
+    fn tool_output(id: &str) -> Message {
+        Message {
+            role: "tool".to_string(),
+            content: crate::llm::MessageContent::text("result"),
+            tool_calls: Vec::new(),
+            tool_call_id: Some(id.to_string()),
+        }
     }
 
     #[tokio::test]

--- a/src/llm/messages.rs
+++ b/src/llm/messages.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashSet;
 
 pub(crate) fn build_request_body(
     model: &str,
@@ -35,16 +36,71 @@ pub(crate) fn build_responses_request_body(
 ) -> serde_json::Value {
     let mut body = serde_json::json!({
         "model": model,
-        "input": messages
-            .iter()
-            .flat_map(translate_message_to_responses)
-            .collect::<Vec<_>>(),
+        "input": translate_messages_to_responses(messages),
     });
     if !system.trim().is_empty() {
         body["instructions"] = serde_json::Value::String(system.to_string());
     }
     append_responses_tools(&mut body, tools);
     body
+}
+
+fn translate_messages_to_responses(messages: &[Message]) -> Vec<serde_json::Value> {
+    let mut seen_function_call_ids = HashSet::new();
+    let mut input = Vec::new();
+
+    for message in messages {
+        match message.role.as_str() {
+            "assistant" if !message.tool_calls.is_empty() => {
+                for tool_call in &message.tool_calls {
+                    seen_function_call_ids.insert(tool_call.id.clone());
+                }
+                input.extend(translate_message_to_responses(message));
+            }
+            "tool" if tool_output_has_matching_call(message, &seen_function_call_ids) => {
+                input.extend(translate_message_to_responses(message));
+            }
+            "tool" => input.extend(orphan_tool_output_to_responses_context(message)),
+            _ => input.extend(translate_message_to_responses(message)),
+        }
+    }
+
+    input
+}
+
+fn tool_output_has_matching_call(
+    message: &Message,
+    seen_function_call_ids: &HashSet<String>,
+) -> bool {
+    message
+        .tool_call_id
+        .as_ref()
+        .is_some_and(|call_id| seen_function_call_ids.contains(call_id))
+}
+
+fn orphan_tool_output_to_responses_context(message: &Message) -> Vec<serde_json::Value> {
+    let call_id = message
+        .tool_call_id
+        .as_deref()
+        .filter(|call_id| !call_id.trim().is_empty())
+        .unwrap_or("unknown");
+    let text = format!(
+        "Previous tool output could not be linked to a function call ({call_id}). Treat this as historical context only.\n{}",
+        message.content.as_text_lossy()
+    );
+    let mut items = vec![serde_json::json!({
+        "type": "message",
+        "role": "user",
+        "content": text,
+    })];
+    if message.content.is_multimodal() {
+        items.push(serde_json::json!({
+            "type": "message",
+            "role": "user",
+            "content": synthetic_tool_attachment_parts(&message.content),
+        }));
+    }
+    items
 }
 
 pub(crate) fn translate_message_to_openai(message: &Message) -> serde_json::Value {
@@ -316,5 +372,60 @@ mod tests {
         assert_eq!(body["tool_choice"], "auto");
         assert_eq!(body["tools"][0]["type"], "function");
         assert_eq!(body["tools"][0]["name"], "read");
+    }
+
+    #[test]
+    fn responses_request_keeps_matched_tool_output_as_function_call_output() {
+        let body = build_responses_request_body(
+            "gpt-5.3-codex",
+            "",
+            &[
+                Message {
+                    role: "assistant".to_string(),
+                    content: MessageContent::text(""),
+                    tool_calls: vec![ToolCall {
+                        id: "call_1".to_string(),
+                        name: "read".to_string(),
+                        arguments: serde_json::json!({"path": "README.md"}),
+                    }],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: "tool".to_string(),
+                    content: MessageContent::text("read result"),
+                    tool_calls: Vec::new(),
+                    tool_call_id: Some("call_1".to_string()),
+                },
+            ],
+            None,
+        );
+
+        assert_eq!(body["input"][0]["type"], "function_call");
+        assert_eq!(body["input"][1]["type"], "function_call_output");
+        assert_eq!(body["input"][1]["call_id"], "call_1");
+    }
+
+    #[test]
+    fn responses_request_converts_orphan_tool_output_to_context_message() {
+        let body = build_responses_request_body(
+            "gpt-5.3-codex",
+            "",
+            &[Message {
+                role: "tool".to_string(),
+                content: MessageContent::text("orphan result"),
+                tool_calls: Vec::new(),
+                tool_call_id: Some("call_missing".to_string()),
+            }],
+            None,
+        );
+
+        assert_eq!(body["input"][0]["type"], "message");
+        assert_eq!(body["input"][0]["role"], "user");
+        assert!(
+            body["input"][0]["content"]
+                .as_str()
+                .expect("content string")
+                .contains("call_missing")
+        );
     }
 }


### PR DESCRIPTION
## 概要
- Responses API 変換時、対応する function_call が同じ input 内にない tool output を function_call_output として送らないようにしました
- compaction の履歴分割で assistant tool call と直後の tool outputs を分断しないようにしました
- Codex provider の注意事項に今回の履歴整合性ルールを追記しました

## 原因
Codex provider は Responses API 形式で全履歴を送るため、compaction などで assistant の tool call と tool output が分断されると、孤立した function_call_output が送信されて 400 Bad Request になります。

## 影響
長いセッションや compaction 後でも、Codex backend に不正な function_call_output を送らずに会話を継続できます。孤立 tool output は履歴 context message として渡します。

## 検証
- cargo fmt --check
- cargo test llm::
- cargo test agent_loop::compaction::
- cargo test
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Codex プロバイダーにおける `function_call_output` の整合性ルールに関するドキュメントを更新しました。

* **Bug Fixes**
  * ツール呼び出しとその出力が適切に関連付けられるようになり、メッセージ処理の信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->