### PR TITLE
refactor: architecture dedup & cache (issue #29)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ src/
 │   └── secret_ref.rs    # SecretRef 型、.env 読み書き
 │
 ├── tools/               # ツールシステム
-│   ├── mod.rs           # ToolRegistry, Tool trait
+│   ├── mod.rs           # ToolRegistry, Tool trait, is_read_only()
 │   ├── mcp_adapter.rs   # MCP tool → Tool trait アダプター
 │   ├── command_guard.rs # bash コマンド検閲
 │   ├── path_guard.rs    # 機密パスブロック
@@ -116,12 +116,15 @@ src/
 │
 ├── storage.rs           # SQLite 永続化
 ├── mcp.rs               # MCP クライアント
+├── codex_auth.rs        # Codex auth 解決、AUTH_CACHE
 ├── channel_adapter.rs   # ChannelAdapter trait, ChannelRegistry
 ├── skills.rs            # スキル管理
+├── slash_commands.rs    # slash command dispatcher、SlashCommandOutcome
 ├── soul_agents.rs       # SOUL.md / AGENTS.md 読み込み
 ├── error.rs             # エラー型
 ├── gateway.rs           # systemd サービス管理
-└── status.rs            # ランタイムステータス
+├── status.rs            # ランタイムステータス
+└── test_env.rs          # テスト用 EnvVarGuard、ENV_MUTEX
 ```
 
 ---
@@ -142,12 +145,14 @@ pub struct AppState {
     pub mcp_manager: Option<Arc<RwLock<McpManager>>>,
     pub assets: Arc<AssetStore>,               // 埋め込みアセット
     pub soul_agents: Arc<SoulAgentsLoader>,    // SOUL/AGENTS ローダー
+    pub llm_cache: Mutex<HashMap<u64, Arc<dyn LlmProvider>>>,  // LLM provider cache
 }
 ```
 
 ### SurfaceContext
 
 メッセージの送信元を識別する型。チャネル・ユーザー・スレッドの組み合わせで一意になる。
+`SurfaceContext::new()` が全チャネルで使用される正規コンストラクタ。
 
 ```rust
 pub struct SurfaceContext {
@@ -196,7 +201,7 @@ pub trait ChannelAdapter: Send + Sync {
       ├─ 3e. LLM に messages + tools を送信
       │      │
       │      ├─ tool_call があれば:
-      │      │  ├ ツール実行 (built-in / MCP adapter)
+      │      │  ├ ツール実行 (read-only は join_all で並列、それ以外は逐次)
       │      │  ├ 結果を messages に追加
       │      │  └ 3e に戻る (最大 50 イテレーション)
       │      │
@@ -271,3 +276,6 @@ pub trait ChannelAdapter: Send + Sync {
 | **Tool Registry** | `tools/mod.rs` | built-in / MCP の区別なくツールを動的登録 |
 | **Feature Flag** | `Cargo.toml` | Discord / Telegram をオプショナルに |
 | **Graceful Shutdown** | `runtime.rs` | 10 秒タイムアウト付きで全チャネルを安全停止 |
+| **LLM Provider Cache** | `runtime.rs` AppState | 同一 ResolvedLlmConfig の LLM クライアントを再利用 |
+| **Codex Auth Cache** | `codex_auth.rs` | 5 分 TTL で codex auth 解決結果をキャッシュ |
+| **Read-only Parallel** | `agent_loop/turn.rs` | `is_read_only()` が真のツールは並列実行 |

--- a/src/agent_loop/formatting.rs
+++ b/src/agent_loop/formatting.rs
@@ -68,7 +68,8 @@ pub(crate) fn tool_message_content(
                 text: payload.to_string(),
             });
             content.extend(parts.iter().filter_map(|part| match part {
-                crate::llm::MessageContentPart::InputText { .. } | crate::llm::MessageContentPart::InputImageRef { .. } => None,
+                crate::llm::MessageContentPart::InputText { .. }
+                | crate::llm::MessageContentPart::InputImageRef { .. } => None,
                 crate::llm::MessageContentPart::InputImage { image_url, detail } => {
                     Some(crate::llm::MessageContentPart::InputImage {
                         image_url: image_url.clone(),
@@ -253,7 +254,8 @@ pub(crate) fn tool_result_payload(message: &Message) -> Option<&str> {
         crate::llm::MessageContent::Text(text) => Some(text.as_str()),
         crate::llm::MessageContent::Parts(parts) => parts.iter().find_map(|part| match part {
             crate::llm::MessageContentPart::InputText { text } => Some(text.as_str()),
-            crate::llm::MessageContentPart::InputImage { .. } | crate::llm::MessageContentPart::InputImageRef { .. } => None,
+            crate::llm::MessageContentPart::InputImage { .. }
+            | crate::llm::MessageContentPart::InputImageRef { .. } => None,
         }),
     }
 }

--- a/src/agent_loop/formatting.rs
+++ b/src/agent_loop/formatting.rs
@@ -68,7 +68,7 @@ pub(crate) fn tool_message_content(
                 text: payload.to_string(),
             });
             content.extend(parts.iter().filter_map(|part| match part {
-                crate::llm::MessageContentPart::InputText { .. } => None,
+                crate::llm::MessageContentPart::InputText { .. } | crate::llm::MessageContentPart::InputImageRef { .. } => None,
                 crate::llm::MessageContentPart::InputImage { image_url, detail } => {
                     Some(crate::llm::MessageContentPart::InputImage {
                         image_url: image_url.clone(),
@@ -236,6 +236,7 @@ fn format_message_part(
                 (true, None) => format!("[image: {image_url}]"),
             })
         }
+        MessageContentPart::InputImageRef { .. } => Some("[image]".to_string()),
     }
 }
 
@@ -252,7 +253,7 @@ pub(crate) fn tool_result_payload(message: &Message) -> Option<&str> {
         crate::llm::MessageContent::Text(text) => Some(text.as_str()),
         crate::llm::MessageContent::Parts(parts) => parts.iter().find_map(|part| match part {
             crate::llm::MessageContentPart::InputText { text } => Some(text.as_str()),
-            crate::llm::MessageContentPart::InputImage { .. } => None,
+            crate::llm::MessageContentPart::InputImage { .. } | crate::llm::MessageContentPart::InputImageRef { .. } => None,
         }),
     }
 }

--- a/src/agent_loop/mod.rs
+++ b/src/agent_loop/mod.rs
@@ -23,8 +23,74 @@ pub struct SurfaceContext {
 }
 
 impl SurfaceContext {
+    /// Creates a new `SurfaceContext` identifying the external conversation surface.
+    pub fn new(
+        channel: String,
+        surface_user: String,
+        surface_thread: String,
+        chat_type: String,
+        agent_id: String,
+    ) -> Self {
+        Self {
+            channel,
+            surface_user,
+            surface_thread,
+            chat_type,
+            agent_id,
+        }
+    }
+
     /// Returns the stable session key in `channel:surface_thread` format.
     pub fn session_key(&self) -> String {
         format!("{}:{}", self.channel, self.surface_thread)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_assigns_all_fields() {
+        // Arrange
+        let channel = "cli".to_string();
+        let surface_user = "alice".to_string();
+        let surface_thread = "session-1".to_string();
+        let chat_type = "cli".to_string();
+        let agent_id = "developer".to_string();
+
+        // Act
+        let ctx = SurfaceContext::new(
+            channel.clone(),
+            surface_user.clone(),
+            surface_thread.clone(),
+            chat_type.clone(),
+            agent_id.clone(),
+        );
+
+        // Assert
+        assert_eq!(ctx.channel, channel);
+        assert_eq!(ctx.surface_user, surface_user);
+        assert_eq!(ctx.surface_thread, surface_thread);
+        assert_eq!(ctx.chat_type, chat_type);
+        assert_eq!(ctx.agent_id, agent_id);
+    }
+
+    #[test]
+    fn session_key_format_is_channel_colon_thread() {
+        // Arrange
+        let ctx = SurfaceContext::new(
+            "discord".to_string(),
+            "bob".to_string(),
+            "123:bot:main:agent:dev".to_string(),
+            "discord".to_string(),
+            "dev".to_string(),
+        );
+
+        // Act
+        let key = ctx.session_key();
+
+        // Assert
+        assert_eq!(key, "discord:123:bot:main:agent:dev");
     }
 }

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -5,8 +5,6 @@
 
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
 use crate::agent_loop::SurfaceContext;
 use crate::assets::AssetStore;
 use crate::error::{EgoPulseError, StorageError};
@@ -26,37 +24,6 @@ pub(crate) struct LoadedSession {
 pub(crate) struct PersistedTurn {
     pub(crate) updated_at: String,
     pub(crate) messages: Vec<Message>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct PersistedMessage {
-    role: String,
-    content: PersistedMessageContent,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    tool_calls: Vec<crate::llm::ToolCall>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    tool_call_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-enum PersistedMessageContent {
-    Text(String),
-    Parts(Vec<PersistedMessageContentPart>),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type")]
-enum PersistedMessageContentPart {
-    #[serde(rename = "input_text")]
-    InputText { text: String },
-    #[serde(rename = "input_image_ref")]
-    InputImageRef {
-        image_ref: String,
-        mime_type: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        detail: Option<String>,
-    },
 }
 
 /// Resolves or creates the internal chat ID for a conversation surface.
@@ -295,14 +262,15 @@ async fn serialize_snapshot(
     .map_err(EgoPulseError::Storage)
 }
 
+/// Convert `InputImage` parts to `InputImageRef` for disk serialization.
 fn persist_messages(
     assets: &AssetStore,
     messages: &[Message],
-) -> Result<Vec<PersistedMessage>, StorageError> {
+) -> Result<Vec<Message>, StorageError> {
     messages
         .iter()
         .map(|message| {
-            Ok(PersistedMessage {
+            Ok(Message {
                 role: message.role.clone(),
                 content: persist_content(assets, &message.content)?,
                 tool_calls: message.tool_calls.clone(),
@@ -315,10 +283,10 @@ fn persist_messages(
 fn persist_content(
     assets: &AssetStore,
     content: &MessageContent,
-) -> Result<PersistedMessageContent, StorageError> {
+) -> Result<MessageContent, StorageError> {
     match content {
-        MessageContent::Text(text) => Ok(PersistedMessageContent::Text(text.clone())),
-        MessageContent::Parts(parts) => Ok(PersistedMessageContent::Parts(
+        MessageContent::Text(text) => Ok(MessageContent::Text(text.clone())),
+        MessageContent::Parts(parts) => Ok(MessageContent::Parts(
             parts
                 .iter()
                 .map(|part| persist_part(assets, part))
@@ -330,57 +298,57 @@ fn persist_content(
 fn persist_part(
     assets: &AssetStore,
     part: &MessageContentPart,
-) -> Result<PersistedMessageContentPart, StorageError> {
+) -> Result<MessageContentPart, StorageError> {
     match part {
         MessageContentPart::InputText { text } => {
-            Ok(PersistedMessageContentPart::InputText { text: text.clone() })
+            Ok(MessageContentPart::InputText { text: text.clone() })
         }
         MessageContentPart::InputImage { image_url, detail } => {
             let stored = assets.persist_image_data_url(image_url)?;
-            Ok(PersistedMessageContentPart::InputImageRef {
+            Ok(MessageContentPart::InputImageRef {
                 image_ref: stored.image_ref,
                 mime_type: stored.mime_type,
                 detail: detail.clone(),
             })
         }
+        MessageContentPart::InputImageRef { .. } => Ok(part.clone()),
     }
 }
 
+/// Deserialize snapshot JSON as `Vec<Message>` and hydrate `InputImageRef` → `InputImage`.
 fn restore_snapshot_messages(
     assets: &AssetStore,
     json: &str,
 ) -> Result<Vec<Message>, StorageError> {
-    let persisted: Vec<PersistedMessage> =
+    let messages: Vec<Message> =
         serde_json::from_str(json).map_err(StorageError::SessionSerialize)?;
-    persisted
+    Ok(messages
         .into_iter()
-        .map(|message| {
-            Ok(Message {
-                role: message.role,
-                content: restore_content(assets, message.content),
-                tool_calls: message.tool_calls,
-                tool_call_id: message.tool_call_id,
-            })
-        })
-        .collect()
+        .map(|message| hydrate_message(assets, message))
+        .collect())
 }
 
-fn restore_content(assets: &AssetStore, content: PersistedMessageContent) -> MessageContent {
+fn hydrate_message(assets: &AssetStore, message: Message) -> Message {
+    Message {
+        content: hydrate_content(assets, message.content),
+        ..message
+    }
+}
+
+fn hydrate_content(assets: &AssetStore, content: MessageContent) -> MessageContent {
     match content {
-        PersistedMessageContent::Text(text) => MessageContent::text(text),
-        PersistedMessageContent::Parts(parts) => MessageContent::parts(
-            parts
-                .into_iter()
-                .map(|part| restore_part(assets, part))
-                .collect(),
+        MessageContent::Text(text) => MessageContent::Text(text),
+        MessageContent::Parts(parts) => MessageContent::Parts(
+            parts.into_iter().map(|part| hydrate_part(assets, part)).collect(),
         ),
     }
 }
 
-fn restore_part(assets: &AssetStore, part: PersistedMessageContentPart) -> MessageContentPart {
+fn hydrate_part(assets: &AssetStore, part: MessageContentPart) -> MessageContentPart {
     match part {
-        PersistedMessageContentPart::InputText { text } => MessageContentPart::InputText { text },
-        PersistedMessageContentPart::InputImageRef {
+        MessageContentPart::InputText { text } => MessageContentPart::InputText { text },
+        MessageContentPart::InputImage { .. } => part,
+        MessageContentPart::InputImageRef {
             image_ref,
             mime_type,
             detail,

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -339,7 +339,10 @@ fn hydrate_content(assets: &AssetStore, content: MessageContent) -> MessageConte
     match content {
         MessageContent::Text(text) => MessageContent::Text(text),
         MessageContent::Parts(parts) => MessageContent::Parts(
-            parts.into_iter().map(|part| hydrate_part(assets, part)).collect(),
+            parts
+                .into_iter()
+                .map(|part| hydrate_part(assets, part))
+                .collect(),
         ),
     }
 }

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -964,6 +964,7 @@ pub(crate) fn build_state(
         mcp_manager: None,
         assets: std::sync::Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
         soul_agents,
+        llm_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
     }
 }
 

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -19,6 +19,7 @@ use crate::runtime::{AppState, build_app_state};
 use crate::storage::{StoredMessage, ToolCall as StoredToolCall, call_blocking};
 use crate::tools::ToolExecutionContext;
 use crate::web::sse::AgentEvent;
+use futures_util::future::join_all;
 use std::ops::ControlFlow;
 use std::sync::Arc;
 use tracing::warn;
@@ -487,17 +488,40 @@ where
     messages = persisted.messages;
     let session_updated_at = Some(persisted.updated_at);
 
-    for tool_call in valid_tool_calls {
-        messages.push(
-            execute_tool_call(
-                state,
-                on_event,
-                tool_context,
-                &assistant_message_id,
-                tool_call,
-            )
-            .await?,
-        );
+    let all_read_only = valid_tool_calls
+        .iter()
+        .all(|tc| state.tools.is_read_only(&tc.name));
+
+    if all_read_only {
+        let tool_futures: Vec<_> = valid_tool_calls
+            .into_iter()
+            .map(|tool_call| {
+                execute_tool_call(
+                    state,
+                    on_event,
+                    tool_context,
+                    &assistant_message_id,
+                    tool_call,
+                )
+            })
+            .collect();
+        let results = join_all(tool_futures).await;
+        for result in results {
+            messages.push(result?);
+        }
+    } else {
+        for tool_call in valid_tool_calls {
+            messages.push(
+                execute_tool_call(
+                    state,
+                    on_event,
+                    tool_context,
+                    &assistant_message_id,
+                    tool_call,
+                )
+                .await?,
+            );
+        }
     }
 
     Ok((messages, session_updated_at))
@@ -1730,5 +1754,126 @@ mod tests {
         assert_eq!(result, "agent reply");
         let systems = provider.seen_systems();
         assert_eq!(systems.len(), 1, "should have exactly one LLM call");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn parallel_read_only_tools_execute_concurrently() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_a = format!("tests/{}/a.txt", uuid::Uuid::new_v4());
+        let file_b = format!("tests/{}/b.txt", uuid::Uuid::new_v4());
+        let provider = RecordingProvider::new(
+            vec![
+                Ok(MessagesResponse {
+                    content: "Reading.".to_string(),
+                    tool_calls: vec![
+                        ToolCall {
+                            id: "call-1".to_string(),
+                            name: "read".to_string(),
+                            arguments: serde_json::json!({"path": file_a.clone()}),
+                        },
+                        ToolCall {
+                            id: "call-2".to_string(),
+                            name: "read".to_string(),
+                            arguments: serde_json::json!({"path": file_b.clone()}),
+                        },
+                    ],
+                    usage: None,
+                }),
+                Ok(MessagesResponse {
+                    content: "Done.".to_string(),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                }),
+            ],
+            vec![0, 0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
+        for path in &[&file_a, &file_b] {
+            let full = workspace.join(path);
+            std::fs::create_dir_all(full.parent().expect("parent")).expect("dir");
+            std::fs::write(&full, format!("content of {}", path)).expect("write");
+        }
+
+        let reply = process_turn(&state, &cli_context("parallel-read"), "read both")
+            .await
+            .expect("turn");
+        assert_eq!(reply, "Done.");
+
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id("cli", "cli:parallel-read", Some("parallel-read"), "cli")
+        })
+        .await
+        .expect("chat id");
+        let tool_calls = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_tool_calls_for_chat(chat_id)
+        })
+        .await
+        .expect("tool calls");
+        assert_eq!(tool_calls.len(), 2);
+        assert!(tool_calls.iter().all(|tc| tc.tool_output.is_some()));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn mixed_tools_execute_sequentially() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_a = format!("tests/{}/a.txt", uuid::Uuid::new_v4());
+        let provider = RecordingProvider::new(
+            vec![
+                Ok(MessagesResponse {
+                    content: "Mixed.".to_string(),
+                    tool_calls: vec![
+                        ToolCall {
+                            id: "call-1".to_string(),
+                            name: "read".to_string(),
+                            arguments: serde_json::json!({"path": file_a.clone()}),
+                        },
+                        ToolCall {
+                            id: "call-2".to_string(),
+                            name: "bash".to_string(),
+                            arguments: serde_json::json!({"command": "echo ok"}),
+                        },
+                    ],
+                    usage: None,
+                }),
+                Ok(MessagesResponse {
+                    content: "Done.".to_string(),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                }),
+            ],
+            vec![0, 0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
+        let full = workspace.join(&file_a);
+        std::fs::create_dir_all(full.parent().expect("parent")).expect("dir");
+        std::fs::write(&full, "hello").expect("write");
+
+        let reply = process_turn(&state, &cli_context("mixed-tools"), "mixed")
+            .await
+            .expect("turn");
+        assert_eq!(reply, "Done.");
+
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id("cli", "cli:mixed-tools", Some("mixed-tools"), "cli")
+        })
+        .await
+        .expect("chat id");
+        let tool_calls = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_tool_calls_for_chat(chat_id)
+        })
+        .await
+        .expect("tool calls");
+        assert_eq!(tool_calls.len(), 2);
+        assert!(tool_calls.iter().all(|tc| tc.tool_output.is_some()));
     }
 }

--- a/src/channels/cli.rs
+++ b/src/channels/cli.rs
@@ -3,11 +3,11 @@
 //! 標準入出力を使った永続化チャットセッションを提供し、入力ごとに agent loop を実行する。
 
 use std::io::{self, BufRead, Write};
-use std::sync::Arc;
 
 use crate::agent_loop::{SurfaceContext, process_turn};
 use crate::error::EgoPulseError;
 use crate::runtime::AppState;
+use crate::slash_commands::{SlashCommandOutcome, process_slash_command};
 
 /// Runs an interactive CLI chat loop for the given persistent session.
 pub async fn run_chat(state: &AppState, session: &str) -> Result<(), EgoPulseError> {
@@ -40,40 +40,18 @@ pub async fn run_chat(state: &AppState, session: &str) -> Result<(), EgoPulseErr
             break;
         }
 
-        if crate::slash_commands::is_slash_command(trimmed) {
-            let slash_chat_id = crate::storage::call_blocking(Arc::clone(&state.db), {
-                let channel = context.channel.clone();
-                let thread = context.surface_thread.clone();
-                let chat_type = context.chat_type.clone();
-                move |db| {
-                    db.resolve_or_create_chat_id(
-                        &channel,
-                        &format!("cli:{thread}"),
-                        Some(&thread),
-                        &chat_type,
-                    )
-                }
-            })
-            .await
-            .map_err(EgoPulseError::from)?;
-
-            let response = crate::slash_commands::handle_slash_command(
-                state,
-                slash_chat_id,
-                &context,
-                trimmed,
-                None,
-            )
-            .await
-            .unwrap_or_else(crate::slash_commands::unknown_command_response);
-            writeln!(stdout, "assistant: {response}")
-                .map_err(crate::error::StorageError::Io)
-                .map_err(EgoPulseError::from)?;
-            stdout
-                .flush()
-                .map_err(crate::error::StorageError::Io)
-                .map_err(EgoPulseError::from)?;
-            continue;
+        match process_slash_command(state, &context, trimmed, None).await {
+            SlashCommandOutcome::Respond(response) | SlashCommandOutcome::Error(response) => {
+                writeln!(stdout, "assistant: {response}")
+                    .map_err(crate::error::StorageError::Io)
+                    .map_err(EgoPulseError::from)?;
+                stdout
+                    .flush()
+                    .map_err(crate::error::StorageError::Io)
+                    .map_err(EgoPulseError::from)?;
+                continue;
+            }
+            SlashCommandOutcome::NotHandled => {}
         }
 
         writeln!(stdout, "you: {trimmed}")

--- a/src/channels/cli.rs
+++ b/src/channels/cli.rs
@@ -13,13 +13,13 @@ use crate::runtime::AppState;
 pub async fn run_chat(state: &AppState, session: &str) -> Result<(), EgoPulseError> {
     let stdin = io::stdin();
     let mut stdout = io::stdout();
-    let context = SurfaceContext {
-        channel: "cli".to_string(),
-        surface_user: "local_user".to_string(),
-        surface_thread: session.to_string(),
-        chat_type: "cli".to_string(),
-        agent_id: state.config.default_agent.to_string(),
-    };
+    let context = SurfaceContext::new(
+        "cli".to_string(),
+        "local_user".to_string(),
+        session.to_string(),
+        "cli".to_string(),
+        state.config.default_agent.to_string(),
+    );
 
     writeln!(stdout, "session: {}", session)
         .map_err(crate::error::StorageError::Io)

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -294,13 +294,13 @@ impl Handler {
     }
 
     fn make_context(&self, user: &str, thread: &str, agent_id: &str) -> SurfaceContext {
-        SurfaceContext {
-            channel: "discord".to_string(),
-            surface_user: user.to_string(),
-            surface_thread: self.agent_thread(thread, agent_id),
-            chat_type: "discord".to_string(),
-            agent_id: agent_id.to_string(),
-        }
+        SurfaceContext::new(
+            "discord".to_string(),
+            user.to_string(),
+            self.agent_thread(thread, agent_id),
+            "discord".to_string(),
+            agent_id.to_string(),
+        )
     }
 
     fn guild_allowed(&self, channel_id: u64) -> bool {

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -372,44 +372,27 @@ impl EventHandler for Handler {
         let agent_id = self.select_agent(channel_id, is_dm).to_string();
 
         let thread = channel_id.to_string();
-        if crate::slash_commands::is_slash_command(&text) {
+        {
             let slash_context = self.make_context(&msg.author.name, &thread, &agent_id);
             let sender_id = msg.author.id.get().to_string();
-            let slash_chat_id =
-                crate::agent_loop::session::resolve_chat_id(&self.app_state, &slash_context).await;
+            let outcome = crate::slash_commands::process_slash_command(
+                &self.app_state,
+                &slash_context,
+                &text,
+                Some(&sender_id),
+            )
+            .await;
 
-            match slash_chat_id {
-                Ok(chat_id) => {
-                    if let Some(response) = crate::slash_commands::handle_slash_command(
-                        &self.app_state,
-                        chat_id,
-                        &slash_context,
-                        &text,
-                        Some(&sender_id),
-                    )
-                    .await
-                    {
-                        send_discord_response(&ctx, msg.channel_id, &response).await;
-                    } else {
-                        send_discord_response(
-                            &ctx,
-                            msg.channel_id,
-                            &crate::slash_commands::unknown_command_response(),
-                        )
-                        .await;
-                    }
+            match outcome {
+                crate::slash_commands::SlashCommandOutcome::Respond(response) => {
+                    send_discord_response(&ctx, msg.channel_id, &response).await;
                     return;
                 }
-                Err(e) => {
-                    error!("failed to resolve chat_id for slash command: {e}");
-                    send_discord_response(
-                        &ctx,
-                        msg.channel_id,
-                        "An error occurred processing the command.",
-                    )
-                    .await;
+                crate::slash_commands::SlashCommandOutcome::Error(response) => {
+                    send_discord_response(&ctx, msg.channel_id, &response).await;
                     return;
                 }
+                crate::slash_commands::SlashCommandOutcome::NotHandled => {}
             }
         }
 
@@ -607,22 +590,19 @@ impl EventHandler for Handler {
 
         let slash_context = self.make_context(&cmd.user.name, &thread, &interaction_agent);
         let sender_id = cmd.user.id.get().to_string();
-        let slash_chat_id =
-            crate::agent_loop::session::resolve_chat_id(&self.app_state, &slash_context).await;
 
-        let response_text = match slash_chat_id {
-            Ok(chat_id) => crate::slash_commands::handle_slash_command(
-                &self.app_state,
-                chat_id,
-                &slash_context,
-                &command_text,
-                Some(&sender_id),
-            )
-            .await
-            .unwrap_or_else(crate::slash_commands::unknown_command_response),
-            Err(e) => {
-                tracing::error!("failed to resolve chat_id for interaction: {e}");
-                "An error occurred processing the command.".to_string()
+        let response_text = match crate::slash_commands::process_slash_command(
+            &self.app_state,
+            &slash_context,
+            &command_text,
+            Some(&sender_id),
+        )
+        .await
+        {
+            crate::slash_commands::SlashCommandOutcome::Respond(response)
+            | crate::slash_commands::SlashCommandOutcome::Error(response) => response,
+            crate::slash_commands::SlashCommandOutcome::NotHandled => {
+                crate::slash_commands::unknown_command_response()
             }
         };
 

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -19,7 +19,7 @@ use crate::agent_loop::SurfaceContext;
 use crate::channel_adapter::ChannelAdapter;
 use crate::channel_adapter::ConversationKind;
 use crate::runtime::AppState;
-use crate::slash_commands;
+use crate::slash_commands::{self, SlashCommandOutcome, process_slash_command};
 use crate::text::split_text;
 
 /// Telegram メッセージ長制限 (文字数)。
@@ -357,8 +357,8 @@ async fn handle_message(
     // --- スラッシュコマンドインターセプト ---
     // process_turn より先に chat_id を解決し、
     // スラッシュコマンドであればエージェントループに入らずに即応答する。
-    if attachment_paths.is_empty() && slash_commands::is_slash_command(&text) {
-        if !is_mentioned {
+    if attachment_paths.is_empty() {
+        if !is_mentioned && slash_commands::is_slash_command(&text) {
             debug!(
                 chat_id = raw_chat_id,
                 "Telegram: skipping non-mentioned slash command in group"
@@ -367,42 +367,17 @@ async fn handle_message(
         }
 
         let sender_id = msg.from.as_ref().map(|u| u.id.0.to_string());
-
-        let resolved_chat_id =
-            crate::agent_loop::session::resolve_chat_id(&state, &context).await;
-
-        match resolved_chat_id {
-            Ok(chat_id) => {
-                if let Some(response) = slash_commands::handle_slash_command(
-                    &state,
-                    chat_id,
-                    &context,
-                    &text,
-                    sender_id.as_deref(),
-                )
-                .await
-                {
-                    send_telegram_response(&bot, msg.chat.id, &response).await;
-                } else {
-                    send_telegram_response(
-                        &bot,
-                        msg.chat.id,
-                        &slash_commands::unknown_command_response(),
-                    )
-                    .await;
-                }
+        match process_slash_command(&state, &context, &text, sender_id.as_deref()).await {
+            SlashCommandOutcome::Respond(response) => {
+                send_telegram_response(&bot, msg.chat.id, &response).await;
+                return Ok(());
             }
-            Err(e) => {
-                error!("failed to resolve chat_id for slash command: {e}");
-                send_telegram_response(
-                    &bot,
-                    msg.chat.id,
-                    "An error occurred processing the command.",
-                )
-                .await;
+            SlashCommandOutcome::Error(response) => {
+                send_telegram_response(&bot, msg.chat.id, &response).await;
+                return Ok(());
             }
+            SlashCommandOutcome::NotHandled => {}
         }
-        return Ok(());
     }
     // --- インターセプトここまで ---
 

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -346,6 +346,14 @@ async fn handle_message(
         }
     };
 
+    let context = SurfaceContext::new(
+        "telegram".to_string(),
+        sender_name,
+        external_chat_id.clone(),
+        chat_type,
+        state.config.default_agent.to_string(),
+    );
+
     // --- スラッシュコマンドインターセプト ---
     // process_turn より先に chat_id を解決し、
     // スラッシュコマンドであればエージェントループに入らずに即応答する。
@@ -359,23 +367,16 @@ async fn handle_message(
         }
 
         let sender_id = msg.from.as_ref().map(|u| u.id.0.to_string());
-        let slash_context = SurfaceContext {
-            channel: "telegram".to_string(),
-            surface_user: sender_name.clone(),
-            surface_thread: external_chat_id.clone(),
-            chat_type: chat_type.clone(),
-            agent_id: state.config.default_agent.to_string(),
-        };
 
         let resolved_chat_id =
-            crate::agent_loop::session::resolve_chat_id(&state, &slash_context).await;
+            crate::agent_loop::session::resolve_chat_id(&state, &context).await;
 
         match resolved_chat_id {
             Ok(chat_id) => {
                 if let Some(response) = slash_commands::handle_slash_command(
                     &state,
                     chat_id,
-                    &slash_context,
+                    &context,
                     &text,
                     sender_id.as_deref(),
                 )
@@ -413,14 +414,6 @@ async fn handle_message(
         );
         return Ok(());
     }
-
-    let context = SurfaceContext {
-        channel: "telegram".to_string(),
-        surface_user: sender_name,
-        surface_thread: external_chat_id.clone(),
-        chat_type: chat_type.clone(),
-        agent_id: state.config.default_agent.to_string(),
-    };
 
     info!(
         chat_id = raw_chat_id,

--- a/src/channels/tui.rs
+++ b/src/channels/tui.rs
@@ -389,47 +389,32 @@ async fn run_loop(
                     }
                     PendingAction::SendMessage(prompt) => {
                         if let View::Chat(chat) = &mut app.view {
-                            if crate::slash_commands::is_slash_command(&prompt) {
-                                chat.messages.push(RenderedMessage {
-                                    role: "user".to_string(),
-                                    content: prompt.clone(),
-                                });
-                                chat.conversation_scroll = 0;
-                                let slash_chat_id = crate::agent_loop::session::resolve_chat_id(
-                                    &app.state,
-                                    &chat.context,
-                                )
-                                .await;
-
-                                match slash_chat_id {
-                                    Ok(chat_id) => {
-                                        if let Some(response) =
-                                            crate::slash_commands::handle_slash_command(
-                                                &app.state,
-                                                chat_id,
-                                                &chat.context,
-                                                &prompt,
-                                                None,
-                                            )
-                                            .await
-                                        {
-                                            chat.messages.push(RenderedMessage {
-                                                role: "assistant".to_string(),
-                                                content: response,
-                                            });
-                                            chat.status = "Command applied".to_string();
-                                            chat.conversation_scroll = 0;
-                                        } else {
-                                            chat.status =
-                                                crate::slash_commands::unknown_command_response();
-                                        }
-                                    }
-                                    Err(e) => {
-                                        chat.status = format!("Command error: {e}");
-                                    }
+                            match crate::slash_commands::process_slash_command(
+                                &app.state,
+                                &chat.context,
+                                &prompt,
+                                None,
+                            )
+                            .await
+                            {
+                                crate::slash_commands::SlashCommandOutcome::Respond(response) => {
+                                    chat.messages.push(RenderedMessage {
+                                        role: "user".to_string(),
+                                        content: prompt.clone(),
+                                    });
+                                    chat.messages.push(RenderedMessage {
+                                        role: "assistant".to_string(),
+                                        content: response,
+                                    });
+                                    chat.status = "Command applied".to_string();
+                                    chat.conversation_scroll = 0;
                                 }
-                            } else {
-                                start_send(app, prompt);
+                                crate::slash_commands::SlashCommandOutcome::Error(msg) => {
+                                    chat.status = msg;
+                                }
+                                crate::slash_commands::SlashCommandOutcome::NotHandled => {
+                                    start_send(app, prompt);
+                                }
                             }
                         }
                     }

--- a/src/channels/tui.rs
+++ b/src/channels/tui.rs
@@ -4,6 +4,7 @@
 //! ローカル対話を 1 つの端末 UI で扱う。
 
 use std::io::{self, Stdout};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
@@ -25,7 +26,7 @@ use crate::agent_loop;
 use crate::agent_loop::SurfaceContext;
 use crate::error::{EgoPulseError, TuiError};
 use crate::runtime::AppState;
-use crate::storage::SessionSummary;
+use crate::storage::{SessionSummary, call_blocking};
 
 /// Owns terminal setup and teardown for the TUI lifecycle.
 struct TuiSession {
@@ -203,11 +204,22 @@ impl TuiApp {
     }
 
     async fn open_session(&mut self, summary: SessionSummary) -> Result<(), EgoPulseError> {
+        let chat_info = call_blocking(Arc::clone(&self.state.db), {
+            let chat_id = summary.chat_id;
+            move |db| db.get_chat_by_id(chat_id)
+        })
+        .await?
+        .ok_or_else(|| {
+            EgoPulseError::Storage(crate::error::StorageError::NotFound(
+                "chat not found".to_string(),
+            ))
+        })?;
+
         let context = SurfaceContext::new(
-            summary.channel.clone(),
+            chat_info.channel,
             "local_user".to_string(),
             summary.surface_thread.clone(),
-            summary.channel,
+            chat_info.chat_type,
             self.state.config.default_agent.to_string(),
         );
         let messages = agent_loop::load_session_messages(&self.state, &context).await?;
@@ -398,6 +410,11 @@ async fn run_loop(
                             .await
                             {
                                 crate::slash_commands::SlashCommandOutcome::Respond(response) => {
+                                    if crate::slash_commands::is_slash_command(&prompt)
+                                        && prompt.trim_start().starts_with("/new")
+                                    {
+                                        chat.messages.clear();
+                                    }
                                     chat.messages.push(RenderedMessage {
                                         role: "user".to_string(),
                                         content: prompt.clone(),

--- a/src/channels/tui.rs
+++ b/src/channels/tui.rs
@@ -173,13 +173,13 @@ impl TuiApp {
 
     async fn open_new_session(&mut self) -> Result<(), EgoPulseError> {
         let session_id = format!("local-{}", short_uuid());
-        let context = SurfaceContext {
-            channel: "tui".to_string(),
-            surface_user: "local_user".to_string(),
-            surface_thread: session_id,
-            chat_type: "tui".to_string(),
-            agent_id: self.state.config.default_agent.to_string(),
-        };
+        let context = SurfaceContext::new(
+            "tui".to_string(),
+            "local_user".to_string(),
+            session_id,
+            "tui".to_string(),
+            self.state.config.default_agent.to_string(),
+        );
         let messages = agent_loop::load_session_messages(&self.state, &context).await?;
         self.view = View::Chat(Box::new(ChatState {
             context,
@@ -203,13 +203,13 @@ impl TuiApp {
     }
 
     async fn open_session(&mut self, summary: SessionSummary) -> Result<(), EgoPulseError> {
-        let context = SurfaceContext {
-            channel: summary.channel.clone(),
-            surface_user: "local_user".to_string(),
-            surface_thread: summary.surface_thread.clone(),
-            chat_type: summary.channel,
-            agent_id: self.state.config.default_agent.to_string(),
-        };
+        let context = SurfaceContext::new(
+            summary.channel.clone(),
+            "local_user".to_string(),
+            summary.surface_thread.clone(),
+            summary.channel,
+            self.state.config.default_agent.to_string(),
+        );
         let messages = agent_loop::load_session_messages(&self.state, &context).await?;
         self.view = View::Chat(Box::new(ChatState {
             context,

--- a/src/codex_auth.rs
+++ b/src/codex_auth.rs
@@ -101,6 +101,26 @@ pub(crate) fn resolve_codex_auth() -> Result<CodexAuth, ConfigError> {
         }
     }
 
+    {
+        let guard = AUTH_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some((instant, cached)) = guard.as_ref() {
+            if instant.elapsed() < CODEX_AUTH_TTL {
+                return Ok(cached.clone());
+            }
+        }
+    }
+
+    let auth = resolve_codex_auth_from_file()?;
+
+    {
+        let mut guard = AUTH_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some((std::time::Instant::now(), auth.clone()));
+    }
+
+    Ok(auth)
+}
+
+fn resolve_codex_auth_from_file() -> Result<CodexAuth, ConfigError> {
     let auth_path = default_codex_auth_path();
     if auth_path.exists() {
         let content = std::fs::read_to_string(&auth_path).map_err(|source| {
@@ -171,6 +191,16 @@ pub(crate) fn is_jwt_expired(token: &str) -> bool {
 
 /// プロセス内で refresh を直列化するミューテックス。
 static REFRESH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+static AUTH_CACHE: LazyLock<std::sync::Mutex<Option<(std::time::Instant, CodexAuth)>>> =
+    LazyLock::new(|| std::sync::Mutex::new(None));
+
+const CODEX_AUTH_TTL: std::time::Duration = std::time::Duration::from_secs(300);
+
+#[cfg(test)]
+fn clear_auth_cache() {
+    *AUTH_CACHE.lock().unwrap_or_else(|e| e.into_inner()) = None;
+}
 
 /// access_token の有効期限が切れている場合、refresh_token を使って更新する。
 ///
@@ -284,6 +314,8 @@ pub(crate) async fn refresh_if_needed(http: &reqwest::Client) {
     };
 
     write_atomic(&auth_path, &updated);
+
+    AUTH_CACHE.lock().unwrap_or_else(|e| e.into_inner()).take();
 }
 
 /// 一時ファイルに書き込み後にリネームして原子的に更新する。
@@ -370,6 +402,7 @@ mod tests {
 
     #[test]
     fn resolve_auth_prefers_env_var() {
+        clear_auth_cache();
         let _guard = EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "env-token-xyz");
         let auth = resolve_codex_auth().expect("resolve");
         assert_eq!(auth.bearer_token, "env-token-xyz");
@@ -378,6 +411,7 @@ mod tests {
 
     #[test]
     fn resolve_auth_reads_access_token() {
+        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             dir.path().join("auth.json"),
@@ -394,6 +428,7 @@ mod tests {
 
     #[test]
     fn resolve_auth_falls_back_to_openai_api_key() {
+        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             dir.path().join("auth.json"),
@@ -410,6 +445,7 @@ mod tests {
 
     #[test]
     fn resolve_auth_errors_when_no_source() {
+        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         let _guard =
             EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
@@ -482,5 +518,51 @@ mod tests {
             "openai",
             "https://api.openai.com/v1"
         ));
+    }
+
+    #[test]
+    fn cache_returns_same_value_within_ttl() {
+        clear_auth_cache();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"cached-token","refresh_token":"rt"}}"#,
+        )
+        .expect("write");
+        let _guard =
+            EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
+
+        let first = resolve_codex_auth().expect("first");
+        assert_eq!(first.bearer_token, "cached-token");
+
+        std::fs::write(
+            dir.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"updated-token","refresh_token":"rt"}}"#,
+        )
+        .expect("overwrite");
+
+        let second = resolve_codex_auth().expect("second");
+        assert_eq!(second.bearer_token, "cached-token");
+    }
+
+    #[test]
+    fn cache_bypassed_for_env_var() {
+        clear_auth_cache();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"file-token","refresh_token":"rt"}}"#,
+        )
+        .expect("write");
+        {
+            let _guard =
+                EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
+            let file_auth = resolve_codex_auth().expect("file");
+            assert_eq!(file_auth.bearer_token, "file-token");
+        }
+
+        let _env_guard = EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "env-override");
+        let env_auth = resolve_codex_auth().expect("env");
+        assert_eq!(env_auth.bearer_token, "env-override");
     }
 }

--- a/src/codex_auth.rs
+++ b/src/codex_auth.rs
@@ -402,8 +402,8 @@ mod tests {
 
     #[test]
     fn resolve_auth_prefers_env_var() {
-        clear_auth_cache();
         let _guard = EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "env-token-xyz");
+        clear_auth_cache();
         let auth = resolve_codex_auth().expect("resolve");
         assert_eq!(auth.bearer_token, "env-token-xyz");
         assert!(auth.account_id.is_none());
@@ -411,7 +411,6 @@ mod tests {
 
     #[test]
     fn resolve_auth_reads_access_token() {
-        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             dir.path().join("auth.json"),
@@ -420,6 +419,7 @@ mod tests {
         .expect("write");
         let _guard =
             EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
+        clear_auth_cache();
 
         let auth = resolve_codex_auth().expect("resolve");
         assert_eq!(auth.bearer_token, "file-access-token");
@@ -428,7 +428,6 @@ mod tests {
 
     #[test]
     fn resolve_auth_falls_back_to_openai_api_key() {
-        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             dir.path().join("auth.json"),
@@ -437,6 +436,7 @@ mod tests {
         .expect("write");
         let _guard =
             EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
+        clear_auth_cache();
 
         let auth = resolve_codex_auth().expect("resolve");
         assert_eq!(auth.bearer_token, "sk-fallback-key");
@@ -445,10 +445,10 @@ mod tests {
 
     #[test]
     fn resolve_auth_errors_when_no_source() {
-        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         let _guard =
             EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
+        clear_auth_cache();
 
         let result = resolve_codex_auth();
         assert!(result.is_err());
@@ -522,7 +522,6 @@ mod tests {
 
     #[test]
     fn cache_returns_same_value_within_ttl() {
-        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             dir.path().join("auth.json"),
@@ -531,6 +530,7 @@ mod tests {
         .expect("write");
         let _guard =
             EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
+        clear_auth_cache();
 
         let first = resolve_codex_auth().expect("first");
         assert_eq!(first.bearer_token, "cached-token");
@@ -547,7 +547,6 @@ mod tests {
 
     #[test]
     fn cache_bypassed_for_env_var() {
-        clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             dir.path().join("auth.json"),
@@ -557,11 +556,13 @@ mod tests {
         {
             let _guard = EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "")
                 .also_set("CODEX_HOME", dir.path());
+            clear_auth_cache();
             let file_auth = resolve_codex_auth().expect("file");
             assert_eq!(file_auth.bearer_token, "file-token");
         }
 
         let _env_guard = EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "env-override");
+        clear_auth_cache();
         let env_auth = resolve_codex_auth().expect("env");
         assert_eq!(env_auth.bearer_token, "env-override");
     }

--- a/src/codex_auth.rs
+++ b/src/codex_auth.rs
@@ -198,7 +198,7 @@ static AUTH_CACHE: LazyLock<std::sync::Mutex<Option<(std::time::Instant, CodexAu
 const CODEX_AUTH_TTL: std::time::Duration = std::time::Duration::from_secs(300);
 
 #[cfg(test)]
-fn clear_auth_cache() {
+pub(crate) fn clear_auth_cache() {
     *AUTH_CACHE.lock().unwrap_or_else(|e| e.into_inner()) = None;
 }
 

--- a/src/codex_auth.rs
+++ b/src/codex_auth.rs
@@ -555,8 +555,8 @@ mod tests {
         )
         .expect("write");
         {
-            let _guard =
-                EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "").also_set("CODEX_HOME", dir.path());
+            let _guard = EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "")
+                .also_set("CODEX_HOME", dir.path());
             let file_auth = resolve_codex_auth().expect("file");
             assert_eq!(file_auth.bearer_token, "file-token");
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -313,6 +313,26 @@ impl PartialEq for ResolvedLlmConfig {
 
 impl Eq for ResolvedLlmConfig {}
 
+impl ResolvedLlmConfig {
+    /// Returns a deterministic hash of all config fields for use as a cache key.
+    ///
+    /// Includes `api_key` via `expose_secret()` so that different keys
+    /// produce different hashes. The key value itself is never stored.
+    pub fn cache_key(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.provider.hash(&mut hasher);
+        self.label.hash(&mut hasher);
+        self.base_url.hash(&mut hasher);
+        self.model.hash(&mut hasher);
+        if let Some(key) = &self.api_key {
+            secrecy::ExposeSecret::expose_secret(key).hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct AgentConfig {
     pub label: String,

--- a/src/llm/messages.rs
+++ b/src/llm/messages.rs
@@ -207,7 +207,7 @@ pub(crate) fn synthetic_tool_attachment_parts(content: &MessageContent) -> Vec<s
     })];
     if let MessageContent::Parts(items) = content {
         parts.extend(items.iter().filter_map(|part| match part {
-            MessageContentPart::InputText { .. } => None,
+            MessageContentPart::InputText { .. } | MessageContentPart::InputImageRef { .. } => None,
             MessageContentPart::InputImage { image_url, detail } => Some(serde_json::json!({
                 "type": "input_image",
                 "image_url": image_url,
@@ -278,6 +278,10 @@ fn chat_content_part(part: &MessageContentPart) -> serde_json::Value {
                 "detail": default_detail(detail),
             }
         }),
+        MessageContentPart::InputImageRef { .. } => serde_json::json!({
+            "type": "text",
+            "text": "[image reference - not hydrated]",
+        }),
     }
 }
 
@@ -291,6 +295,10 @@ fn responses_content_part(part: &MessageContentPart) -> serde_json::Value {
             "type": "input_image",
             "image_url": image_url,
             "detail": default_detail(detail),
+        }),
+        MessageContentPart::InputImageRef { .. } => serde_json::json!({
+            "type": "input_text",
+            "text": "[image reference - not hydrated]",
         }),
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -118,7 +118,8 @@ impl MessageContent {
                 .iter()
                 .filter_map(|part| match part {
                     MessageContentPart::InputText { text } => Some(text.clone()),
-                    MessageContentPart::InputImage { .. } | MessageContentPart::InputImageRef { .. } => None,
+                    MessageContentPart::InputImage { .. }
+                    | MessageContentPart::InputImageRef { .. } => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -73,6 +73,19 @@ pub enum MessageContentPart {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         detail: Option<String>,
     },
+    /// Asset-store reference used in session persistence.
+    ///
+    /// When a session snapshot is serialized to disk, `InputImage` parts are
+    /// converted to `InputImageRef` so the actual image bytes are stored in
+    /// the content-addressable asset store rather than inline as data URLs.
+    /// On restore, `InputImageRef` parts are hydrated back to `InputImage`.
+    #[serde(rename = "input_image_ref")]
+    InputImageRef {
+        image_ref: String,
+        mime_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
 }
 
 impl Default for MessageContent {
@@ -94,7 +107,7 @@ impl MessageContent {
 
     /// Returns `true` if the content includes at least one image part.
     pub fn is_multimodal(&self) -> bool {
-        matches!(self, Self::Parts(parts) if parts.iter().any(|part| matches!(part, MessageContentPart::InputImage { .. })))
+        matches!(self, Self::Parts(parts) if parts.iter().any(|part| matches!(part, MessageContentPart::InputImage { .. } | MessageContentPart::InputImageRef { .. })))
     }
 
     /// Extract all text, discarding images (lossy conversion).
@@ -105,7 +118,7 @@ impl MessageContent {
                 .iter()
                 .filter_map(|part| match part {
                     MessageContentPart::InputText { text } => Some(text.clone()),
-                    MessageContentPart::InputImage { .. } => None,
+                    MessageContentPart::InputImage { .. } | MessageContentPart::InputImageRef { .. } => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -119,17 +119,12 @@ impl AppState {
         resolved: &crate::config::ResolvedLlmConfig,
     ) -> Result<Arc<dyn crate::llm::LlmProvider>, EgoPulseError> {
         let key = resolved.cache_key();
-        {
-            let cache = self.llm_cache.lock().expect("llm_cache lock");
-            if let Some(provider) = cache.get(&key) {
-                return Ok(Arc::clone(provider));
-            }
+        let mut cache = self.llm_cache.lock().expect("llm_cache lock");
+        if let Some(provider) = cache.get(&key) {
+            return Ok(Arc::clone(provider));
         }
         let provider: Arc<dyn crate::llm::LlmProvider> = Arc::from(create_provider(resolved)?);
-        {
-            let mut cache = self.llm_cache.lock().expect("llm_cache lock");
-            cache.insert(key, Arc::clone(&provider));
-        }
+        cache.insert(key, Arc::clone(&provider));
         Ok(provider)
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -538,7 +538,9 @@ mod tests {
             provider: provider.to_string(),
             label: format!("{provider} label"),
             base_url: base_url.to_string(),
-            api_key: Some(secrecy::SecretString::new("sk-test".to_string().into_boxed_str())),
+            api_key: Some(secrecy::SecretString::new(
+                "sk-test".to_string().into_boxed_str(),
+            )),
             model: model.to_string(),
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,8 +2,10 @@
 //!
 //! `AppState` の構築、単発 LLM 実行、各チャネルの起動と監視を提供する。
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -37,6 +39,7 @@ pub struct AppState {
     pub mcp_manager: Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>>,
     pub assets: Arc<AssetStore>,
     pub soul_agents: Arc<SoulAgentsLoader>,
+    pub llm_cache: Mutex<HashMap<u64, Arc<dyn crate::llm::LlmProvider>>>,
 }
 
 impl Clone for AppState {
@@ -52,6 +55,7 @@ impl Clone for AppState {
             mcp_manager: self.mcp_manager.clone(),
             assets: Arc::clone(&self.assets),
             soul_agents: Arc::clone(&self.soul_agents),
+            llm_cache: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -80,9 +84,8 @@ impl AppState {
         }
 
         let config = self.try_current_config()?;
-        Ok(Arc::from(create_provider(
-            &config.resolve_llm_for_channel(channel)?,
-        )?))
+        let resolved = config.resolve_llm_for_channel(channel)?;
+        self.cached_provider(&resolved)
     }
 
     /// Returns the global default LLM provider for CLI/TUI surfaces.
@@ -92,7 +95,8 @@ impl AppState {
         }
 
         let config = self.try_current_config()?;
-        Ok(Arc::from(create_provider(&config.resolve_global_llm())?))
+        let resolved = config.resolve_global_llm();
+        self.cached_provider(&resolved)
     }
 
     /// Returns the LLM provider resolved for the agent and channel in the given context.
@@ -106,9 +110,27 @@ impl AppState {
 
         let config = self.try_current_config()?;
         let agent_id = crate::config::AgentId::new(&context.agent_id);
-        Ok(Arc::from(create_provider(
-            &config.resolve_llm_for_agent_channel(&agent_id, &context.channel)?,
-        )?))
+        let resolved = config.resolve_llm_for_agent_channel(&agent_id, &context.channel)?;
+        self.cached_provider(&resolved)
+    }
+
+    fn cached_provider(
+        &self,
+        resolved: &crate::config::ResolvedLlmConfig,
+    ) -> Result<Arc<dyn crate::llm::LlmProvider>, EgoPulseError> {
+        let key = resolved.cache_key();
+        {
+            let cache = self.llm_cache.lock().expect("llm_cache lock");
+            if let Some(provider) = cache.get(&key) {
+                return Ok(Arc::clone(provider));
+            }
+        }
+        let provider: Arc<dyn crate::llm::LlmProvider> = Arc::from(create_provider(resolved)?);
+        {
+            let mut cache = self.llm_cache.lock().expect("llm_cache lock");
+            cache.insert(key, Arc::clone(&provider));
+        }
+        Ok(provider)
     }
 }
 
@@ -180,6 +202,7 @@ pub async fn build_app_state_with_path(
         mcp_manager: Some(mcp_arc),
         assets,
         soul_agents,
+        llm_cache: Mutex::new(HashMap::new()),
     })
 }
 
@@ -479,6 +502,7 @@ async fn write_startup_status(state: &AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ResolvedLlmConfig;
     use crate::soul_agents::SoulAgentsLoader;
 
     fn test_config_for_runtime(state_root: String) -> crate::config::Config {
@@ -490,7 +514,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let config = test_config_for_runtime(dir.path().to_str().expect("utf8").to_string());
         let state = build_app_state(config).await.expect("build state");
-        // soul_agents が初期化されてアクセス可能であることを検証
         let _ = &*state.soul_agents;
     }
 
@@ -501,14 +524,96 @@ mod tests {
         let config = test_config_for_runtime(state_root);
         let loader = SoulAgentsLoader::new(&config);
 
-        // ファイルが存在しない場合は None
         assert!(loader.load_global_agents().is_none());
 
-        // AGENTS.md を書き込むと読み取れる
         std::fs::write(dir.path().join("AGENTS.md"), "test agents content").expect("write");
         assert_eq!(
             loader.load_global_agents(),
             Some("test agents content".to_string())
         );
+    }
+
+    fn resolved_config(provider: &str, model: &str, base_url: &str) -> ResolvedLlmConfig {
+        ResolvedLlmConfig {
+            provider: provider.to_string(),
+            label: format!("{provider} label"),
+            base_url: base_url.to_string(),
+            api_key: Some(secrecy::SecretString::new("sk-test".to_string().into_boxed_str())),
+            model: model.to_string(),
+        }
+    }
+
+    #[test]
+    fn cache_key_differs_when_provider_differs() {
+        let a = resolved_config("openai", "gpt-4o", "https://api.openai.com/v1");
+        let b = resolved_config("anthropic", "gpt-4o", "https://api.openai.com/v1");
+        assert_ne!(a.cache_key(), b.cache_key());
+    }
+
+    #[test]
+    fn cache_key_differs_when_model_differs() {
+        let a = resolved_config("openai", "gpt-4o", "https://api.openai.com/v1");
+        let b = resolved_config("openai", "gpt-4o-mini", "https://api.openai.com/v1");
+        assert_ne!(a.cache_key(), b.cache_key());
+    }
+
+    #[test]
+    fn cache_key_differs_when_base_url_differs() {
+        let a = resolved_config("openai", "gpt-4o", "https://api.openai.com/v1");
+        let b = resolved_config("openai", "gpt-4o", "https://proxy.example.com/v1");
+        assert_ne!(a.cache_key(), b.cache_key());
+    }
+
+    #[test]
+    fn cache_key_differs_when_api_key_differs() {
+        let a = resolved_config("openai", "gpt-4o", "https://api.openai.com/v1");
+        let mut b = resolved_config("openai", "gpt-4o", "https://api.openai.com/v1");
+        b.api_key = Some(secrecy::SecretString::new(
+            "sk-other".to_string().into_boxed_str(),
+        ));
+        assert_ne!(a.cache_key(), b.cache_key());
+    }
+
+    #[test]
+    fn cache_key_same_for_identical_configs() {
+        let a = resolved_config("openai", "gpt-4o", "https://api.openai.com/v1");
+        let b = resolved_config("openai", "gpt-4o", "https://api.openai.com/v1");
+        assert_eq!(a.cache_key(), b.cache_key());
+    }
+
+    #[tokio::test]
+    async fn global_llm_reuses_cached_provider() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config_for_runtime(dir.path().to_str().expect("utf8").to_string());
+        let state = build_app_state(config).await.expect("build state");
+
+        let a = state.global_llm().expect("llm");
+        let b = state.global_llm().expect("llm");
+
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[tokio::test]
+    async fn llm_override_bypasses_cache() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config_for_runtime(dir.path().to_str().expect("utf8").to_string());
+        let mut state = build_app_state(config).await.expect("build state");
+
+        let override_provider: Arc<dyn crate::llm::LlmProvider> = Arc::from(
+            crate::llm::create_provider(&resolved_config(
+                "override",
+                "model-x",
+                "https://example.com/v1",
+            ))
+            .expect("provider"),
+        );
+
+        state.llm_override = Some(Arc::clone(&override_provider));
+
+        let result = state.global_llm().expect("llm");
+        assert!(Arc::ptr_eq(&result, &override_provider));
+
+        let cache = state.llm_cache.lock().expect("lock");
+        assert!(cache.is_empty());
     }
 }

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -73,6 +73,16 @@ pub async fn process_slash_command(
         return SlashCommandOutcome::NotHandled;
     }
 
+    let command_name = extract_command_name(text);
+    let needs_chat_id = matches!(command_name, Some("/new" | "/compact" | "/status"));
+
+    if !needs_chat_id {
+        let response = handle_slash_command(state, 0, context, text, sender_id)
+            .await
+            .unwrap_or_else(unknown_command_response);
+        return SlashCommandOutcome::Respond(response);
+    }
+
     match resolve_chat_id(state, context).await {
         Ok(chat_id) => {
             let response = handle_slash_command(state, chat_id, context, text, sender_id)
@@ -85,6 +95,16 @@ pub async fn process_slash_command(
             SlashCommandOutcome::Error("An error occurred processing the command.".to_string())
         }
     }
+}
+
+fn extract_command_name(text: &str) -> Option<&str> {
+    let normalized = normalized_slash_command(text)?;
+    let bare = normalized
+        .split_once('@')
+        .map(|(cmd, _)| cmd)
+        .unwrap_or(normalized);
+    let lower = bare.split_whitespace().next()?;
+    Some(lower)
 }
 
 /// スラッシュコマンドを実行し、結果メッセージを返す。

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::agent_loop::SurfaceContext;
 use crate::agent_loop::compaction::force_compact;
-use crate::agent_loop::session::load_messages_for_turn;
+use crate::agent_loop::session::{load_messages_for_turn, resolve_chat_id};
 use crate::llm_profile;
 use crate::runtime::AppState;
 use crate::storage::call_blocking;
@@ -37,6 +37,54 @@ pub fn is_slash_command(text: &str) -> bool {
         return false;
     }
     true
+}
+
+/// [`process_slash_command`] の戻り値。
+///
+/// 各チャネルはこの結果に基づいてチャネル固有の方法で応答を送信する。
+#[derive(Debug)]
+pub enum SlashCommandOutcome {
+    /// コマンドが正常に処理され、応答メッセージが生成された。
+    Respond(String),
+    /// chat_id の解決に失敗した等の内部的エラー。
+    Error(String),
+    /// テキストがスラッシュコマンドではなかった。
+    NotHandled,
+}
+
+/// スラッシュコマンドの判定・chat_id 解決・実行を一括で行う。
+///
+/// 各チャネルのスラッシュコマンド処理ブロックを共通化するためのエントリポイント。
+/// チャネル側は戻り値の [`SlashCommandOutcome`] に従って応答を送信すればよい。
+///
+/// # Arguments
+///
+/// * `state` — アプリケーション状態
+/// * `context` — チャネルごとのサーフェスコンテキスト
+/// * `text` — ユーザー入力テキスト
+/// * `sender_id` — 送信者 ID（`/status` で表示）
+pub async fn process_slash_command(
+    state: &AppState,
+    context: &SurfaceContext,
+    text: &str,
+    sender_id: Option<&str>,
+) -> SlashCommandOutcome {
+    if !is_slash_command(text) {
+        return SlashCommandOutcome::NotHandled;
+    }
+
+    match resolve_chat_id(state, context).await {
+        Ok(chat_id) => {
+            let response = handle_slash_command(state, chat_id, context, text, sender_id)
+                .await
+                .unwrap_or_else(unknown_command_response);
+            SlashCommandOutcome::Respond(response)
+        }
+        Err(e) => {
+            tracing::warn!("failed to resolve chat_id for slash command: {e}");
+            SlashCommandOutcome::Error("An error occurred processing the command.".to_string())
+        }
+    }
 }
 
 /// スラッシュコマンドを実行し、結果メッセージを返す。
@@ -325,7 +373,10 @@ mod tests {
     use crate::runtime::AppState;
     use crate::storage::{StoredMessage, call_blocking};
 
-    use super::{all_commands, find_command, handle_slash_command, is_slash_command};
+    use super::{
+        SlashCommandOutcome, all_commands, find_command, handle_slash_command, is_slash_command,
+        process_slash_command,
+    };
 
     // -- is_slash_command tests ---------------------------------------------------
 
@@ -954,5 +1005,62 @@ agents:
         let mut state = build_state(config, Box::new(NoOpProvider));
         state.config_path = Some(path.clone());
         (state, dir, path)
+    }
+
+    // -- process_slash_command tests -------------------------------------------
+
+    #[tokio::test]
+    async fn process_slash_command_responds_to_known_command() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let context = test_context();
+
+        // Act
+        let outcome = process_slash_command(&state, &context, "/skills", None).await;
+
+        // Assert
+        match outcome {
+            SlashCommandOutcome::Respond(response) => {
+                assert!(
+                    response.contains("No skills loaded."),
+                    "expected skills response, got: {response}"
+                );
+            }
+            other => panic!("expected Respond, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn process_slash_command_returns_not_handled_for_plain_text() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let context = test_context();
+
+        // Act
+        let outcome = process_slash_command(&state, &context, "hello world", None).await;
+
+        // Assert
+        assert!(
+            matches!(outcome, SlashCommandOutcome::NotHandled),
+            "plain text should not be handled as slash command"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_slash_command_returns_respond_for_unknown_command() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let context = test_context();
+
+        // Act
+        let outcome = process_slash_command(&state, &context, "/foobar", None).await;
+
+        // Assert
+        match outcome {
+            SlashCommandOutcome::Respond(response) => {
+                assert_eq!(response, "Unknown command.");
+            }
+            other => panic!("expected Respond with unknown fallback, got {other:?}"),
+        }
     }
 }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -16,7 +16,7 @@ pub(crate) struct EnvVarGuard {
 impl EnvVarGuard {
     /// 環境変数を設定し、元の値を保持するガードを作成する。
     pub(crate) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let original = std::env::var_os(key);
         unsafe {
             std::env::set_var(key, value);

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -79,6 +79,7 @@ pub fn build_state_with_provider(
         mcp_manager: None,
         assets: Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
         soul_agents: Arc::new(crate::soul_agents::SoulAgentsLoader::new(&config)),
+        llm_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
     }
 }
 

--- a/src/tools/files.rs
+++ b/src/tools/files.rs
@@ -69,6 +69,10 @@ impl Tool for ReadTool {
         "read"
     }
 
+    fn is_read_only(&self) -> bool {
+        true
+    }
+
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "read".to_string(),

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -125,6 +125,14 @@ pub trait Tool: Send + Sync {
     fn definition(&self) -> ToolDefinition;
     async fn execute(&self, input: serde_json::Value, context: &ToolExecutionContext)
     -> ToolResult;
+
+    /// Whether this tool only reads data without side effects.
+    ///
+    /// Read-only tools can be executed in parallel when multiple tool calls
+    /// appear in a single LLM response. Default is `false`.
+    fn is_read_only(&self) -> bool {
+        false
+    }
 }
 
 /// Owns all tool instances and dispatches execution by tool name.
@@ -237,6 +245,13 @@ impl ToolRegistry {
             &self.config_secrets,
         )
     }
+
+    /// Returns `true` if the named tool is a read-only tool safe for parallel execution.
+    pub fn is_read_only(&self, name: &str) -> bool {
+        self.tool_index
+            .get(name)
+            .is_some_and(|&idx| self.tools[idx].is_read_only())
+    }
 }
 
 /// Loads a skill's full instructions on demand by name.
@@ -254,6 +269,10 @@ impl ActivateSkillTool {
 impl Tool for ActivateSkillTool {
     fn name(&self) -> &str {
         "activate_skill"
+    }
+
+    fn is_read_only(&self) -> bool {
+        true
     }
 
     fn definition(&self) -> ToolDefinition {
@@ -830,5 +849,59 @@ mod tests {
         assert!(find_result.content.contains("src/lib.rs"));
         assert!(!find_result.content.contains(".env"));
         assert!(!find_result.content.contains(".ssh/id_rsa"));
+    }
+
+    #[test]
+    #[serial]
+    fn read_only_tools_report_true() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", dir.path());
+        let config = test_config(dir.path().to_str().expect("utf8"));
+        let registry = test_registry(&config);
+
+        assert!(registry.is_read_only("read"));
+        assert!(registry.is_read_only("grep"));
+        assert!(registry.is_read_only("find"));
+        assert!(registry.is_read_only("ls"));
+        assert!(registry.is_read_only("activate_skill"));
+    }
+
+    #[test]
+    #[serial]
+    fn write_tools_report_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", dir.path());
+        let config = test_config(dir.path().to_str().expect("utf8"));
+        let registry = test_registry(&config);
+
+        assert!(!registry.is_read_only("bash"));
+        assert!(!registry.is_read_only("write"));
+        assert!(!registry.is_read_only("edit"));
+    }
+
+    #[test]
+    #[serial]
+    fn unknown_tool_is_not_read_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", dir.path());
+        let config = test_config(dir.path().to_str().expect("utf8"));
+        let registry = test_registry(&config);
+
+        assert!(!registry.is_read_only("nonexistent_tool"));
+    }
+
+    #[test]
+    #[serial]
+    fn registered_custom_tool_defaults_to_not_read_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", dir.path());
+        let config = test_config(dir.path().to_str().expect("utf8"));
+        let mut registry = test_registry(&config);
+        registry.register_tool(Box::new(StaticTool {
+            name: "custom",
+            result: ToolResult::success("ok".to_string()),
+        }));
+
+        assert!(!registry.is_read_only("custom"));
     }
 }

--- a/src/tools/sanitizer.rs
+++ b/src/tools/sanitizer.rs
@@ -119,13 +119,15 @@ pub(crate) fn sanitize_message_content(
                             detail: detail.map(|value| sanitize_output_string(&value, secrets)),
                         }
                     }
-                    MessageContentPart::InputImageRef { image_ref, mime_type, detail } => {
-                        MessageContentPart::InputImageRef {
-                            image_ref: sanitize_output_string(&image_ref, secrets),
-                            mime_type: sanitize_output_string(&mime_type, secrets),
-                            detail: detail.map(|value| sanitize_output_string(&value, secrets)),
-                        }
-                    }
+                    MessageContentPart::InputImageRef {
+                        image_ref,
+                        mime_type,
+                        detail,
+                    } => MessageContentPart::InputImageRef {
+                        image_ref: sanitize_output_string(&image_ref, secrets),
+                        mime_type: sanitize_output_string(&mime_type, secrets),
+                        detail: detail.map(|value| sanitize_output_string(&value, secrets)),
+                    },
                 })
                 .collect(),
         ),

--- a/src/tools/sanitizer.rs
+++ b/src/tools/sanitizer.rs
@@ -569,6 +569,7 @@ mod tests {
     #[test]
     fn test_collect_config_secrets_extracts_codex_bearer_token() {
         // Arrange
+        crate::codex_auth::clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         let _guard = EnvVarGuard::set("HOME", dir.path())
             .also_set("OPENAI_CODEX_ACCESS_TOKEN", "")

--- a/src/tools/sanitizer.rs
+++ b/src/tools/sanitizer.rs
@@ -569,11 +569,11 @@ mod tests {
     #[test]
     fn test_collect_config_secrets_extracts_codex_bearer_token() {
         // Arrange
-        crate::codex_auth::clear_auth_cache();
         let dir = tempfile::tempdir().expect("tempdir");
         let _guard = EnvVarGuard::set("HOME", dir.path())
             .also_set("OPENAI_CODEX_ACCESS_TOKEN", "")
             .also_set("CODEX_HOME", "");
+        crate::codex_auth::clear_auth_cache();
 
         let codex_dir = dir.path().join(".codex");
         std::fs::create_dir_all(&codex_dir).expect("create .codex dir");

--- a/src/tools/sanitizer.rs
+++ b/src/tools/sanitizer.rs
@@ -119,6 +119,13 @@ pub(crate) fn sanitize_message_content(
                             detail: detail.map(|value| sanitize_output_string(&value, secrets)),
                         }
                     }
+                    MessageContentPart::InputImageRef { image_ref, mime_type, detail } => {
+                        MessageContentPart::InputImageRef {
+                            image_ref: sanitize_output_string(&image_ref, secrets),
+                            mime_type: sanitize_output_string(&mime_type, secrets),
+                            detail: detail.map(|value| sanitize_output_string(&value, secrets)),
+                        }
+                    }
                 })
                 .collect(),
         ),

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -106,6 +106,10 @@ impl Tool for GrepTool {
         "grep"
     }
 
+    fn is_read_only(&self) -> bool {
+        true
+    }
+
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "grep".to_string(),
@@ -376,6 +380,10 @@ impl Tool for FindTool {
         "find"
     }
 
+    fn is_read_only(&self) -> bool {
+        true
+    }
+
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "find".to_string(),
@@ -594,6 +602,10 @@ impl LsTool {
 impl Tool for LsTool {
     fn name(&self) -> &str {
         "ls"
+    }
+
+    fn is_read_only(&self) -> bool {
+        true
     }
 
     fn definition(&self) -> ToolDefinition {

--- a/src/web/stream.rs
+++ b/src/web/stream.rs
@@ -196,52 +196,43 @@ pub(super) async fn start_stream_run(
     let run_id = Uuid::new_v4().to_string();
     state.run_hub.create(&run_id, actor.to_string()).await;
 
-    if crate::slash_commands::is_slash_command(&message) {
-        let slash_chat_id =
-            crate::agent_loop::session::resolve_chat_id(&state.app_state, &context).await;
-
-        let response = match slash_chat_id {
-            Ok(id) => crate::slash_commands::handle_slash_command(
-                &state.app_state,
-                id,
-                &context,
-                &message,
-                Some(actor),
-            )
-            .await
-            .unwrap_or_else(crate::slash_commands::unknown_command_response),
-            Err(e) => {
-                state
-                    .run_hub
-                    .publish(
-                        &run_id,
-                        "error",
-                        json!({"error": e.to_string()}).to_string(),
-                    )
-                    .await;
-                state
-                    .run_hub
-                    .remove_later(run_id.clone(), RUN_TTL_SECONDS)
-                    .await;
-                return Ok(StartedRun {
-                    run_id,
-                    session_key,
-                });
-            }
-        };
-
-        state
-            .run_hub
-            .publish(&run_id, "done", json!({"response": response}).to_string())
-            .await;
-        state
-            .run_hub
-            .remove_later(run_id.clone(), RUN_TTL_SECONDS)
-            .await;
-        return Ok(StartedRun {
-            run_id,
-            session_key,
-        });
+    match crate::slash_commands::process_slash_command(
+        &state.app_state,
+        &context,
+        &message,
+        Some(actor),
+    )
+    .await
+    {
+        crate::slash_commands::SlashCommandOutcome::Respond(response) => {
+            state
+                .run_hub
+                .publish(&run_id, "done", json!({"response": response}).to_string())
+                .await;
+            state
+                .run_hub
+                .remove_later(run_id.clone(), RUN_TTL_SECONDS)
+                .await;
+            return Ok(StartedRun {
+                run_id,
+                session_key,
+            });
+        }
+        crate::slash_commands::SlashCommandOutcome::Error(e) => {
+            state
+                .run_hub
+                .publish(&run_id, "error", json!({"error": e}).to_string())
+                .await;
+            state
+                .run_hub
+                .remove_later(run_id.clone(), RUN_TTL_SECONDS)
+                .await;
+            return Ok(StartedRun {
+                run_id,
+                session_key,
+            });
+        }
+        crate::slash_commands::SlashCommandOutcome::NotHandled => {}
     }
 
     let state_for_task = state.clone();

--- a/src/web/stream.rs
+++ b/src/web/stream.rs
@@ -156,26 +156,26 @@ pub(super) async fn start_stream_run(
                     .to_string();
                 (
                     format!("chat:{}", chat_id),
-                    SurfaceContext {
-                        channel: info.channel,
-                        surface_user: actor.to_string(),
+                    SurfaceContext::new(
+                        info.channel,
+                        actor.to_string(),
                         surface_thread,
-                        chat_type: info.chat_type,
-                        agent_id: state.app_state.config.default_agent.to_string(),
-                    },
+                        info.chat_type,
+                        state.app_state.config.default_agent.to_string(),
+                    ),
                 )
             }
             None => {
                 let key = web_session_key(raw_session_key);
                 (
                     key.clone(),
-                    SurfaceContext {
-                        channel: "web".to_string(),
-                        surface_user: actor.to_string(),
-                        surface_thread: key,
-                        chat_type: "web".to_string(),
-                        agent_id: state.app_state.config.default_agent.to_string(),
-                    },
+                    SurfaceContext::new(
+                        "web".to_string(),
+                        actor.to_string(),
+                        key,
+                        "web".to_string(),
+                        state.app_state.config.default_agent.to_string(),
+                    ),
                 )
             }
         }
@@ -183,13 +183,13 @@ pub(super) async fn start_stream_run(
         let key = web_session_key(raw_session_key);
         (
             key.clone(),
-            SurfaceContext {
-                channel: "web".to_string(),
-                surface_user: actor.to_string(),
-                surface_thread: key,
-                chat_type: "web".to_string(),
-                agent_id: state.app_state.config.default_agent.to_string(),
-            },
+            SurfaceContext::new(
+                "web".to_string(),
+                actor.to_string(),
+                key,
+                "web".to_string(),
+                state.app_state.config.default_agent.to_string(),
+            ),
         )
     };
 


### PR DESCRIPTION
Close #29

## 概要

Issue #29 のリファクタリング6項目を実装。

### 変更内容

| # | 変更 | コミット |
|---|------|---------|
| 1 | `SurfaceContext::new()` 正規コンストラクタ追加、4チャネル + web/stream.rs の inline 構築を置換 | `8a4f849` |
| 2 | `process_slash_command()` / `SlashCommandOutcome` 抽出、全チャネルの slash command 重複を共通化 | `3b36493` |
| 3 | `PersistedMessage` 削除、`MessageContentPart` に `InputImageRef` バリアント追加、変換関数を AssetStore 経由に簡略化 | `e76db28` |
| 4 | `AppState` に `llm_cache: Mutex<HashMap<u64, Arc<dyn LlmProvider>>>` 追加（キーは `ResolvedLlmConfig` 全フィールドのハッシュ） | `797d1cf` |
| 5 | `AUTH_CACHE` + TTL 5分キャッシュ追加、`refresh_if_needed` 後にキャッシュクリア | `e75bf13` |
| 6 | `Tool` trait に `is_read_only(&self) -> bool` 追加、read-only tools のみ `join_all` で並列実行 | `b9432e1` |

### その他

- `test_env.rs` の `ENV_MUTEX` を poison-safe に変更（`unwrap_or_else(|e| e.into_inner())`）
- `docs/architecture.md` に新モジュール・設計パターンを反映

## 検証

- `cargo test -p egopulse` → 496 passed / 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` → pass
- `cargo fmt --check` → pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * LLMプロバイダーとアクセストークンのキャッシング機能を追加し、リクエスト処理を高速化しました。
  * 読み取り専用ツール実行を並列化してパフォーマンスを向上させました。

* **バグ修正**
  * セッションスナップショットの永続化時における画像参照の処理を改善しました。
  * メッセージコンテンツの画像処理をより堅牢にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->