### PR TITLE
feat: long-term memory Phase 1 — 長期記憶の読み込み・注入基盤

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -29,7 +29,7 @@ egopulse.db (SQLite / WAL mode)
 | テーブル数 | 7（データテーブル 5 + マイグレーション基盤テーブル 2） |
 | インデックス数 | 6 |
 | 外部キー制約 | 1（tool_calls.chat_id → chats.chat_id） |
-| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v3） |
+| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v4） |
 | DBライブラリ | rusqlite 0.37（bundled） |
 | DBファイル | `{data_dir}/egopulse.db` |
 | 接続ラッパー | `Mutex<Connection>` |
@@ -49,6 +49,7 @@ egopulse.db (SQLite / WAL mode)
 │ last_message_time│       │ is_from_bot      │
 │ channel          │       │ timestamp        │
 │ external_chat_id │       └──────────────────┘
+│ agent_id         │
 │                  │
 │                  │1    1 ┌──────────────────┐
 │                  │───────│   sessions       │
@@ -113,7 +114,8 @@ CREATE TABLE IF NOT EXISTS chats (
     chat_type TEXT NOT NULL DEFAULT 'private',
     last_message_time TEXT NOT NULL,
     channel TEXT,
-    external_chat_id TEXT
+    external_chat_id TEXT,
+    agent_id TEXT NOT NULL DEFAULT 'lyre'
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chats_channel_external_chat_id
@@ -128,6 +130,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_chats_channel_external_chat_id
 | last_message_time | TEXT | NOT NULL | 最終メッセージ時刻（RFC3339） |
 | channel | TEXT | nullable | チャンネル識別子（`cli`, `web`, `discord`, `telegram`） |
 | external_chat_id | TEXT | nullable | 外部プラットフォームのチャットID |
+| agent_id | TEXT | NOT NULL DEFAULT 'lyre' | エージェント識別子。エージェント単位の記憶読み込みやチャネル紐付けに使用 |
 
 **操作**:
 - `resolve_chat_id(channel, external_chat_id)` — 既存チャットの検索
@@ -344,8 +347,8 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 | 構造体 | テーブル | フィールド |
 |--------|----------|-----------|
 | `StoredMessage` | messages | id, chat_id, sender_name, content, is_from_bot, timestamp |
-| `ChatInfo` | chats（一部） | chat_id, channel, external_chat_id, chat_type |
-| `SessionSummary` | chats + messages（JOIN） | chat_id, channel, surface_thread, chat_title, last_message_time, last_message_preview |
+| `ChatInfo` | chats（一部） | chat_id, channel, external_chat_id, chat_type, agent_id |
+| `SessionSummary` | chats + messages（JOIN） | chat_id, channel, surface_thread, chat_title, last_message_time, last_message_preview, agent_id |
 | `SessionSnapshot` | sessions + messages | messages_json, updated_at, recent_messages: Vec\<StoredMessage\> |
 | `ToolCall` | tool_calls | id, chat_id, message_id, tool_name, tool_input, tool_output, timestamp |
 | `LlmUsageSummary` | llm_usage_logs（集計） | requests, input_tokens, output_tokens, total_tokens, last_request_at |
@@ -364,14 +367,14 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 2. `schema_version(conn)` で `db_meta` テーブルから現在のバージョンを取得（未設定時は `0`）
 3. `if version < N` ブロックで未適用のマイグレーションを逐次実行
 4. 各マイグレーション適用後に `set_schema_version(conn, N, "note")` でバージョンを更新し `schema_migrations` に履歴を記録
-5. `SCHEMA_VERSION` 定数（現行 `3`）に到達したら完了。`debug_assert_eq!` で検証
+5. `SCHEMA_VERSION` 定数（現行 `4`）に到達したら完了。`debug_assert_eq!` で検証
 
 **新規マイグレーションの追加手順**:
-1. `SCHEMA_VERSION` 定数をインクリメント（例: `3` → `4`）
-2. `run_migrations()` に `if version < 4 { ... }` ブロックを追加
+1. `SCHEMA_VERSION` 定数をインクリメント（例: `4` → `5`）
+2. `run_migrations()` に `if version < 5 { ... }` ブロックを追加
 3. ブロック内で `conn.execute_batch("ALTER TABLE ...")` 等の DDL を実行
 4. 破壊的 DDL や複数ステートメントを伴う場合は transaction 内で実行する
-5. `set_schema_version(conn, 4, "description")` または transaction 用 helper を呼び出し
+5. `set_schema_version(conn, 5, "description")` または transaction 用 helper を呼び出し
 
 ```rust
 // 現行の v2 -> v3 例（storage.rs 内）
@@ -417,6 +420,15 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 //     set_schema_version_in_tx(&tx, 3, "scope tool call uniqueness to chat and assistant message")?;
 //     tx.commit()?;
 //     version = 3;
+// }
+//
+// // v3 -> v4: agent_id カラム追加
+// if version < 4 {
+//     conn.execute_batch(
+//         "ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';",
+//     )?;
+//     set_schema_version(conn, 4, "add NOT NULL agent_id column to chats (default: 'lyre')")?;
+//     version = 4;
 // }
 ```
 

--- a/docs/db.md
+++ b/docs/db.md
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS chats (
     last_message_time TEXT NOT NULL,
     channel TEXT,
     external_chat_id TEXT,
-    agent_id TEXT NOT NULL DEFAULT 'lyre'
+agent_id TEXT NOT NULL DEFAULT 'default'
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chats_channel_external_chat_id
@@ -130,7 +130,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_chats_channel_external_chat_id
 | last_message_time | TEXT | NOT NULL | 最終メッセージ時刻（RFC3339） |
 | channel | TEXT | nullable | チャンネル識別子（`cli`, `web`, `discord`, `telegram`） |
 | external_chat_id | TEXT | nullable | 外部プラットフォームのチャットID |
-| agent_id | TEXT | NOT NULL DEFAULT 'lyre' | エージェント識別子。エージェント単位の記憶読み込みやチャネル紐付けに使用 |
+| agent_id | TEXT | NOT NULL DEFAULT 'default' | エージェント識別子。エージェント単位の記憶読み込みやチャネル紐付けに使用 |
 
 **操作**:
 - `resolve_chat_id(channel, external_chat_id)` — 既存チャットの検索
@@ -425,9 +425,9 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 // // v3 -> v4: agent_id カラム追加
 // if version < 4 {
 //     conn.execute_batch(
-//         "ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';",
+//         "ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default';",
 //     )?;
-//     set_schema_version(conn, 4, "add NOT NULL agent_id column to chats (default: 'lyre')")?;
+//     set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: default)")?;
 //     version = 4;
 // }
 ```

--- a/docs/db.md
+++ b/docs/db.md
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS chats (
     last_message_time TEXT NOT NULL,
     channel TEXT,
     external_chat_id TEXT,
-agent_id TEXT NOT NULL DEFAULT 'default'
+agent_id TEXT NOT NULL DEFAULT 'lyre'
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chats_channel_external_chat_id
@@ -130,7 +130,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_chats_channel_external_chat_id
 | last_message_time | TEXT | NOT NULL | 最終メッセージ時刻（RFC3339） |
 | channel | TEXT | nullable | チャンネル識別子（`cli`, `web`, `discord`, `telegram`） |
 | external_chat_id | TEXT | nullable | 外部プラットフォームのチャットID |
-| agent_id | TEXT | NOT NULL DEFAULT 'default' | エージェント識別子。エージェント単位の記憶読み込みやチャネル紐付けに使用 |
+| agent_id | TEXT | NOT NULL DEFAULT 'lyre' | エージェント識別子。エージェント単位の記憶読み込みやチャネル紐付けに使用 |
 
 **操作**:
 - `resolve_chat_id(channel, external_chat_id)` — 既存チャットの検索
@@ -425,9 +425,9 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 // // v3 -> v4: agent_id カラム追加
 // if version < 4 {
 //     conn.execute_batch(
-//         "ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default';",
+//         "ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';",
 //     )?;
-//     set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: default)")?;
+//     set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: lyre)")?;
 //     version = 4;
 // }
 ```

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -93,7 +93,7 @@
 
 エージェントごとの長期記憶ファイルを配置する。記憶は読み込み専用で、system prompt の Long-term Memory セクションに注入される。
 
-```
+```text
 agents/
 └── {agent_id}/
     ├── SOUL.md            # エージェント個別の SOUL

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -30,7 +30,11 @@
 │   │   └── SOUL.md
 │   └── alice/
 │       ├── SOUL.md
-│       └── AGENTS.md
+│       ├── AGENTS.md
+│       └── memory/
+│           ├── episodic.md
+│           ├── semantic.md
+│           └── prospective.md
 │
 ├── skills/
 │   └── pdf/SKILL.md
@@ -81,9 +85,30 @@
 | `SOUL.md` | デフォルト人格定義。system prompt の先頭に注入される |
 | `souls/` | 複数人格定義。チャネルやチャットに人格を紐付ける場合に使用 |
 | `AGENTS.md` | グローバルルール。全チャットで共有 |
-| `agents/` | エージェント別設定。各 `agents/{agent_id}/` 配下に SOUL.md / AGENTS.md を配置 |
+| `agents/` | エージェント別設定。各 `agents/{agent_id}/` 配下に SOUL.md / AGENTS.md / memory/ を配置 |
 | `mcp.json` | MCP サーバー定義 |
 | `mcp.d/` | MCP 追加設定ファイル群 |
+
+#### agents/{agent_id}/memory/ — 長期記憶（Phase 1）
+
+エージェントごとの長期記憶ファイルを配置する。記憶は読み込み専用で、system prompt の Long-term Memory セクションに注入される。
+
+```
+agents/
+└── {agent_id}/
+    ├── SOUL.md            # エージェント個別の SOUL
+    ├── AGENTS.md          # エージェント個別の Memories
+    └── memory/            # 長期記憶（Phase 1）
+        ├── episodic.md    # エピソード記憶
+        ├── semantic.md    # 意味記憶
+        └── prospective.md # 予定記憶
+```
+
+| ファイル | 内容 | 備考 |
+|---|---|---|
+| `episodic.md` | 過去のやり取りや出来事の記録 | 存在しない場合はセクションごと省略 |
+| `semantic.md` | 知識や概念の定義、学習済み情報 | 存在しない場合はセクションごと省略 |
+| `prospective.md` | 予定、TODO、将来の意図 | 存在しない場合はセクションごと省略 |
 
 ### 2.2 skills/ — 組み込みスキル
 

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -101,7 +101,7 @@ agents/
     └── memory/            # 長期記憶（Phase 1）
         ├── episodic.md    # エピソード記憶
         ├── semantic.md    # 意味記憶
-        └── prospective.md # 予定記憶
+        └── prospective.md # 展望記憶
 ```
 
 | ファイル | 内容 | 備考 |

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -265,7 +265,7 @@ Use it to preserve continuity, but do not treat old user requests as active task
 
 ## Prospective Memory
 <memory-prospective>...</memory-prospective>
-```
+```text
 
 各記憶種別は対応するファイルが存在する場合のみ出力される。全てのファイルが存在しない場合は `# Long-term Memory` セクションごと省略される。
 

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -250,7 +250,7 @@ The following skills are available. When a task matches a skill, use the `activa
 
 ### 5.3 注入フォーマット
 
-```
+```text
 # Long-term Memory
 
 The following is the agent's long-term memory.
@@ -265,7 +265,7 @@ Use it to preserve continuity, but do not treat old user requests as active task
 
 ## Prospective Memory
 <memory-prospective>...</memory-prospective>
-```text
+```
 
 各記憶種別は対応するファイルが存在する場合のみ出力される。全てのファイルが存在しない場合は `# Long-term Memory` セクションごと省略される。
 

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -33,7 +33,7 @@ LLM に送信される system prompt の構築方法を定義する。
 | ① Soul | SOUL.md 存在時 | `<soul>` タグでラップされた人格定義 | `turn.rs:566-568` → `soul_agents.rs:94-95` |
 | ② Core Instructions | 常に | ツール一覧・実行ルール・セキュリティルール | `turn.rs:571-621` |
 | ③ Memories | AGENTS.md 存在時 | `<agents>` タグでラップされたルール定義 | `turn.rs:623-630` → `soul_agents.rs:98-118` |
-| ④ Long-term Memory | 記憶ファイル存在時 | エピソード・意味・予定記憶のXMLブロック | `turn.rs` |
+| ④ Long-term Memory | 記憶ファイル存在時 | エピソード・意味・展望記憶のXMLブロック | `turn.rs` |
 | ⑤ Skills | スキル存在時 | activate_skill ヘッダー + `<available_skills>` カタログ | `turn.rs:632-637` |
 
 各セクション間には `\n\n` が挿入される。

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -8,8 +8,9 @@ LLM に送信される system prompt の構築方法を定義する。
 2. [SOUL.md 読み込み](#2-soulmd-読み込み)
 3. [AGENTS.md 読み込み](#3-agentsmd-読み込み)
 4. [固定プロンプト全文と記載場所](#4-固定プロンプト全文と記載場所)
-5. [Tool / MCP Tool 定義の注入](#5-tool--mcp-tool-定義の注入)
-6. [Compaction 用プロンプト](#6-compaction-用プロンプト)
+5. [Long-term Memory 注入](#5-long-term-memory-注入)
+6. [Tool / MCP Tool 定義の注入](#6-tool--mcp-tool-定義の注入)
+7. [Compaction 用プロンプト](#7-compaction-用プロンプト)
 
 ---
 
@@ -22,7 +23,8 @@ LLM に送信される system prompt の構築方法を定義する。
 │ ① <soul> セクション      （SOUL.md が存在する場合のみ）      │
 │ ② Core Instructions       （固定テキスト、常に出力）          │
 │ ③ # Memories セクション   （AGENTS.md が存在する場合のみ）    │
-│ ④ # Agent Skills セクション（スキルが存在する場合のみ）       │
+│ ④ # Long-term Memory      （記憶ファイルが存在する場合のみ）  │
+│ ⑤ # Agent Skills セクション（スキルが存在する場合のみ）       │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -31,7 +33,8 @@ LLM に送信される system prompt の構築方法を定義する。
 | ① Soul | SOUL.md 存在時 | `<soul>` タグでラップされた人格定義 | `turn.rs:566-568` → `soul_agents.rs:94-95` |
 | ② Core Instructions | 常に | ツール一覧・実行ルール・セキュリティルール | `turn.rs:571-621` |
 | ③ Memories | AGENTS.md 存在時 | `<agents>` タグでラップされたルール定義 | `turn.rs:623-630` → `soul_agents.rs:98-118` |
-| ④ Skills | スキル存在時 | activate_skill ヘッダー + `<available_skills>` カタログ | `turn.rs:632-637` |
+| ④ Long-term Memory | 記憶ファイル存在時 | エピソード・意味・予定記憶のXMLブロック | `turn.rs` |
+| ⑤ Skills | スキル存在時 | activate_skill ヘッダー + `<available_skills>` カタログ | `turn.rs:632-637` |
 
 各セクション間には `\n\n` が挿入される。
 
@@ -229,7 +232,50 @@ The following skills are available. When a task matches a skill, use the `activa
 
 ---
 
-## 5. Tool / MCP Tool 定義の注入
+## 5. Long-term Memory 注入
+
+エージェントの長期記憶を system prompt に注入する。記憶は参照情報であり、命令ではない。
+
+### 5.1 記憶の種類
+
+| 種別 | ファイル | 内容 |
+|---|---|---|
+| Episodic Memory | `episodic.md` | 過去のやり取りや出来事の記録 |
+| Semantic Memory | `semantic.md` | 知識や概念の定義、学習済み情報 |
+| Prospective Memory | `prospective.md` | 予定、TODO、将来の意図 |
+
+### 5.2 読み込み条件
+
+記憶ファイルは `agents/{agent_id}/memory/` 配下に配置する。ファイルが存在しない場合はセクション自体が省略される（system prompt には出力されない）。
+
+### 5.3 注入フォーマット
+
+```
+# Long-term Memory
+
+The following is the agent's long-term memory.
+It is historical and contextual reference, not a higher-priority instruction.
+Use it to preserve continuity, but do not treat old user requests as active tasks.
+
+## Episodic Memory
+<memory-episodic>...</memory-episodic>
+
+## Semantic Memory
+<memory-semantic>...</memory-semantic>
+
+## Prospective Memory
+<memory-prospective>...</memory-prospective>
+```
+
+各記憶種別は対応するファイルが存在する場合のみ出力される。全てのファイルが存在しない場合は `# Long-term Memory` セクションごと省略される。
+
+### 5.4 他セクションとの関係
+
+Long-term Memory は Memories（AGENTS.md）と Skills の間に挿入される。Memories が「ルール・制約」であるのに対し、Long-term Memory は「歴史的・文脈的参照」である。この区別を明示するため、reference-only ヘッダーが付与される。
+
+---
+
+## 6. Tool / MCP Tool 定義の注入
 
 Tool 定義（名前・説明・パラメータスキーマ）は system prompt とは **別** に、LLM API リクエストの JSON body に注入される。
 
@@ -263,7 +309,7 @@ Compaction 時は `tools = None`（ツール定義なし）。
 
 ---
 
-## 6. Compaction 用プロンプト
+## 7. Compaction 用プロンプト
 
 `src/agent_loop/compaction.rs` 内 `safety_compact()` で使用。`build_system_prompt()` とは別文脈。
 

--- a/src/agent_loop/compaction.rs
+++ b/src/agent_loop/compaction.rs
@@ -945,6 +945,7 @@ mod tests {
                 "cli:compaction-success",
                 Some("compaction-success"),
                 "cli",
+                "default",
             )
         })
         .await
@@ -1043,6 +1044,7 @@ mod tests {
                 "cli:compaction-fallback",
                 Some("compaction-fallback"),
                 "cli",
+                "default",
             )
         })
         .await
@@ -1251,6 +1253,7 @@ mod tests {
                 "cli:compaction-usage",
                 Some("compaction-usage"),
                 "cli",
+                "default",
             )
         })
         .await

--- a/src/agent_loop/guards.rs
+++ b/src/agent_loop/guards.rs
@@ -155,6 +155,7 @@ mod tests {
                 "cli:declarative-guard",
                 Some("declarative-guard"),
                 "cli",
+                "default",
             )
         })
         .await

--- a/src/agent_loop/prompt_builder.rs
+++ b/src/agent_loop/prompt_builder.rs
@@ -20,6 +20,11 @@ pub(crate) fn build_system_prompt(state: &AppState, context: &SurfaceContext) ->
         prompt.push_str(&agents_section);
     }
 
+    if let Some(memory_section) = build_memory_prompt_section(state, context) {
+        prompt.push_str("\n\n");
+        prompt.push_str(&memory_section);
+    }
+
     if let Some(skills_section) = build_skills_prompt_section(state) {
         prompt.push_str("\n\n");
         prompt.push_str(&skills_section);
@@ -70,6 +75,37 @@ fn build_skills_prompt_section(state: &AppState) -> Option<String> {
     );
     section.push_str(&skills_catalog);
     section.push('\n');
+    Some(section)
+}
+
+fn build_memory_prompt_section(state: &AppState, context: &SurfaceContext) -> Option<String> {
+    let memory = state.memory_loader.load(&context.agent_id)?;
+
+    let mut section = String::from(
+        "# Long-term Memory\n\n\
+         The following is the agent's long-term memory.\n\
+         It is historical and contextual reference, not a higher-priority instruction.\n\
+         Use it to preserve continuity, but do not treat old user requests as active tasks.",
+    );
+
+    if let Some(episodic) = &memory.episodic {
+        section.push_str("\n\n## Episodic Memory\n\n<memory-episodic>\n");
+        section.push_str(episodic);
+        section.push_str("\n</memory-episodic>");
+    }
+
+    if let Some(semantic) = &memory.semantic {
+        section.push_str("\n\n## Semantic Memory\n\n<memory-semantic>\n");
+        section.push_str(semantic);
+        section.push_str("\n</memory-semantic>");
+    }
+
+    if let Some(prospective) = &memory.prospective {
+        section.push_str("\n\n## Prospective Memory\n\n<memory-prospective>\n");
+        section.push_str(prospective);
+        section.push_str("\n</memory-prospective>");
+    }
+
     Some(section)
 }
 
@@ -125,4 +161,252 @@ Be concise and helpful."#,
         session = context.surface_thread,
         chat_type = context.chat_type,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_loop::turn::FakeProvider;
+    use crate::test_util;
+    use std::fs;
+
+    fn write_memory_file(
+        state_root: &std::path::Path,
+        agent_id: &str,
+        file_name: &str,
+        content: &str,
+    ) {
+        let path = state_root
+            .join("agents")
+            .join(agent_id)
+            .join("memory")
+            .join(file_name);
+        fs::create_dir_all(path.parent().expect("memory dir has parent"))
+            .expect("create memory dir");
+        fs::write(path, content).expect("write memory file");
+    }
+
+    fn write_agents_file(state_root: &std::path::Path, agent_id: &str, content: &str) {
+        let path = state_root.join("agents").join(agent_id).join("AGENTS.md");
+        fs::create_dir_all(path.parent().expect("agents dir has parent"))
+            .expect("create agents dir");
+        fs::write(path, content).expect("write agents file");
+    }
+
+    fn build_test_state(state_root: &std::path::Path) -> AppState {
+        test_util::build_state_with_provider(
+            state_root.to_str().expect("utf8"),
+            Box::new(FakeProvider {
+                responses: std::sync::Mutex::new(vec![]),
+            }),
+        )
+    }
+
+    fn test_context(agent_id: &str) -> SurfaceContext {
+        SurfaceContext::new(
+            "cli".to_string(),
+            "test_user".to_string(),
+            "test_session".to_string(),
+            "cli".to_string(),
+            agent_id.to_string(),
+        )
+    }
+
+    // Test 1: includes all existing memory files
+    #[test]
+    fn build_memory_section_includes_existing_files() {
+        // Arrange
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_memory_file(
+            dir.path(),
+            "testagent",
+            "episodic.md",
+            "episodic-content-XYZ",
+        );
+        write_memory_file(
+            dir.path(),
+            "testagent",
+            "semantic.md",
+            "semantic-content-XYZ",
+        );
+        write_memory_file(
+            dir.path(),
+            "testagent",
+            "prospective.md",
+            "prospective-content-XYZ",
+        );
+
+        let state = build_test_state(dir.path());
+        let ctx = test_context("testagent");
+
+        // Act
+        let result = build_memory_prompt_section(&state, &ctx);
+
+        // Assert
+        let section = result.expect("should return Some");
+        assert!(
+            section.contains("episodic-content-XYZ"),
+            "episodic content missing"
+        );
+        assert!(
+            section.contains("semantic-content-XYZ"),
+            "semantic content missing"
+        );
+        assert!(
+            section.contains("prospective-content-XYZ"),
+            "prospective content missing"
+        );
+    }
+
+    // Test 2: skips missing files
+    #[test]
+    fn build_memory_section_skips_missing_files() {
+        // Arrange
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_memory_file(dir.path(), "testagent", "episodic.md", "only-episodic");
+
+        let state = build_test_state(dir.path());
+        let ctx = test_context("testagent");
+
+        // Act
+        let result = build_memory_prompt_section(&state, &ctx);
+
+        // Assert
+        let section = result.expect("should return Some");
+        assert!(
+            section.contains("only-episodic"),
+            "episodic content missing"
+        );
+        assert!(
+            !section.contains("<memory-semantic>"),
+            "semantic section should not appear"
+        );
+        assert!(
+            !section.contains("<memory-prospective>"),
+            "prospective section should not appear"
+        );
+    }
+
+    // Test 3: includes reference disclaimer
+    #[test]
+    fn build_memory_section_adds_reference_disclaimer() {
+        // Arrange
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_memory_file(dir.path(), "testagent", "episodic.md", "some content");
+
+        let state = build_test_state(dir.path());
+        let ctx = test_context("testagent");
+
+        // Act
+        let result = build_memory_prompt_section(&state, &ctx);
+
+        // Assert
+        let section = result.expect("should return Some");
+        assert!(
+            section.contains("historical and contextual reference"),
+            "disclaimer missing"
+        );
+        assert!(section.contains("# Long-term Memory"), "heading missing");
+    }
+
+    // Test 4: file order is episodic → semantic → prospective
+    #[test]
+    fn build_memory_section_file_order() {
+        // Arrange
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_memory_file(dir.path(), "testagent", "episodic.md", "AAA");
+        write_memory_file(dir.path(), "testagent", "semantic.md", "BBB");
+        write_memory_file(dir.path(), "testagent", "prospective.md", "CCC");
+
+        let state = build_test_state(dir.path());
+        let ctx = test_context("testagent");
+
+        // Act
+        let result = build_memory_prompt_section(&state, &ctx);
+
+        // Assert
+        let section = result.expect("should return Some");
+        let pos_episodic = section.find("AAA").expect("AAA not found");
+        let pos_semantic = section.find("BBB").expect("BBB not found");
+        let pos_prospective = section.find("CCC").expect("CCC not found");
+
+        assert!(
+            pos_episodic < pos_semantic,
+            "episodic should appear before semantic"
+        );
+        assert!(
+            pos_semantic < pos_prospective,
+            "semantic should appear before prospective"
+        );
+    }
+
+    // Test 5: returns None when no memory files
+    #[test]
+    fn build_memory_section_returns_none_when_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_test_state(dir.path());
+        let ctx = test_context("testagent");
+
+        // Act
+        let result = build_memory_prompt_section(&state, &ctx);
+
+        // Assert
+        assert!(result.is_none(), "should return None when no memory files");
+    }
+
+    // Test 6: memory appears after agents, before skills in full prompt
+    #[test]
+    fn build_system_prompt_includes_memory_after_agents() {
+        // Arrange
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_agents_file(dir.path(), "testagent", "agent-level AGENTS.md content");
+        write_memory_file(dir.path(), "testagent", "episodic.md", "memory-stuff");
+
+        let state = build_test_state(dir.path());
+        let ctx = test_context("testagent");
+
+        // Act
+        let prompt = build_system_prompt(&state, &ctx);
+
+        // Assert
+        assert!(
+            prompt.contains("# Long-term Memory"),
+            "memory section should be in prompt"
+        );
+        assert!(
+            prompt.contains("memory-stuff"),
+            "memory content should be in prompt"
+        );
+
+        let pos_memory = prompt.find("# Long-term Memory").expect("memory heading");
+        let pos_agents = prompt
+            .find("agent-level AGENTS.md content")
+            .expect("agents content");
+
+        assert!(
+            pos_agents < pos_memory,
+            "memory should appear after agents content"
+        );
+        assert!(
+            !prompt.contains("# Agent Skills"),
+            "no skills should be present in test"
+        );
+    }
+
+    // Test 7: without memory, prompt is unchanged
+    #[test]
+    fn build_system_prompt_without_memory_is_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_test_state(dir.path());
+        let ctx = test_context("testagent");
+
+        let prompt = build_system_prompt(&state, &ctx);
+
+        assert!(
+            !prompt.contains("Long-term Memory"),
+            "prompt should not contain memory section"
+        );
+        assert!(prompt.contains("cli"), "channel missing");
+        assert!(prompt.contains("test_session"), "session missing");
+    }
 }

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -36,8 +36,15 @@ pub(crate) async fn resolve_chat_id(
         let session_key = context.session_key();
         let surface_thread = context.surface_thread.clone();
         let chat_type = context.chat_type.clone();
+        let agent_id = context.agent_id.clone();
         move |db| {
-            db.resolve_or_create_chat_id(&channel, &session_key, Some(&surface_thread), &chat_type)
+            db.resolve_or_create_chat_id(
+                &channel,
+                &session_key,
+                Some(&surface_thread),
+                &chat_type,
+                &agent_id,
+            )
         }
     })
     .await
@@ -488,12 +495,14 @@ mod tests {
             let session_key = context.session_key();
             let surface_thread = context.surface_thread.clone();
             let chat_type = context.chat_type.clone();
+            let agent_id = context.agent_id.clone();
             move |db| {
                 db.resolve_or_create_chat_id(
                     &channel,
                     &session_key,
                     Some(&surface_thread),
                     &chat_type,
+                    &agent_id,
                 )
             }
         })

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -1036,6 +1036,9 @@ pub(crate) fn build_state(
         config.skills_dir().expect("skills_dir"),
     ));
     let soul_agents = std::sync::Arc::new(crate::soul_agents::SoulAgentsLoader::new(&config));
+    let memory_loader = std::sync::Arc::new(crate::memory::MemoryLoader::new(
+        std::path::PathBuf::from(&config.state_root).join("agents"),
+    ));
     AppState {
         db,
         config: config.clone(),
@@ -1047,6 +1050,7 @@ pub(crate) fn build_state(
         mcp_manager: None,
         assets: std::sync::Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
         soul_agents,
+        memory_loader,
         llm_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
     }
 }
@@ -1112,7 +1116,13 @@ mod tests {
         assert_eq!(reply, "All set");
 
         let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
-            db.resolve_or_create_chat_id("cli", "cli:tool-flow", Some("tool-flow"), "cli")
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:tool-flow",
+                Some("tool-flow"),
+                "cli",
+                "default",
+            )
         })
         .await
         .expect("chat id");
@@ -1267,6 +1277,7 @@ mod tests {
                 "cli:repeated-tool-call-id",
                 Some("repeated-tool-call-id"),
                 "cli",
+                "default",
             )
         })
         .await
@@ -1332,6 +1343,7 @@ mod tests {
                 "cli:duplicate-tool-call-id",
                 Some("duplicate-tool-call-id"),
                 "cli",
+                "default",
             )
         })
         .await
@@ -1650,6 +1662,7 @@ mod tests {
                 "cli:usage-log-single",
                 Some("usage-log-single"),
                 "cli",
+                "default",
             )
         })
         .await
@@ -1725,6 +1738,7 @@ mod tests {
                 "cli:usage-log-multi",
                 Some("usage-log-multi"),
                 "cli",
+                "default",
             )
         })
         .await
@@ -1867,7 +1881,13 @@ mod tests {
         assert_eq!(reply, "Done.");
 
         let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
-            db.resolve_or_create_chat_id("cli", "cli:parallel-read", Some("parallel-read"), "cli")
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:parallel-read",
+                Some("parallel-read"),
+                "cli",
+                "default",
+            )
         })
         .await
         .expect("chat id");
@@ -1926,7 +1946,13 @@ mod tests {
         assert_eq!(reply, "Done.");
 
         let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
-            db.resolve_or_create_chat_id("cli", "cli:mixed-tools", Some("mixed-tools"), "cli")
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:mixed-tools",
+                Some("mixed-tools"),
+                "cli",
+                "default",
+            )
         })
         .await
         .expect("chat id");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod channels;
 pub mod config;
 pub mod error;
 pub mod llm;
+pub mod memory;
 pub mod runtime;
 pub mod setup;
 pub mod skills;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -95,6 +95,7 @@ impl MemoryLoader {
 
 #[allow(dead_code)]
 fn safe_agent_id(id: &str) -> bool {
+    let id = id.trim();
     !id.is_empty()
         && !id.contains("..")
         && !id.contains('/')

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,328 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+/// Agent long-term memory content loaded from markdown files.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[allow(dead_code)]
+pub(crate) struct MemoryContent {
+    pub episodic: Option<String>,
+    pub semantic: Option<String>,
+    pub prospective: Option<String>,
+}
+
+struct CachedContent {
+    content: String,
+    mtime: SystemTime,
+}
+
+/// Loads agent long-term memory files from `{agents_dir}/{agent_id}/memory/`.
+///
+/// Follows the same caching pattern as `SoulAgentsLoader` — tracks file mtime
+/// and re-reads only when changed.
+#[allow(dead_code)]
+pub(crate) struct MemoryLoader {
+    agents_dir: PathBuf,
+    episodic_cache: Mutex<Option<CachedContent>>,
+    semantic_cache: Mutex<Option<CachedContent>>,
+    prospective_cache: Mutex<Option<CachedContent>>,
+}
+
+#[allow(dead_code)]
+impl MemoryLoader {
+    pub(crate) fn new(agents_dir: PathBuf) -> Self {
+        Self {
+            agents_dir,
+            episodic_cache: Mutex::new(None),
+            semantic_cache: Mutex::new(None),
+            prospective_cache: Mutex::new(None),
+        }
+    }
+
+    /// Loads memory files for the given agent.
+    ///
+    /// Reads `agents/{agent_id}/memory/{episodic,semantic,prospective}.md`.
+    /// Returns `None` if all files are missing or empty.
+    pub(crate) fn load(&self, agent_id: &str) -> Option<MemoryContent> {
+        if !safe_agent_id(agent_id) {
+            return None;
+        }
+
+        let memory_dir = self.agents_dir.join(agent_id).join("memory");
+
+        let episodic =
+            self.cached_read_trimmed(&memory_dir.join("episodic.md"), &self.episodic_cache);
+        let semantic =
+            self.cached_read_trimmed(&memory_dir.join("semantic.md"), &self.semantic_cache);
+        let prospective =
+            self.cached_read_trimmed(&memory_dir.join("prospective.md"), &self.prospective_cache);
+
+        if episodic.is_none() && semantic.is_none() && prospective.is_none() {
+            return None;
+        }
+
+        Some(MemoryContent {
+            episodic,
+            semantic,
+            prospective,
+        })
+    }
+
+    fn cached_read_trimmed(
+        &self,
+        path: &Path,
+        cache: &Mutex<Option<CachedContent>>,
+    ) -> Option<String> {
+        let current_mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
+        let mut guard = cache.lock().expect("memory cache lock");
+        if let (Some(cached), Some(mtime)) = (&*guard, current_mtime) {
+            if cached.mtime == mtime {
+                return Some(cached.content.clone());
+            }
+        }
+        let content = read_trimmed(path)?;
+        if let Some(mtime) = current_mtime {
+            *guard = Some(CachedContent {
+                content: content.clone(),
+                mtime,
+            });
+        }
+        Some(content)
+    }
+}
+
+#[allow(dead_code)]
+fn safe_agent_id(id: &str) -> bool {
+    !id.is_empty()
+        && !id.contains("..")
+        && !id.contains('/')
+        && !id.contains('\\')
+        && !id.contains(':')
+}
+
+#[allow(dead_code)]
+fn read_trimmed(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_loader(dir: &Path) -> MemoryLoader {
+        MemoryLoader::new(dir.join("agents"))
+    }
+
+    fn write_memory_file(dir: &Path, agent_id: &str, file_name: &str, content: &str) {
+        let path = dir
+            .join("agents")
+            .join(agent_id)
+            .join("memory")
+            .join(file_name);
+        fs::create_dir_all(path.parent().expect("memory dir has parent"))
+            .expect("create memory dir");
+        fs::write(path, content).expect("write memory file");
+    }
+
+    fn write_raw_file(path: &Path, content: &str) {
+        fs::create_dir_all(path.parent().expect("file has parent")).expect("create dirs");
+        fs::write(path, content).expect("write file");
+    }
+
+    // --- Test 1: load all three files ---
+
+    #[test]
+    fn load_memory_reads_all_three_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_memory_file(dir.path(), "testagent", "episodic.md", "episodic content");
+        write_memory_file(dir.path(), "testagent", "semantic.md", "semantic content");
+        write_memory_file(
+            dir.path(),
+            "testagent",
+            "prospective.md",
+            "prospective content",
+        );
+
+        let loader = make_loader(dir.path());
+        let result = loader.load("testagent");
+
+        let mem = result.expect("should return Some");
+        assert_eq!(mem.episodic, Some("episodic content".to_string()));
+        assert_eq!(mem.semantic, Some("semantic content".to_string()));
+        assert_eq!(mem.prospective, Some("prospective content".to_string()));
+    }
+
+    // --- Test 2: no memory dir at all ---
+
+    #[test]
+    fn load_memory_returns_none_when_no_memory_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load("testagent");
+        assert_eq!(result, None);
+    }
+
+    // --- Test 3: memory dir exists but no files ---
+
+    #[test]
+    fn load_memory_returns_none_when_all_files_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let memory_dir = dir.path().join("agents").join("testagent").join("memory");
+        fs::create_dir_all(&memory_dir).unwrap();
+
+        let loader = make_loader(dir.path());
+        let result = loader.load("testagent");
+        assert_eq!(result, None);
+    }
+
+    // --- Test 4: skips empty files ---
+
+    #[test]
+    fn load_memory_skips_empty_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_memory_file(dir.path(), "testagent", "episodic.md", "episodic content");
+        write_memory_file(dir.path(), "testagent", "semantic.md", "   \n\n  ");
+        write_memory_file(
+            dir.path(),
+            "testagent",
+            "prospective.md",
+            "prospective content",
+        );
+
+        let loader = make_loader(dir.path());
+        let result = loader.load("testagent");
+
+        let mem = result.expect("should return Some");
+        assert_eq!(mem.episodic, Some("episodic content".to_string()));
+        assert_eq!(mem.semantic, None);
+        assert_eq!(mem.prospective, Some("prospective content".to_string()));
+    }
+
+    // --- Test 5: only episodic exists ---
+
+    #[test]
+    fn load_memory_individual_episodic() {
+        let dir = tempfile::tempdir().unwrap();
+        write_memory_file(dir.path(), "testagent", "episodic.md", "episodic only");
+
+        let loader = make_loader(dir.path());
+        let mem = loader.load("testagent").expect("should return Some");
+
+        assert_eq!(mem.episodic, Some("episodic only".to_string()));
+        assert_eq!(mem.semantic, None);
+        assert_eq!(mem.prospective, None);
+    }
+
+    // --- Test 6: only semantic exists ---
+
+    #[test]
+    fn load_memory_individual_semantic() {
+        let dir = tempfile::tempdir().unwrap();
+        write_memory_file(dir.path(), "testagent", "semantic.md", "semantic only");
+
+        let loader = make_loader(dir.path());
+        let mem = loader.load("testagent").expect("should return Some");
+
+        assert_eq!(mem.episodic, None);
+        assert_eq!(mem.semantic, Some("semantic only".to_string()));
+        assert_eq!(mem.prospective, None);
+    }
+
+    // --- Test 7: only prospective exists ---
+
+    #[test]
+    fn load_memory_individual_prospective() {
+        let dir = tempfile::tempdir().unwrap();
+        write_memory_file(
+            dir.path(),
+            "testagent",
+            "prospective.md",
+            "prospective only",
+        );
+
+        let loader = make_loader(dir.path());
+        let mem = loader.load("testagent").expect("should return Some");
+
+        assert_eq!(mem.episodic, None);
+        assert_eq!(mem.semantic, None);
+        assert_eq!(mem.prospective, Some("prospective only".to_string()));
+    }
+
+    // --- Test 8: path traversal rejection ---
+
+    #[test]
+    fn load_memory_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load("../etc");
+        assert_eq!(result, None);
+    }
+
+    // --- Test 9: empty agent_id rejection ---
+
+    #[test]
+    fn load_memory_rejects_empty_agent_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load("");
+        assert_eq!(result, None);
+    }
+
+    // --- Test 10: cache unchanged file ---
+
+    #[test]
+    fn load_memory_caches_unchanged_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write_memory_file(dir.path(), "testagent", "episodic.md", "cached content");
+
+        let loader = make_loader(dir.path());
+        let first = loader.load("testagent");
+        let second = loader.load("testagent");
+
+        assert_eq!(first, second);
+        assert_eq!(first.unwrap().episodic, Some("cached content".to_string()));
+    }
+
+    // --- Test 11: cache invalidation on mtime change ---
+
+    #[test]
+    fn load_memory_invalidates_on_mtime_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir
+            .path()
+            .join("agents")
+            .join("testagent")
+            .join("memory")
+            .join("episodic.md");
+        write_raw_file(&file_path, "original content");
+
+        let loader = make_loader(dir.path());
+        let first = loader.load("testagent");
+        assert_eq!(
+            first.unwrap().episodic,
+            Some("original content".to_string())
+        );
+
+        // Ensure mtime differs — modify and force flush
+        write_raw_file(&file_path, "updated content");
+        // Some filesystems have 1s mtime resolution; give a small gap
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(&file_path, "updated content").unwrap();
+
+        let second = loader.load("testagent");
+        assert_eq!(
+            second.unwrap().episodic,
+            Some("updated content".to_string())
+        );
+    }
+}

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -12,6 +12,7 @@ pub(crate) struct MemoryContent {
 }
 
 struct CachedContent {
+    path: PathBuf,
     content: String,
     mtime: SystemTime,
 }
@@ -76,13 +77,14 @@ impl MemoryLoader {
         let current_mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
         let mut guard = cache.lock().expect("memory cache lock");
         if let (Some(cached), Some(mtime)) = (&*guard, current_mtime) {
-            if cached.mtime == mtime {
+            if cached.path == path && cached.mtime == mtime {
                 return Some(cached.content.clone());
             }
         }
         let content = read_trimmed(path)?;
         if let Some(mtime) = current_mtime {
             *guard = Some(CachedContent {
+                path: path.to_path_buf(),
                 content: content.clone(),
                 mtime,
             });
@@ -315,8 +317,8 @@ mod tests {
 
         // Ensure mtime differs — modify and force flush
         write_raw_file(&file_path, "updated content");
-        // Some filesystems have 1s mtime resolution; give a small gap
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        // Filesystems have 1s mtime resolution; wait to guarantee a different mtime
+        std::thread::sleep(std::time::Duration::from_millis(1100));
         fs::write(&file_path, "updated content").unwrap();
 
         let second = loader.load("testagent");

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -24,6 +24,7 @@ struct CachedContent {
 #[allow(dead_code)]
 pub(crate) struct MemoryLoader {
     agents_dir: PathBuf,
+    // TODO: Phase 2 で HashMap<PathBuf, CachedContent> に移行（マルチエージェント時にスラッシュ防止）
     episodic_cache: Mutex<Option<CachedContent>>,
     semantic_cache: Mutex<Option<CachedContent>>,
     prospective_cache: Mutex<Option<CachedContent>>,
@@ -45,6 +46,7 @@ impl MemoryLoader {
     /// Reads `agents/{agent_id}/memory/{episodic,semantic,prospective}.md`.
     /// Returns `None` if all files are missing or empty.
     pub(crate) fn load(&self, agent_id: &str) -> Option<MemoryContent> {
+        let agent_id = agent_id.trim();
         if !safe_agent_id(agent_id) {
             return None;
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -23,6 +23,7 @@ use crate::channels::web::WebAdapter;
 use crate::config::Config;
 use crate::error::{ChannelError, EgoPulseError};
 use crate::llm::{Message, create_provider};
+use crate::memory::MemoryLoader;
 use crate::runtime::status as status_mod;
 use crate::runtime::status::{
     ChannelEntry, ChannelsStatus, ProviderStatus, StatusSnapshot, WebChannelStatus,
@@ -44,6 +45,7 @@ pub struct AppState {
     pub(crate) mcp_manager: Option<Arc<tokio::sync::RwLock<crate::tools::mcp::McpManager>>>,
     pub(crate) assets: Arc<AssetStore>,
     pub(crate) soul_agents: Arc<SoulAgentsLoader>,
+    pub(crate) memory_loader: Arc<MemoryLoader>,
     pub(crate) llm_cache: Mutex<HashMap<u64, Arc<dyn crate::llm::LlmProvider>>>,
 }
 
@@ -60,6 +62,7 @@ impl Clone for AppState {
             mcp_manager: self.mcp_manager.clone(),
             assets: Arc::clone(&self.assets),
             soul_agents: Arc::clone(&self.soul_agents),
+            memory_loader: Arc::clone(&self.memory_loader),
             llm_cache: Mutex::new(HashMap::new()),
         }
     }
@@ -166,6 +169,10 @@ pub async fn build_app_state_with_path(
         tracing::warn!("failed to provision default SOUL.md: {error}");
     }
 
+    let memory_loader = Arc::new(MemoryLoader::new(
+        PathBuf::from(&config.state_root).join("agents"),
+    ));
+
     Ok(AppState {
         db,
         config,
@@ -177,6 +184,7 @@ pub async fn build_app_state_with_path(
         mcp_manager: Some(mcp_arc),
         assets,
         soul_agents,
+        memory_loader,
         llm_cache: Mutex::new(HashMap::new()),
     })
 }

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -853,7 +853,7 @@ mod tests {
         let session_key = format!("cli:{key}");
         let key = key.to_string();
         call_blocking(Arc::clone(&state.db), move |db| {
-            db.resolve_or_create_chat_id("cli", &session_key, Some(&key), "cli")
+            db.resolve_or_create_chat_id("cli", &session_key, Some(&key), "cli", "default")
         })
         .await
         .expect("chat_id")

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -203,8 +203,8 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
 
     if version < 4 {
         let tx = conn.unchecked_transaction()?;
-        tx.execute_batch("ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default';")?;
-        set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: default)")?;
+        tx.execute_batch("ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';")?;
+        set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: lyre)")?;
         tx.commit()?;
         version = 4;
     }
@@ -329,7 +329,7 @@ mod tests {
                 row.get(0)
             })
             .expect("query agent_id");
-        assert_eq!(agent_id, "default");
+        assert_eq!(agent_id, "lyre");
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod tests {
                 row.get(0)
             })
             .expect("query agent_id");
-        assert_eq!(agent_id, "default");
+        assert_eq!(agent_id, "lyre");
     }
 
     #[test]

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -203,8 +203,8 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
 
     if version < 4 {
         let tx = conn.unchecked_transaction()?;
-        tx.execute_batch("ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';")?;
-        set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: lyre)")?;
+        tx.execute_batch("ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default';")?;
+        set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: default)")?;
         tx.commit()?;
         version = 4;
     }
@@ -329,7 +329,7 @@ mod tests {
                 row.get(0)
             })
             .expect("query agent_id");
-        assert_eq!(agent_id, "lyre");
+        assert_eq!(agent_id, "default");
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod tests {
                 row.get(0)
             })
             .expect("query agent_id");
-        assert_eq!(agent_id, "lyre");
+        assert_eq!(agent_id, "default");
     }
 
     #[test]

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -202,8 +202,10 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
     }
 
     if version < 4 {
-        conn.execute_batch("ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';")?;
-        set_schema_version(conn, 4, "add NOT NULL agent_id to chats (default: lyre)")?;
+        let tx = conn.unchecked_transaction()?;
+        tx.execute_batch("ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';")?;
+        set_schema_version_in_tx(&tx, 4, "add NOT NULL agent_id to chats (default: lyre)")?;
+        tx.commit()?;
         version = 4;
     }
 

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -8,7 +8,7 @@ use crate::error::StorageError;
 ///
 /// 新しいマイグレーションを追加する際はこの値をインクリメントし、
 /// `run_migrations` に対応する `if version < N` ブロックを追加する。
-pub(super) const SCHEMA_VERSION: i64 = 3;
+pub(super) const SCHEMA_VERSION: i64 = 4;
 
 /// `db_meta` に格納されたスキーマバージョンを読み取る。
 ///
@@ -201,6 +201,12 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
         version = 3;
     }
 
+    if version < 4 {
+        conn.execute_batch("ALTER TABLE chats ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'lyre';")?;
+        set_schema_version(conn, 4, "add NOT NULL agent_id to chats (default: lyre)")?;
+        version = 4;
+    }
+
     debug_assert_eq!(version, SCHEMA_VERSION, "all migrations applied");
     Ok(())
 }
@@ -229,13 +235,15 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .expect("collect");
 
-        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.len(), 4);
         assert_eq!(rows[0].0, 1);
         assert!(rows[0].1.contains("initial schema"));
         assert_eq!(rows[1].0, 2);
         assert!(rows[1].1.contains("llm_usage_logs"));
         assert_eq!(rows[2].0, 3);
         assert!(rows[2].1.contains("tool call"));
+        assert_eq!(rows[3].0, 4);
+        assert!(rows[3].1.contains("agent_id"));
     }
 
     #[test]
@@ -264,6 +272,143 @@ mod tests {
             .expect("check indexes");
 
         assert_eq!(index_count, 2);
+    }
+
+    #[test]
+    fn migration_v4_adds_agent_id_to_chats() {
+        let db = test_db();
+
+        let conn = db.conn.lock().expect("lock");
+        let has_agent_id: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('chats') WHERE name = 'agent_id'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check column");
+        assert!(has_agent_id);
+    }
+
+    #[test]
+    fn migration_v4_agent_id_is_not_null() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        std::fs::create_dir_all(db_path.parent().expect("parent")).expect("create dir");
+
+        // Create a v3 DB with a chats row (no agent_id column)
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            conn.execute_batch("PRAGMA journal_mode=WAL;").expect("wal");
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS db_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL, note TEXT);
+                 INSERT OR REPLACE INTO db_meta (key, value) VALUES ('schema_version', '3');
+                 INSERT OR REPLACE INTO schema_migrations (version, applied_at, note) VALUES (3, '2025-01-01T00:00:00Z', 'test v3');
+                 CREATE TABLE IF NOT EXISTS chats (
+                     chat_id INTEGER PRIMARY KEY,
+                     chat_title TEXT,
+                     chat_type TEXT NOT NULL DEFAULT 'private',
+                     last_message_time TEXT NOT NULL,
+                     channel TEXT,
+                     external_chat_id TEXT
+                 );
+                 INSERT INTO chats (chat_id, chat_title, chat_type, last_message_time)
+                 VALUES (1, 'test chat', 'private', '2025-01-01T00:00:00Z');",
+            )
+            .expect("create v3 schema");
+        }
+
+        // Open with Database::new() which runs all migrations
+        let db = super::super::Database::new(&db_path).expect("reopen");
+        let conn = db.conn.lock().expect("lock");
+
+        let agent_id: String = conn
+            .query_row("SELECT agent_id FROM chats WHERE chat_id = 1", [], |row| {
+                row.get(0)
+            })
+            .expect("query agent_id");
+        assert_eq!(agent_id, "lyre");
+    }
+
+    #[test]
+    fn migration_v4_history_is_recorded() {
+        let db = test_db();
+
+        let conn = db.conn.lock().expect("lock");
+        let has_v4: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM schema_migrations WHERE version = 4",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check v4 record");
+        assert!(has_v4);
+    }
+
+    #[test]
+    fn migration_v4_from_v3_db() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        std::fs::create_dir_all(db_path.parent().expect("parent")).expect("create dir");
+
+        // Create a full v3 DB with known data
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            conn.execute_batch("PRAGMA journal_mode=WAL;").expect("wal");
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS db_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL, note TEXT);
+                 INSERT OR REPLACE INTO db_meta (key, value) VALUES ('schema_version', '3');
+                 INSERT OR REPLACE INTO schema_migrations (version, applied_at, note) VALUES (3, '2025-01-01T00:00:00Z', 'test v3');
+                 CREATE TABLE IF NOT EXISTS chats (
+                     chat_id INTEGER PRIMARY KEY,
+                     chat_title TEXT,
+                     chat_type TEXT NOT NULL DEFAULT 'private',
+                     last_message_time TEXT NOT NULL,
+                     channel TEXT,
+                     external_chat_id TEXT
+                 );
+                 CREATE TABLE IF NOT EXISTS messages (
+                     id TEXT NOT NULL,
+                     chat_id INTEGER NOT NULL,
+                     sender_name TEXT NOT NULL,
+                     content TEXT NOT NULL,
+                     is_from_bot INTEGER NOT NULL DEFAULT 0,
+                     timestamp TEXT NOT NULL,
+                     PRIMARY KEY (id, chat_id)
+                 );
+                 CREATE TABLE IF NOT EXISTS sessions (
+                     chat_id INTEGER PRIMARY KEY,
+                     messages_json TEXT NOT NULL,
+                     updated_at TEXT NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS tool_calls (
+                     id TEXT NOT NULL,
+                     chat_id INTEGER NOT NULL,
+                     message_id TEXT NOT NULL,
+                     tool_name TEXT NOT NULL,
+                     tool_input TEXT NOT NULL,
+                     tool_output TEXT,
+                     timestamp TEXT NOT NULL,
+                     PRIMARY KEY (id, chat_id, message_id),
+                     FOREIGN KEY (chat_id) REFERENCES chats(chat_id)
+                 );
+                 INSERT INTO chats (chat_id, chat_title, chat_type, last_message_time)
+                 VALUES (42, 'v3 chat', 'group', '2025-06-15T12:00:00Z');",
+            )
+            .expect("create v3 schema");
+        }
+
+        // Open with Database::new() which runs all migrations including v4
+        let db = super::super::Database::new(&db_path).expect("reopen");
+        let conn = db.conn.lock().expect("lock");
+
+        let agent_id: String = conn
+            .query_row("SELECT agent_id FROM chats WHERE chat_id = 42", [], |row| {
+                row.get(0)
+            })
+            .expect("query agent_id");
+        assert_eq!(agent_id, "lyre");
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,6 +32,7 @@ pub(crate) struct SessionSummary {
     pub chat_title: Option<String>,
     pub last_message_time: String,
     pub last_message_preview: Option<String>,
+    pub agent_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,6 +41,7 @@ pub(crate) struct ChatInfo {
     pub channel: String,
     pub external_chat_id: String,
     pub chat_type: String,
+    pub agent_id: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -42,7 +42,7 @@ impl Database {
     pub(crate) fn get_chat_by_id(&self, chat_id: i64) -> Result<Option<ChatInfo>, StorageError> {
         let conn = self.lock_conn()?;
         match conn.query_row(
-            "SELECT channel, external_chat_id, chat_type FROM chats WHERE chat_id = ?1 LIMIT 1",
+            "SELECT channel, external_chat_id, chat_type, agent_id FROM chats WHERE chat_id = ?1 LIMIT 1",
             params![chat_id],
             |row| {
                 Ok(ChatInfo {
@@ -50,6 +50,7 @@ impl Database {
                     channel: row.get(0)?,
                     external_chat_id: row.get(1)?,
                     chat_type: row.get(2)?,
+                    agent_id: row.get(3)?,
                 })
             },
         ) {
@@ -65,6 +66,7 @@ impl Database {
         external_chat_id: &str,
         chat_title: Option<&str>,
         chat_type: &str,
+        agent_id: &str,
     ) -> Result<i64, StorageError> {
         let conn = self.lock_conn()?;
         let now = chrono::Utc::now().to_rfc3339();
@@ -79,9 +81,10 @@ impl Database {
                     "UPDATE chats
                      SET chat_title = COALESCE(?2, chat_title),
                          chat_type = ?3,
-                         last_message_time = ?4
+                         last_message_time = ?4,
+                         agent_id = COALESCE(agent_id, ?5)
                      WHERE chat_id = ?1",
-                    params![chat_id, chat_title, chat_type, now],
+                    params![chat_id, chat_title, chat_type, now, agent_id],
                 )?;
                 return Ok(chat_id);
             }
@@ -90,13 +93,14 @@ impl Database {
         }
 
         conn.execute(
-            "INSERT INTO chats(chat_title, chat_type, last_message_time, channel, external_chat_id)
-             VALUES(?1, ?2, ?3, ?4, ?5)
+            "INSERT INTO chats(chat_title, chat_type, last_message_time, channel, external_chat_id, agent_id)
+             VALUES(?1, ?2, ?3, ?4, ?5, ?6)
              ON CONFLICT(channel, external_chat_id) DO UPDATE SET
                 chat_title = COALESCE(excluded.chat_title, chats.chat_title),
                 chat_type = excluded.chat_type,
-                last_message_time = excluded.last_message_time",
-            params![chat_title, chat_type, now, channel, external_chat_id],
+                last_message_time = excluded.last_message_time,
+                agent_id = COALESCE(chats.agent_id, excluded.agent_id)",
+            params![chat_title, chat_type, now, channel, external_chat_id, agent_id],
         )?;
         conn.query_row(
             "SELECT chat_id FROM chats WHERE channel = ?1 AND external_chat_id = ?2 LIMIT 1",
@@ -121,7 +125,8 @@ impl Database {
                     WHERE m.chat_id = c.chat_id
                     ORDER BY m.timestamp DESC
                     LIMIT 1
-                ) AS last_message_preview
+                ) AS last_message_preview,
+                c.agent_id
              FROM chats c
              ORDER BY c.last_message_time DESC, c.chat_id DESC",
         )?;
@@ -140,6 +145,7 @@ impl Database {
                 chat_title,
                 last_message_time: row.get(4)?,
                 last_message_preview: row.get(5)?,
+                agent_id: row.get(6)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()
@@ -626,10 +632,10 @@ mod tests {
         let (db, _dir) = test_db();
 
         let first = db
-            .resolve_or_create_chat_id("cli", "cli:local-dev", Some("local-dev"), "cli")
+            .resolve_or_create_chat_id("cli", "cli:local-dev", Some("local-dev"), "cli", "default")
             .expect("create chat");
         let second = db
-            .resolve_or_create_chat_id("cli", "cli:local-dev", Some("renamed"), "cli")
+            .resolve_or_create_chat_id("cli", "cli:local-dev", Some("renamed"), "cli", "default")
             .expect("reuse chat");
 
         assert_eq!(first, second);
@@ -641,7 +647,7 @@ mod tests {
         let (db, _dir) = test_db();
 
         let chat_id = db
-            .resolve_or_create_chat_id("cli", "cli:demo", Some("demo"), "cli")
+            .resolve_or_create_chat_id("cli", "cli:demo", Some("demo"), "cli", "default")
             .expect("create chat");
         store_msg(&db, "msg-1", chat_id, "hello", "2024-01-01T00:00:00Z");
         db.save_session(chat_id, r#"[{"role":"user","content":"hello"}]"#)
@@ -659,6 +665,7 @@ mod tests {
                 &format!("cli:{}", sessions[0].surface_thread),
                 sessions[0].chat_title.as_deref(),
                 "cli",
+                "default",
             )
             .expect("reopen chat");
         assert_eq!(reopened_chat_id, chat_id);
@@ -668,7 +675,7 @@ mod tests {
     fn update_tool_call_output_fails_when_tool_call_is_missing() {
         let (db, _dir) = test_db();
         let chat_id = db
-            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web")
+            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web", "default")
             .expect("create chat");
 
         let error = db
@@ -687,7 +694,7 @@ mod tests {
     fn update_tool_call_output_updates_existing_record() {
         let (db, _dir) = test_db();
         let chat_id = db
-            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web")
+            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web", "default")
             .expect("create chat");
         let tool_call = ToolCall {
             id: "tool-1".to_string(),
@@ -718,7 +725,7 @@ mod tests {
     fn tool_call_ids_are_scoped_by_message() {
         let (db, _dir) = test_db();
         let chat_id = db
-            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web")
+            .resolve_or_create_chat_id("web", "web:message-1", Some("message-1"), "web", "default")
             .expect("create chat");
         let first = ToolCall {
             id: "tool-1".to_string(),
@@ -797,5 +804,98 @@ mod tests {
             .expect("log usage");
 
         assert!(row_id > 0);
+    }
+
+    #[test]
+    fn resolve_or_create_chat_id_sets_agent_id() {
+        let (db, _dir) = test_db();
+
+        db.resolve_or_create_chat_id("cli", "cli:mybot", Some("mybot"), "cli", "mybot")
+            .expect("create chat");
+
+        let info = db
+            .get_chat_by_id(
+                db.resolve_or_create_chat_id("cli", "cli:mybot", Some("mybot"), "cli", "mybot")
+                    .expect("chat id"),
+            )
+            .expect("chat info")
+            .expect("chat should exist");
+
+        assert_eq!(info.agent_id, "mybot");
+    }
+
+    #[test]
+    fn resolve_or_create_chat_id_preserves_agent_id_on_update() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id(
+                "cli",
+                "cli:persist-agent",
+                Some("persist-agent"),
+                "cli",
+                "agent_a",
+            )
+            .expect("create with agent_a");
+
+        let second_id = db
+            .resolve_or_create_chat_id(
+                "cli",
+                "cli:persist-agent",
+                Some("persist-agent"),
+                "cli",
+                "agent_b",
+            )
+            .expect("reuse chat");
+
+        assert_eq!(second_id, chat_id);
+
+        let info = db
+            .get_chat_by_id(chat_id)
+            .expect("chat info")
+            .expect("chat should exist");
+
+        assert_eq!(info.agent_id, "agent_a");
+    }
+
+    #[test]
+    fn get_chat_by_id_returns_agent_id() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id(
+                "web",
+                "web:agent-test",
+                Some("agent-test"),
+                "web",
+                "custom-agent",
+            )
+            .expect("create chat");
+
+        let info = db
+            .get_chat_by_id(chat_id)
+            .expect("get chat")
+            .expect("chat should exist");
+
+        assert_eq!(info.agent_id, "custom-agent");
+    }
+
+    #[test]
+    fn list_sessions_includes_agent_id() {
+        let (db, _dir) = test_db();
+
+        db.resolve_or_create_chat_id(
+            "cli",
+            "cli:session-agent",
+            Some("session-agent"),
+            "cli",
+            "list-agent",
+        )
+        .expect("create chat");
+        store_msg(&db, "msg-1", 1, "hello", "2024-01-01T00:00:00Z");
+
+        let sessions = db.list_sessions().expect("list sessions");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].agent_id, "list-agent");
     }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -10,6 +10,7 @@ use crate::config::{
     AgentConfig, AgentId, ChannelConfig, ChannelName, Config, ProviderConfig, ProviderId,
     secret_ref::ResolvedValue,
 };
+use crate::memory::MemoryLoader;
 use crate::runtime::AppState;
 use crate::skills::SkillManager;
 use crate::storage::Database;
@@ -84,6 +85,9 @@ pub(crate) fn build_state_with_provider(
         mcp_manager: None,
         assets: Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
         soul_agents: Arc::new(crate::soul_agents::SoulAgentsLoader::new(&config)),
+        memory_loader: Arc::new(MemoryLoader::new(
+            std::path::PathBuf::from(&config.state_root).join("agents"),
+        )),
         llm_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
     }
 }


### PR DESCRIPTION
## 概要

エージェント単位の長期記憶ファイル（episodic / semantic / prospective）を system prompt に参照情報として注入する基盤を実装。記憶の更新・睡眠バッチは含まない（Phase 2 以降）。

Close #53

## 変更内容

### DB マイグレーション (Migration v4)
- `chats` テーブルに `agent_id TEXT NOT NULL DEFAULT 'lyre'` カラムを追加
- 既存レコードは一律 `'lyre'`（現行 default_agent）に設定

### Storage Layer — agent_id 対応
- `ChatInfo` / `SessionSummary` に `agent_id` フィールド追加
- `resolve_or_create_chat_id` に `agent_id` パラメータ追加（INSERT 時設定、UPDATE 時は上書きしない）
- 全呼び出し箇所（session.rs, slash_commands.rs, turn.rs, guards.rs, compaction.rs）を更新

### Memory Loader Module（新規 `src/memory.rs`）
- `MemoryLoader` 構造体: `agents/{agent_id}/memory/` 配下の3ファイルを読み込み
- mtime ベースのキャッシュ機構（`SoulAgentsLoader` パターンを踏襲）
- パス検証（`safe_agent_id`）でパストラバーサルを防止

### AppState 統合
- `AppState` に `memory_loader: Arc<MemoryLoader>` フィールド追加
- `build_app_state_with_path` で初期化

### System Prompt 注入
- `build_memory_prompt_section` 関数を追加
- Agents セクションと Skills セクションの間に "Long-term Memory" セクションを挿入
- 記憶は参照情報（reference-only）として注入 — 命令とは明確に区別

### ドキュメント更新
- `docs/db.md`: agent_id カラム・migration v4 説明・ER 図更新・Rust 構造体マッピング更新
- `docs/system-prompt.md`: ⑤ Long-term Memory セクション追加
- `docs/directory.md`: `agents/{agent_id}/memory/` ディレクトリ構造を追加

## コミット分割

1. `feat(storage): add NOT NULL agent_id column to chats table via migration v4`
2. `feat(storage): propagate agent_id through chat creation and queries`
3. `feat(memory): add MemoryLoader for reading agent long-term memory files`
4. `feat(runtime): integrate MemoryLoader into AppState`
5. `feat(agent-loop): inject long-term memory into system prompt as reference`
6. `docs: update db, system-prompt, and directory docs for long-term memory Phase 1`

## テスト

**全 515 テスト通過**（新規 26 テスト追加）

| カテゴリ | テスト数 |
|---|---|
| DB Migration v4 | 4 |
| Storage Queries (agent_id) | 4 |
| Memory Loader | 11 |
| System Prompt Injection | 7 |

## 動作確認

- `cargo fmt --check` ✅
- `cargo check -p egopulse` ✅
- `cargo test -p egopulse` ✅ (515 passed)
- `cargo clippy -p egopulse --all-targets --all-features -- -D warnings` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * エージェント別の長期メモリ（エピソード／セマンティック／プロスペクティブ）の読み込み、キャッシュ、プロンプトへの注入を導入
  * 各会話にエージェントIDを紐付けてエージェント単位でセッションを管理

* **Documentation**
  * SQLiteスキーマをv4へ更新（chatsにagent_id追加、マイグレーション例を記載）
  * システムプロンプトにLong-term Memory注入仕様とagents/{agent_id}/memory構成を追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->