### PR TITLE
feat: long-term memory Phase 2 — DB 監査基盤

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -21,15 +21,17 @@ egopulse.db (SQLite / WAL mode)
 ├── messages            — メッセージ履歴
 ├── sessions            — セッションスナップショット（シリアライズ済み会話）
 ├── tool_calls          — ツール呼び出し記録
-└── llm_usage_logs      — LLM API 使用量ログ
+├── llm_usage_logs      — LLM API 使用量ログ
+├── sleep_runs          — スリープバッチ実行履歴
+└── memory_snapshots    — スリープ実行中のメモリファイル更新履歴
 ```
 
 | 項目 | 値 |
 |------|----|
-| テーブル数 | 7（データテーブル 5 + マイグレーション基盤テーブル 2） |
-| インデックス数 | 6 |
+| テーブル数 | 9（データテーブル 7 + マイグレーション基盤テーブル 2） |
+| インデックス数 | 10 |
 | 外部キー制約 | 1（tool_calls.chat_id → chats.chat_id） |
-| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v4） |
+| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v5） |
 | DBライブラリ | rusqlite 0.37（bundled） |
 | DBファイル | `{data_dir}/egopulse.db` |
 | 接続ラッパー | `Mutex<Connection>` |
@@ -89,6 +91,25 @@ egopulse.db (SQLite / WAL mode)
                 │ request_kind     │
                 │ created_at       │
                 └──────────────────┘
+
+        ┌──────────────────┐       ┌──────────────────┐
+        │   sleep_runs     │1    * │memory_snapshots  │
+        │──────────────────│───────│──────────────────│
+        │ id (PK)          │       │ id (PK)          │
+        │ agent_id         │       │ run_id           │
+        │ status           │       │ agent_id         │
+        │ trigger_type     │       │ phase            │
+        │ started_at       │       │ file             │
+        │ finished_at      │       │ content_before   │
+        │ source_chats_json│       │ content_after    │
+        │ source_digest_md │       │ created_at       │
+        │ phases_json      │       └──────────────────┘
+        │ summary_md       │
+        │ input_tokens     │
+        │ output_tokens    │
+        │ total_tokens     │
+        │ error_message    │
+        └──────────────────┘
 
 ┌──────────────────┐       ┌──────────────────┐
 │    db_meta       │       │ schema_migrations│
@@ -296,6 +317,109 @@ CREATE INDEX IF NOT EXISTS idx_llm_usage_created
 
 ---
 
+### sleep_runs
+
+スリープバッチ（記憶整理処理）の実行履歴。
+
+```sql
+CREATE TABLE IF NOT EXISTS sleep_runs (
+    id                  TEXT PRIMARY KEY,
+    agent_id            TEXT NOT NULL,
+    status              TEXT NOT NULL,
+    trigger_type        TEXT NOT NULL,
+    started_at          TEXT NOT NULL,
+    finished_at         TEXT,
+    source_chats_json   TEXT NOT NULL DEFAULT '[]',
+    source_digest_md    TEXT,
+    phases_json         TEXT NOT NULL DEFAULT '[]',
+    summary_md          TEXT,
+    input_tokens        INTEGER NOT NULL DEFAULT 0,
+    output_tokens       INTEGER NOT NULL DEFAULT 0,
+    total_tokens        INTEGER NOT NULL DEFAULT 0,
+    error_message       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sleep_runs_agent_started
+    ON sleep_runs(agent_id, started_at);
+
+CREATE INDEX IF NOT EXISTS idx_sleep_runs_agent_status
+    ON sleep_runs(agent_id, status);
+```
+
+| カラム | 型 | 制約 | 説明 |
+|--------|----|------|------|
+| id | TEXT | PK | UUID v4 |
+| agent_id | TEXT | NOT NULL | エージェント識別子 |
+| status | TEXT | NOT NULL | 実行状態（running/success/failed/skipped） |
+| trigger_type | TEXT | NOT NULL | 起動トリガー（manual/scheduled） |
+| started_at | TEXT | NOT NULL | 開始時刻（RFC3339） |
+| finished_at | TEXT | nullable | 終了時刻（RFC3339） |
+| source_chats_json | TEXT | NOT NULL DEFAULT '[]' | 対象チャットID一覧（JSON配列） |
+| source_digest_md | TEXT | nullable | ソースダイジェスト（Markdown） |
+| phases_json | TEXT | NOT NULL DEFAULT '[]' | 実行フェーズ一覧（JSON配列） |
+| summary_md | TEXT | nullable | 実行サマリー（Markdown） |
+| input_tokens | INTEGER | NOT NULL DEFAULT 0 | 入力トークン数 |
+| output_tokens | INTEGER | NOT NULL DEFAULT 0 | 出力トークン数 |
+| total_tokens | INTEGER | NOT NULL DEFAULT 0 | 合計トークン数 |
+| error_message | TEXT | nullable | エラーメッセージ |
+
+**操作**:
+- `create_sleep_run(agent_id, trigger)` — INSERT（status=running, id/started_at 自動生成）
+- `update_sleep_run_success(id, ...)` — status=success 更新
+- `update_sleep_run_failed(id, error_message)` — status=failed 更新
+- `update_sleep_run_skipped(id)` — status=skipped 更新
+- `get_sleep_run(id)` — id で取得
+- `list_sleep_runs(agent_id, limit)` — agent_id 絞り込み + started_at 降順
+- `get_latest_successful_run(agent_id)` — success の最新1件
+
+**設計ポイント**:
+- `trigger` は SQLite 予約語のため `trigger_type` にリネーム
+- 外部キー制約なし（アプリケーション層で整合性担保）
+
+---
+
+### memory_snapshots
+
+スリープ実行中のメモリファイル更新履歴。各フェーズにおけるファイルの before/after を記録。
+
+```sql
+CREATE TABLE IF NOT EXISTS memory_snapshots (
+    id              TEXT PRIMARY KEY,
+    run_id          TEXT NOT NULL,
+    agent_id        TEXT NOT NULL,
+    phase           TEXT NOT NULL,
+    file            TEXT NOT NULL,
+    content_before  TEXT NOT NULL,
+    content_after   TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_snapshots_run_id
+    ON memory_snapshots(run_id);
+
+CREATE INDEX IF NOT EXISTS idx_memory_snapshots_agent_created
+    ON memory_snapshots(agent_id, created_at);
+```
+
+| カラム | 型 | 制約 | 説明 |
+|--------|----|------|------|
+| id | TEXT | PK | UUID v4 |
+| run_id | TEXT | NOT NULL | sleep_runs.id への参照 |
+| agent_id | TEXT | NOT NULL | エージェント識別子 |
+| phase | TEXT | NOT NULL | 実行フェーズ（pruning/consolidation/compression） |
+| file | TEXT | NOT NULL | 対象ファイル（episodic/semantic/prospective） |
+| content_before | TEXT | NOT NULL | 更新前のファイル内容 |
+| content_after | TEXT | NOT NULL | 更新後のファイル内容 |
+| created_at | TEXT | NOT NULL | 作成時刻（RFC3339） |
+
+**操作**:
+- `create_memory_snapshot(run_id, agent_id, phase, file, content_before, content_after)` — INSERT
+- `get_snapshots_for_run(run_id)` — run_id 絞り込み + created_at 昇順
+- `get_snapshots_for_agent(agent_id, limit)` — agent_id 絞り込み + created_at 降順
+- `get_latest_snapshot_for_file(agent_id, file)` — agent+file の最新1件
+
+---
+
 ### db_meta
 
 スキーマバージョンの key-value ストア。現在は `schema_version` のみ格納。
@@ -353,6 +477,8 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 | `ToolCall` | tool_calls | id, chat_id, message_id, tool_name, tool_input, tool_output, timestamp |
 | `LlmUsageSummary` | llm_usage_logs（集計） | requests, input_tokens, output_tokens, total_tokens, last_request_at |
 | `LlmModelUsageSummary` | llm_usage_logs（モデル別集計） | model, requests, input_tokens, output_tokens, total_tokens |
+| `SleepRun` | sleep_runs | id, agent_id, status, trigger, started_at, finished_at, source_chats_json, source_digest_md, phases_json, summary_md, input_tokens, output_tokens, total_tokens, error_message |
+| `MemorySnapshot` | memory_snapshots | id, run_id, agent_id, phase, file, content_before, content_after, created_at |
 
 ---
 
@@ -367,14 +493,14 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 2. `schema_version(conn)` で `db_meta` テーブルから現在のバージョンを取得（未設定時は `0`）
 3. `if version < N` ブロックで未適用のマイグレーションを逐次実行
 4. 各マイグレーション適用後に `set_schema_version(conn, N, "note")` でバージョンを更新し `schema_migrations` に履歴を記録
-5. `SCHEMA_VERSION` 定数（現行 `4`）に到達したら完了。`debug_assert_eq!` で検証
+5. `SCHEMA_VERSION` 定数（現行 `5`）に到達したら完了。`debug_assert_eq!` で検証
 
 **新規マイグレーションの追加手順**:
-1. `SCHEMA_VERSION` 定数をインクリメント（例: `4` → `5`）
-2. `run_migrations()` に `if version < 5 { ... }` ブロックを追加
+1. `SCHEMA_VERSION` 定数をインクリメント（例: `5` → `6`）
+2. `run_migrations()` に `if version < 6 { ... }` ブロックを追加
 3. ブロック内で `conn.execute_batch("ALTER TABLE ...")` 等の DDL を実行
 4. 破壊的 DDL や複数ステートメントを伴う場合は transaction 内で実行する
-5. `set_schema_version(conn, 5, "description")` または transaction 用 helper を呼び出し
+5. `set_schema_version(conn, 6, "description")` または transaction 用 helper を呼び出し
 
 ```rust
 // 現行の v2 -> v3 例（storage.rs 内）

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,6 +194,8 @@ pub enum StorageError {
     SessionSnapshotConflict,
     #[error("storage_not_found: {0}")]
     NotFound(String),
+    #[error("storage_conflict: {0}")]
+    Conflict(String),
 }
 
 /// Channel (Web / Discord / Telegram) operational errors.

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -1364,7 +1364,8 @@ agents:
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("egopulse.config.yaml");
         std::fs::write(&path, yaml).expect("write config");
-        let config = Config::load_allow_missing_api_key(Some(&path)).expect("load config");
+        let mut config = Config::load_allow_missing_api_key(Some(&path)).expect("load config");
+        config.state_root = dir.path().to_string_lossy().into_owned();
         let mut state = build_state(config, Box::new(NoOpProvider));
         state.config_path = Some(path.clone());
         (state, dir, path)

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -8,7 +8,7 @@ use crate::error::StorageError;
 ///
 /// 新しいマイグレーションを追加する際はこの値をインクリメントし、
 /// `run_migrations` に対応する `if version < N` ブロックを追加する。
-pub(super) const SCHEMA_VERSION: i64 = 4;
+pub(super) const SCHEMA_VERSION: i64 = 5;
 
 /// `db_meta` に格納されたスキーマバージョンを読み取る。
 ///
@@ -209,6 +209,56 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
         version = 4;
     }
 
+    if version < 5 {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sleep_runs (
+                id                  TEXT PRIMARY KEY,
+                agent_id            TEXT NOT NULL,
+                status              TEXT NOT NULL,
+                trigger_type        TEXT NOT NULL,
+                started_at          TEXT NOT NULL,
+                finished_at         TEXT,
+                source_chats_json   TEXT NOT NULL DEFAULT '[]',
+                source_digest_md    TEXT,
+                phases_json         TEXT NOT NULL DEFAULT '[]',
+                summary_md          TEXT,
+                input_tokens        INTEGER NOT NULL DEFAULT 0,
+                output_tokens       INTEGER NOT NULL DEFAULT 0,
+                total_tokens        INTEGER NOT NULL DEFAULT 0,
+                error_message       TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_sleep_runs_agent_started
+                ON sleep_runs(agent_id, started_at);
+
+            CREATE INDEX IF NOT EXISTS idx_sleep_runs_agent_status
+                ON sleep_runs(agent_id, status);
+
+            CREATE TABLE IF NOT EXISTS memory_snapshots (
+                id              TEXT PRIMARY KEY,
+                run_id          TEXT NOT NULL,
+                agent_id        TEXT NOT NULL,
+                phase           TEXT NOT NULL,
+                file            TEXT NOT NULL,
+                content_before  TEXT NOT NULL,
+                content_after   TEXT NOT NULL,
+                created_at      TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_memory_snapshots_run_id
+                ON memory_snapshots(run_id);
+
+            CREATE INDEX IF NOT EXISTS idx_memory_snapshots_agent_created
+                ON memory_snapshots(agent_id, created_at);",
+        )?;
+        set_schema_version(
+            conn,
+            5,
+            "add sleep_runs and memory_snapshots tables for long-term memory audit",
+        )?;
+        version = 5;
+    }
+
     debug_assert_eq!(version, SCHEMA_VERSION, "all migrations applied");
     Ok(())
 }
@@ -237,7 +287,7 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .expect("collect");
 
-        assert_eq!(rows.len(), 4);
+        assert_eq!(rows.len(), 5);
         assert_eq!(rows[0].0, 1);
         assert!(rows[0].1.contains("initial schema"));
         assert_eq!(rows[1].0, 2);
@@ -246,6 +296,8 @@ mod tests {
         assert!(rows[2].1.contains("tool call"));
         assert_eq!(rows[3].0, 4);
         assert!(rows[3].1.contains("agent_id"));
+        assert_eq!(rows[4].0, 5);
+        assert!(rows[4].1.contains("sleep_runs"));
     }
 
     #[test]
@@ -454,5 +506,218 @@ mod tests {
             )
             .expect("check table");
         assert!(table_exists);
+    }
+
+    #[test]
+    fn migration_v5_creates_sleep_runs_table() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = super::super::Database::new(&db_path).expect("db");
+
+        let conn = db.conn.lock().expect("lock");
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='sleep_runs'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check table");
+
+        assert!(table_exists);
+    }
+
+    #[test]
+    fn migration_v5_creates_memory_snapshots_table() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = super::super::Database::new(&db_path).expect("db");
+
+        let conn = db.conn.lock().expect("lock");
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='memory_snapshots'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check table");
+
+        assert!(table_exists);
+    }
+
+    #[test]
+    fn migration_v5_creates_four_indexes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = super::super::Database::new(&db_path).expect("db");
+
+        let conn = db.conn.lock().expect("lock");
+
+        let expected_indexes = [
+            "idx_sleep_runs_agent_started",
+            "idx_sleep_runs_agent_status",
+            "idx_memory_snapshots_run_id",
+            "idx_memory_snapshots_agent_created",
+        ];
+
+        for index_name in &expected_indexes {
+            let exists: bool = conn
+                .query_row(
+                    "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='index' AND name = ?1",
+                    [index_name],
+                    |row| row.get(0),
+                )
+                .expect("check index");
+            assert!(exists, "expected index {index_name} to exist");
+        }
+    }
+
+    #[test]
+    fn migration_v5_history_is_recorded() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = super::super::Database::new(&db_path).expect("db");
+
+        let conn = db.conn.lock().expect("lock");
+        let has_v5: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM schema_migrations WHERE version = 5",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check v5 record");
+        assert!(has_v5);
+    }
+
+    #[test]
+    fn migration_v5_from_v4_db() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        std::fs::create_dir_all(db_path.parent().expect("parent")).expect("create dir");
+
+        // Create a full v4 DB with known data
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            conn.execute_batch("PRAGMA journal_mode=WAL;").expect("wal");
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS db_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL, note TEXT);
+                 INSERT OR REPLACE INTO db_meta (key, value) VALUES ('schema_version', '4');
+                 INSERT OR REPLACE INTO schema_migrations (version, applied_at, note) VALUES (4, '2025-01-01T00:00:00Z', 'test v4');
+                 CREATE TABLE IF NOT EXISTS chats (
+                     chat_id INTEGER PRIMARY KEY,
+                     chat_title TEXT,
+                     chat_type TEXT NOT NULL DEFAULT 'private',
+                     last_message_time TEXT NOT NULL,
+                     channel TEXT,
+                     external_chat_id TEXT,
+                     agent_id TEXT NOT NULL DEFAULT 'lyre'
+                 );
+                 CREATE TABLE IF NOT EXISTS messages (
+                     id TEXT NOT NULL,
+                     chat_id INTEGER NOT NULL,
+                     sender_name TEXT NOT NULL,
+                     content TEXT NOT NULL,
+                     is_from_bot INTEGER NOT NULL DEFAULT 0,
+                     timestamp TEXT NOT NULL,
+                     PRIMARY KEY (id, chat_id)
+                 );
+                 CREATE TABLE IF NOT EXISTS sessions (
+                     chat_id INTEGER PRIMARY KEY,
+                     messages_json TEXT NOT NULL,
+                     updated_at TEXT NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS tool_calls (
+                     id TEXT NOT NULL,
+                     chat_id INTEGER NOT NULL,
+                     message_id TEXT NOT NULL,
+                     tool_name TEXT NOT NULL,
+                     tool_input TEXT NOT NULL,
+                     tool_output TEXT,
+                     timestamp TEXT NOT NULL,
+                     PRIMARY KEY (id, chat_id, message_id),
+                     FOREIGN KEY (chat_id) REFERENCES chats(chat_id)
+                 );
+                 CREATE TABLE IF NOT EXISTS llm_usage_logs (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     chat_id INTEGER NOT NULL,
+                     caller_channel TEXT NOT NULL,
+                     provider TEXT NOT NULL,
+                     model TEXT NOT NULL,
+                     input_tokens INTEGER NOT NULL,
+                     output_tokens INTEGER NOT NULL,
+                     total_tokens INTEGER NOT NULL,
+                     request_kind TEXT NOT NULL DEFAULT 'agent_loop',
+                     created_at TEXT NOT NULL
+                 );
+                 INSERT INTO chats (chat_id, chat_title, chat_type, last_message_time)
+                 VALUES (42, 'v4 chat', 'group', '2025-06-15T12:00:00Z');",
+            )
+            .expect("create v4 schema");
+        }
+
+        // Open with Database::new() which runs migrations including v5
+        let db = super::super::Database::new(&db_path).expect("reopen");
+        let conn = db.conn.lock().expect("lock");
+
+        // Verify sleep_runs table exists
+        let sleep_runs_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='sleep_runs'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check sleep_runs table");
+        assert!(sleep_runs_exists);
+
+        // Verify memory_snapshots table exists
+        let memory_snapshots_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='memory_snapshots'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check memory_snapshots table");
+        assert!(memory_snapshots_exists);
+
+        // Verify schema_migrations has version 5 record
+        let has_v5: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM schema_migrations WHERE version = 5",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check v5 record");
+        assert!(has_v5);
+    }
+
+    #[test]
+    fn migration_v5_from_fresh_db() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = super::super::Database::new(&db_path).expect("db");
+
+        let conn = db.conn.lock().expect("lock");
+
+        // Verify all tables from v1-v5 exist
+        let expected_tables = [
+            "chats",
+            "messages",
+            "sessions",
+            "tool_calls",
+            "llm_usage_logs",
+            "sleep_runs",
+            "memory_snapshots",
+        ];
+
+        for table_name in &expected_tables {
+            let exists: bool = conn
+                .query_row(
+                    "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name = ?1",
+                    [table_name],
+                    |row| row.get(0),
+                )
+                .expect("check table");
+            assert!(exists, "expected table {table_name} to exist");
+        }
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,6 @@
+use std::fmt;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -62,6 +64,156 @@ pub(crate) struct ToolCall {
     pub timestamp: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SleepRunStatus {
+    Running,
+    Success,
+    Failed,
+    Skipped,
+}
+
+impl fmt::Display for SleepRunStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Running => write!(f, "running"),
+            Self::Success => write!(f, "success"),
+            Self::Failed => write!(f, "failed"),
+            Self::Skipped => write!(f, "skipped"),
+        }
+    }
+}
+
+impl FromStr for SleepRunStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "running" => Ok(Self::Running),
+            "success" => Ok(Self::Success),
+            "failed" => Ok(Self::Failed),
+            "skipped" => Ok(Self::Skipped),
+            other => Err(format!("invalid sleep run status: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SleepRunTrigger {
+    Manual,
+    Scheduled,
+}
+
+impl fmt::Display for SleepRunTrigger {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Manual => write!(f, "manual"),
+            Self::Scheduled => write!(f, "scheduled"),
+        }
+    }
+}
+
+impl FromStr for SleepRunTrigger {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "manual" => Ok(Self::Manual),
+            "scheduled" => Ok(Self::Scheduled),
+            other => Err(format!("invalid sleep run trigger: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SleepRun {
+    pub id: String,
+    pub agent_id: String,
+    pub status: SleepRunStatus,
+    pub trigger: SleepRunTrigger,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub source_chats_json: String,
+    pub source_digest_md: Option<String>,
+    pub phases_json: String,
+    pub summary_md: Option<String>,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub total_tokens: i64,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotPhase {
+    Pruning,
+    Consolidation,
+    Compression,
+}
+
+impl fmt::Display for SnapshotPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pruning => write!(f, "pruning"),
+            Self::Consolidation => write!(f, "consolidation"),
+            Self::Compression => write!(f, "compression"),
+        }
+    }
+}
+
+impl FromStr for SnapshotPhase {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pruning" => Ok(Self::Pruning),
+            "consolidation" => Ok(Self::Consolidation),
+            "compression" => Ok(Self::Compression),
+            other => Err(format!("invalid snapshot phase: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MemoryFile {
+    Episodic,
+    Semantic,
+    Prospective,
+}
+
+impl fmt::Display for MemoryFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Episodic => write!(f, "episodic"),
+            Self::Semantic => write!(f, "semantic"),
+            Self::Prospective => write!(f, "prospective"),
+        }
+    }
+}
+
+impl FromStr for MemoryFile {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "episodic" => Ok(Self::Episodic),
+            "semantic" => Ok(Self::Semantic),
+            "prospective" => Ok(Self::Prospective),
+            other => Err(format!("invalid memory file: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemorySnapshot {
+    pub id: String,
+    pub run_id: String,
+    pub agent_id: String,
+    pub phase: SnapshotPhase,
+    pub file: MemoryFile,
+    pub content_before: String,
+    pub content_after: String,
+    pub created_at: String,
+}
+
 pub(crate) struct LlmUsageLogEntry<'a> {
     pub chat_id: i64,
     pub caller_channel: &'a str,
@@ -70,6 +222,35 @@ pub(crate) struct LlmUsageLogEntry<'a> {
     pub input_tokens: i64,
     pub output_tokens: i64,
     pub request_kind: &'a str,
+}
+
+const _: () = {
+    const fn assert_display<T: fmt::Display>() {}
+    const fn assert_from_str<T: FromStr>() {}
+
+    assert_display::<SleepRunStatus>();
+    assert_display::<SleepRunTrigger>();
+    assert_display::<SnapshotPhase>();
+    assert_display::<MemoryFile>();
+    assert_from_str::<SleepRunStatus>();
+    assert_from_str::<SleepRunTrigger>();
+    assert_from_str::<SnapshotPhase>();
+    assert_from_str::<MemoryFile>();
+
+    assert_display::<SleepRun>();
+    assert_display::<MemorySnapshot>();
+};
+
+impl fmt::Display for SleepRun {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sleep_run({})", self.id)
+    }
+}
+
+impl fmt::Display for MemorySnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "memory_snapshot({}, {})", self.id, self.phase)
+    }
 }
 
 pub async fn call_blocking<T, F>(db: Arc<Database>, f: F) -> Result<T, StorageError>
@@ -119,5 +300,107 @@ impl Database {
         self.conn
             .lock()
             .map_err(|error| StorageError::InitFailed(error.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn sleep_run_status_display() {
+        assert_eq!(SleepRunStatus::Running.to_string(), "running");
+        assert_eq!(SleepRunStatus::Success.to_string(), "success");
+        assert_eq!(SleepRunStatus::Failed.to_string(), "failed");
+        assert_eq!(SleepRunStatus::Skipped.to_string(), "skipped");
+    }
+
+    #[test]
+    fn sleep_run_trigger_display() {
+        assert_eq!(SleepRunTrigger::Manual.to_string(), "manual");
+        assert_eq!(SleepRunTrigger::Scheduled.to_string(), "scheduled");
+    }
+
+    #[test]
+    fn snapshot_phase_display() {
+        assert_eq!(SnapshotPhase::Pruning.to_string(), "pruning");
+        assert_eq!(SnapshotPhase::Consolidation.to_string(), "consolidation");
+        assert_eq!(SnapshotPhase::Compression.to_string(), "compression");
+    }
+
+    #[test]
+    fn memory_file_display() {
+        assert_eq!(MemoryFile::Episodic.to_string(), "episodic");
+        assert_eq!(MemoryFile::Semantic.to_string(), "semantic");
+        assert_eq!(MemoryFile::Prospective.to_string(), "prospective");
+    }
+
+    #[test]
+    fn sleep_run_status_from_str() {
+        assert_eq!(
+            SleepRunStatus::from_str("running").unwrap(),
+            SleepRunStatus::Running
+        );
+        assert_eq!(
+            SleepRunStatus::from_str("success").unwrap(),
+            SleepRunStatus::Success
+        );
+        assert_eq!(
+            SleepRunStatus::from_str("failed").unwrap(),
+            SleepRunStatus::Failed
+        );
+        assert_eq!(
+            SleepRunStatus::from_str("skipped").unwrap(),
+            SleepRunStatus::Skipped
+        );
+        assert!(SleepRunStatus::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn sleep_run_trigger_from_str() {
+        assert_eq!(
+            SleepRunTrigger::from_str("manual").unwrap(),
+            SleepRunTrigger::Manual
+        );
+        assert_eq!(
+            SleepRunTrigger::from_str("scheduled").unwrap(),
+            SleepRunTrigger::Scheduled
+        );
+        assert!(SleepRunTrigger::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn snapshot_phase_from_str() {
+        assert_eq!(
+            SnapshotPhase::from_str("pruning").unwrap(),
+            SnapshotPhase::Pruning
+        );
+        assert_eq!(
+            SnapshotPhase::from_str("consolidation").unwrap(),
+            SnapshotPhase::Consolidation
+        );
+        assert_eq!(
+            SnapshotPhase::from_str("compression").unwrap(),
+            SnapshotPhase::Compression
+        );
+        assert!(SnapshotPhase::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn memory_file_from_str() {
+        assert_eq!(
+            MemoryFile::from_str("episodic").unwrap(),
+            MemoryFile::Episodic
+        );
+        assert_eq!(
+            MemoryFile::from_str("semantic").unwrap(),
+            MemoryFile::Semantic
+        );
+        assert_eq!(
+            MemoryFile::from_str("prospective").unwrap(),
+            MemoryFile::Prospective
+        );
+        assert!(MemoryFile::from_str("invalid").is_err());
     }
 }

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -620,7 +620,7 @@ impl Database {
                     input_tokens, output_tokens, total_tokens, error_message
              FROM sleep_runs
              WHERE agent_id = ?1
-             ORDER BY started_at DESC
+             ORDER BY started_at DESC, rowid DESC
              LIMIT ?2",
         )?;
         stmt.query_map(params![agent_id, limit], row_to_sleep_run)?
@@ -681,9 +681,7 @@ impl Database {
             ],
         )?;
         if changed == 0 {
-            return Err(StorageError::NotFound(format!(
-                "sleep_run:{run_id}"
-            )));
+            return Err(StorageError::NotFound(format!("sleep_run:{run_id}")));
         }
         Ok(id)
     }

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -21,7 +21,6 @@ fn row_to_stored_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredMess
     })
 }
 
-#[allow(dead_code)]
 fn row_to_sleep_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<SleepRun> {
     let status_str: String = row.get(2)?;
     let status = SleepRunStatus::from_str(&status_str).map_err(|e| {
@@ -485,7 +484,13 @@ impl Database {
     }
 }
 
-#[allow(dead_code)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 2 DB audit queries; exercised by unit tests below, wired into runtime in Phase 3+"
+    )
+)]
 impl Database {
     pub(crate) fn create_sleep_run(
         &self,

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -523,13 +523,14 @@ impl Database {
         let finished_at = chrono::Utc::now().to_rfc3339();
         let total_tokens = input_tokens.saturating_add(output_tokens);
         let status = SleepRunStatus::Success.to_string();
+        let running = SleepRunStatus::Running.to_string();
 
-        conn.execute(
+        let changed = conn.execute(
             "UPDATE sleep_runs
              SET status = ?1, finished_at = ?2, source_chats_json = ?3,
                  source_digest_md = ?4, phases_json = ?5, summary_md = ?6,
                  input_tokens = ?7, output_tokens = ?8, total_tokens = ?9
-             WHERE id = ?10",
+             WHERE id = ?10 AND status = ?11",
             params![
                 status,
                 finished_at,
@@ -541,8 +542,14 @@ impl Database {
                 output_tokens,
                 total_tokens,
                 id,
+                running,
             ],
         )?;
+        if changed == 0 {
+            return Err(StorageError::Conflict(format!(
+                "sleep_run:{id} is not running"
+            )));
+        }
         Ok(())
     }
 
@@ -554,12 +561,18 @@ impl Database {
         let conn = self.lock_conn()?;
         let finished_at = chrono::Utc::now().to_rfc3339();
         let status = SleepRunStatus::Failed.to_string();
+        let running = SleepRunStatus::Running.to_string();
 
-        conn.execute(
+        let changed = conn.execute(
             "UPDATE sleep_runs SET status = ?1, finished_at = ?2, error_message = ?3
-             WHERE id = ?4",
-            params![status, finished_at, error_message, id],
+             WHERE id = ?4 AND status = ?5",
+            params![status, finished_at, error_message, id, running],
         )?;
+        if changed == 0 {
+            return Err(StorageError::Conflict(format!(
+                "sleep_run:{id} is not running"
+            )));
+        }
         Ok(())
     }
 
@@ -567,11 +580,17 @@ impl Database {
         let conn = self.lock_conn()?;
         let finished_at = chrono::Utc::now().to_rfc3339();
         let status = SleepRunStatus::Skipped.to_string();
+        let running = SleepRunStatus::Running.to_string();
 
-        conn.execute(
-            "UPDATE sleep_runs SET status = ?1, finished_at = ?2 WHERE id = ?3",
-            params![status, finished_at, id],
+        let changed = conn.execute(
+            "UPDATE sleep_runs SET status = ?1, finished_at = ?2 WHERE id = ?3 AND status = ?4",
+            params![status, finished_at, id, running],
         )?;
+        if changed == 0 {
+            return Err(StorageError::Conflict(format!(
+                "sleep_run:{id} is not running"
+            )));
+        }
         Ok(())
     }
 
@@ -620,7 +639,7 @@ impl Database {
                     input_tokens, output_tokens, total_tokens, error_message
              FROM sleep_runs
              WHERE agent_id = ?1 AND status = 'success'
-             ORDER BY started_at DESC
+             ORDER BY finished_at DESC
              LIMIT 1",
             params![agent_id],
             row_to_sleep_run,
@@ -646,9 +665,10 @@ impl Database {
         let id = uuid::Uuid::new_v4().to_string();
         let created_at = chrono::Utc::now().to_rfc3339();
 
-        conn.execute(
+        let changed = conn.execute(
             "INSERT INTO memory_snapshots (id, run_id, agent_id, phase, file, content_before, content_after, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+             SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
+             WHERE EXISTS (SELECT 1 FROM sleep_runs WHERE id = ?2 AND agent_id = ?3)",
             params![
                 id,
                 run_id,
@@ -660,6 +680,11 @@ impl Database {
                 created_at,
             ],
         )?;
+        if changed == 0 {
+            return Err(StorageError::NotFound(format!(
+                "sleep_run:{run_id}"
+            )));
+        }
         Ok(id)
     }
 
@@ -1400,6 +1425,17 @@ mod tests {
         .expect("create memory_snapshots table");
     }
 
+    fn ensure_sleep_run_exists(db: &Database, run_id: &str, agent_id: &str) {
+        ensure_sleep_runs_table(db);
+        let conn = db.conn.lock().expect("lock");
+        conn.execute(
+            "INSERT OR IGNORE INTO sleep_runs (id, agent_id, status, trigger_type, started_at)
+             VALUES (?1, ?2, 'running', 'manual', ?3)",
+            rusqlite::params![run_id, agent_id, chrono::Utc::now().to_rfc3339()],
+        )
+        .expect("create sleep run for test snapshot");
+    }
+
     fn create_test_snapshot(
         db: &Database,
         run_id: &str,
@@ -1408,6 +1444,7 @@ mod tests {
         file: MemoryFile,
     ) -> String {
         ensure_memory_snapshots_table(db);
+        ensure_sleep_run_exists(db, run_id, agent_id);
         db.create_memory_snapshot(
             run_id,
             agent_id,

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -1,9 +1,13 @@
+use std::str::FromStr;
+
 use rusqlite::{OptionalExtension, params};
 
 use crate::error::StorageError;
 
 use super::{
-    ChatInfo, Database, LlmUsageLogEntry, SessionSnapshot, SessionSummary, StoredMessage, ToolCall,
+    ChatInfo, Database, LlmUsageLogEntry, MemoryFile, MemorySnapshot, SessionSnapshot,
+    SessionSummary, SleepRun, SleepRunStatus, SleepRunTrigger, SnapshotPhase, StoredMessage,
+    ToolCall,
 };
 
 fn row_to_stored_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredMessage> {
@@ -17,8 +21,77 @@ fn row_to_stored_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredMess
     })
 }
 
+#[allow(dead_code)]
+fn row_to_sleep_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<SleepRun> {
+    let status_str: String = row.get(2)?;
+    let status = SleepRunStatus::from_str(&status_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            2,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    let trigger_str: String = row.get(3)?;
+    let trigger = SleepRunTrigger::from_str(&trigger_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    Ok(SleepRun {
+        id: row.get(0)?,
+        agent_id: row.get(1)?,
+        status,
+        trigger,
+        started_at: row.get(4)?,
+        finished_at: row.get(5)?,
+        source_chats_json: row.get(6)?,
+        source_digest_md: row.get(7)?,
+        phases_json: row.get(8)?,
+        summary_md: row.get(9)?,
+        input_tokens: row.get(10)?,
+        output_tokens: row.get(11)?,
+        total_tokens: row.get(12)?,
+        error_message: row.get(13)?,
+    })
+}
+
+fn row_to_memory_snapshot(row: &rusqlite::Row<'_>) -> rusqlite::Result<MemorySnapshot> {
+    let phase_str: String = row.get(3)?;
+    let phase = SnapshotPhase::from_str(&phase_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    let file_str: String = row.get(4)?;
+    let file = MemoryFile::from_str(&file_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    Ok(MemorySnapshot {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        agent_id: row.get(2)?,
+        phase,
+        file,
+        content_before: row.get(5)?,
+        content_after: row.get(6)?,
+        created_at: row.get(7)?,
+    })
+}
+
 // ---------------------------------------------------------------------------
-// Chats
+// Sleep runs
 // ---------------------------------------------------------------------------
 
 impl Database {
@@ -409,6 +482,238 @@ impl Database {
             ],
         )?;
         Ok(conn.last_insert_rowid())
+    }
+}
+
+#[allow(dead_code)]
+impl Database {
+    pub(crate) fn create_sleep_run(
+        &self,
+        agent_id: &str,
+        trigger: SleepRunTrigger,
+    ) -> Result<String, StorageError> {
+        let conn = self.lock_conn()?;
+        let id = uuid::Uuid::new_v4().to_string();
+        let status = SleepRunStatus::Running.to_string();
+        let started_at = chrono::Utc::now().to_rfc3339();
+
+        conn.execute(
+            "INSERT INTO sleep_runs
+                 (id, agent_id, status, trigger_type, started_at, finished_at,
+                  source_chats_json, source_digest_md, phases_json, summary_md,
+                  input_tokens, output_tokens, total_tokens, error_message)
+             VALUES (?1, ?2, ?3, ?4, ?5, NULL, '[]', NULL, '[]', NULL, 0, 0, 0, NULL)",
+            params![id, agent_id, status, trigger.to_string(), started_at],
+        )?;
+        Ok(id)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn update_sleep_run_success(
+        &self,
+        id: &str,
+        source_chats_json: &str,
+        source_digest_md: Option<&str>,
+        phases_json: &str,
+        summary_md: Option<&str>,
+        input_tokens: i64,
+        output_tokens: i64,
+    ) -> Result<(), StorageError> {
+        let conn = self.lock_conn()?;
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let total_tokens = input_tokens.saturating_add(output_tokens);
+        let status = SleepRunStatus::Success.to_string();
+
+        conn.execute(
+            "UPDATE sleep_runs
+             SET status = ?1, finished_at = ?2, source_chats_json = ?3,
+                 source_digest_md = ?4, phases_json = ?5, summary_md = ?6,
+                 input_tokens = ?7, output_tokens = ?8, total_tokens = ?9
+             WHERE id = ?10",
+            params![
+                status,
+                finished_at,
+                source_chats_json,
+                source_digest_md,
+                phases_json,
+                summary_md,
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                id,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn update_sleep_run_failed(
+        &self,
+        id: &str,
+        error_message: &str,
+    ) -> Result<(), StorageError> {
+        let conn = self.lock_conn()?;
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let status = SleepRunStatus::Failed.to_string();
+
+        conn.execute(
+            "UPDATE sleep_runs SET status = ?1, finished_at = ?2, error_message = ?3
+             WHERE id = ?4",
+            params![status, finished_at, error_message, id],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn update_sleep_run_skipped(&self, id: &str) -> Result<(), StorageError> {
+        let conn = self.lock_conn()?;
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let status = SleepRunStatus::Skipped.to_string();
+
+        conn.execute(
+            "UPDATE sleep_runs SET status = ?1, finished_at = ?2 WHERE id = ?3",
+            params![status, finished_at, id],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn get_sleep_run(&self, id: &str) -> Result<Option<SleepRun>, StorageError> {
+        let conn = self.lock_conn()?;
+        conn.query_row(
+            "SELECT id, agent_id, status, trigger_type, started_at, finished_at,
+                    source_chats_json, source_digest_md, phases_json, summary_md,
+                    input_tokens, output_tokens, total_tokens, error_message
+             FROM sleep_runs WHERE id = ?1",
+            params![id],
+            row_to_sleep_run,
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    pub(crate) fn list_sleep_runs(
+        &self,
+        agent_id: &str,
+        limit: i64,
+    ) -> Result<Vec<SleepRun>, StorageError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, agent_id, status, trigger_type, started_at, finished_at,
+                    source_chats_json, source_digest_md, phases_json, summary_md,
+                    input_tokens, output_tokens, total_tokens, error_message
+             FROM sleep_runs
+             WHERE agent_id = ?1
+             ORDER BY started_at DESC
+             LIMIT ?2",
+        )?;
+        stmt.query_map(params![agent_id, limit], row_to_sleep_run)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub(crate) fn get_latest_successful_run(
+        &self,
+        agent_id: &str,
+    ) -> Result<Option<SleepRun>, StorageError> {
+        let conn = self.lock_conn()?;
+        conn.query_row(
+            "SELECT id, agent_id, status, trigger_type, started_at, finished_at,
+                    source_chats_json, source_digest_md, phases_json, summary_md,
+                    input_tokens, output_tokens, total_tokens, error_message
+             FROM sleep_runs
+             WHERE agent_id = ?1 AND status = 'success'
+             ORDER BY started_at DESC
+             LIMIT 1",
+            params![agent_id],
+            row_to_sleep_run,
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Memory snapshots
+    // ---------------------------------------------------------------------------
+
+    pub(crate) fn create_memory_snapshot(
+        &self,
+        run_id: &str,
+        agent_id: &str,
+        phase: SnapshotPhase,
+        file: MemoryFile,
+        content_before: &str,
+        content_after: &str,
+    ) -> Result<String, StorageError> {
+        let conn = self.lock_conn()?;
+        let id = uuid::Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+
+        conn.execute(
+            "INSERT INTO memory_snapshots (id, run_id, agent_id, phase, file, content_before, content_after, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                id,
+                run_id,
+                agent_id,
+                phase.to_string(),
+                file.to_string(),
+                content_before,
+                content_after,
+                created_at,
+            ],
+        )?;
+        Ok(id)
+    }
+
+    pub(crate) fn get_snapshots_for_run(
+        &self,
+        run_id: &str,
+    ) -> Result<Vec<MemorySnapshot>, StorageError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, run_id, agent_id, phase, file, content_before, content_after, created_at
+             FROM memory_snapshots
+             WHERE run_id = ?1
+             ORDER BY created_at ASC",
+        )?;
+        stmt.query_map(params![run_id], row_to_memory_snapshot)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub(crate) fn get_snapshots_for_agent(
+        &self,
+        agent_id: &str,
+        limit: i64,
+    ) -> Result<Vec<MemorySnapshot>, StorageError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, run_id, agent_id, phase, file, content_before, content_after, created_at
+             FROM memory_snapshots
+             WHERE agent_id = ?1
+             ORDER BY created_at DESC
+             LIMIT ?2",
+        )?;
+        stmt.query_map(params![agent_id, limit], row_to_memory_snapshot)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub(crate) fn get_latest_snapshot_for_file(
+        &self,
+        agent_id: &str,
+        file: MemoryFile,
+    ) -> Result<Option<MemorySnapshot>, StorageError> {
+        let conn = self.lock_conn()?;
+        conn.query_row(
+            "SELECT id, run_id, agent_id, phase, file, content_before, content_after, created_at
+             FROM memory_snapshots
+             WHERE agent_id = ?1 AND file = ?2
+             ORDER BY created_at DESC
+             LIMIT 1",
+            params![agent_id, file.to_string()],
+            row_to_memory_snapshot,
+        )
+        .optional()
+        .map_err(Into::into)
     }
 }
 
@@ -897,5 +1202,438 @@ mod tests {
         let sessions = db.list_sessions().expect("list sessions");
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].agent_id, "list-agent");
+    }
+
+    fn ensure_sleep_runs_table(db: &Database) {
+        let conn = db.conn.lock().expect("lock");
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sleep_runs (
+                id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'running',
+                trigger_type TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT,
+                source_chats_json TEXT NOT NULL DEFAULT '[]',
+                source_digest_md TEXT,
+                phases_json TEXT NOT NULL DEFAULT '[]',
+                summary_md TEXT,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                total_tokens INTEGER NOT NULL DEFAULT 0,
+                error_message TEXT
+            )",
+        )
+        .expect("create sleep_runs table");
+    }
+
+    fn create_test_sleep_run(db: &Database, agent_id: &str) -> String {
+        ensure_sleep_runs_table(db);
+        db.create_sleep_run(agent_id, SleepRunTrigger::Manual)
+            .expect("create sleep run")
+    }
+
+    #[test]
+    fn create_sleep_run_inserts_with_running_status() {
+        let (db, _dir) = test_db();
+        let id = create_test_sleep_run(&db, "agent-a");
+
+        let run = db.get_sleep_run(&id).expect("get").expect("run exists");
+        assert_eq!(run.status, SleepRunStatus::Running);
+    }
+
+    #[test]
+    fn create_sleep_run_generates_id_and_timestamp() {
+        let (db, _dir) = test_db();
+        let id = create_test_sleep_run(&db, "agent-a");
+
+        assert!(id.contains('-'), "UUID v4 should contain hyphens");
+
+        let run = db.get_sleep_run(&id).expect("get").expect("run exists");
+        assert!(
+            run.started_at.contains('T'),
+            "RFC3339 timestamp should contain 'T'"
+        );
+    }
+
+    #[test]
+    fn update_sleep_run_to_success() {
+        let (db, _dir) = test_db();
+        let id = create_test_sleep_run(&db, "agent-a");
+
+        db.update_sleep_run_success(
+            &id,
+            r#"[1, 2, 3]"#,
+            Some("digest-abc"),
+            r#"[{"phase":"pruning"}]"#,
+            Some("# Summary"),
+            100,
+            50,
+        )
+        .expect("update success");
+
+        let run = db.get_sleep_run(&id).expect("get").expect("run exists");
+        assert_eq!(run.status, SleepRunStatus::Success);
+        assert!(run.finished_at.is_some());
+        assert_eq!(run.total_tokens, 150);
+        assert_eq!(run.source_chats_json, r#"[1, 2, 3]"#);
+        assert_eq!(run.source_digest_md.as_deref(), Some("digest-abc"));
+        assert_eq!(run.phases_json, r#"[{"phase":"pruning"}]"#);
+        assert_eq!(run.summary_md.as_deref(), Some("# Summary"));
+    }
+
+    #[test]
+    fn update_sleep_run_to_failed() {
+        let (db, _dir) = test_db();
+        let id = create_test_sleep_run(&db, "agent-a");
+
+        db.update_sleep_run_failed(&id, "LLM timeout")
+            .expect("update failed");
+
+        let run = db.get_sleep_run(&id).expect("get").expect("run exists");
+        assert_eq!(run.status, SleepRunStatus::Failed);
+        assert_eq!(run.error_message.as_deref(), Some("LLM timeout"));
+    }
+
+    #[test]
+    fn update_sleep_run_to_skipped() {
+        let (db, _dir) = test_db();
+        let id = create_test_sleep_run(&db, "agent-a");
+
+        db.update_sleep_run_skipped(&id).expect("update skipped");
+
+        let run = db.get_sleep_run(&id).expect("get").expect("run exists");
+        assert_eq!(run.status, SleepRunStatus::Skipped);
+    }
+
+    #[test]
+    fn get_sleep_run_by_id() {
+        let (db, _dir) = test_db();
+        let id = create_test_sleep_run(&db, "agent-a");
+
+        let run = db.get_sleep_run(&id).expect("get").expect("run exists");
+        assert_eq!(run.id, id);
+        assert_eq!(run.agent_id, "agent-a");
+        assert_eq!(run.trigger, SleepRunTrigger::Manual);
+        assert_eq!(run.source_chats_json, "[]");
+        assert_eq!(run.phases_json, "[]");
+        assert_eq!(run.input_tokens, 0);
+        assert_eq!(run.output_tokens, 0);
+        assert_eq!(run.total_tokens, 0);
+    }
+
+    #[test]
+    fn get_sleep_run_returns_none_for_missing() {
+        let (db, _dir) = test_db();
+        ensure_sleep_runs_table(&db);
+
+        let result = db.get_sleep_run("nonexistent-id").expect("get");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn list_sleep_runs_by_agent() {
+        let (db, _dir) = test_db();
+
+        let _id_a1 = create_test_sleep_run(&db, "agent-a");
+        let id_a2 = create_test_sleep_run(&db, "agent-a");
+        let id_a3 = create_test_sleep_run(&db, "agent-a");
+        let _id_b1 = create_test_sleep_run(&db, "agent-b");
+
+        let runs = db.list_sleep_runs("agent-a", 2).expect("list");
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].id, id_a3);
+        assert_eq!(runs[1].id, id_a2);
+    }
+
+    #[test]
+    fn list_sleep_runs_empty() {
+        let (db, _dir) = test_db();
+        ensure_sleep_runs_table(&db);
+
+        let runs = db.list_sleep_runs("nobody", 10).expect("list");
+        assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn get_latest_successful_run() {
+        let (db, _dir) = test_db();
+
+        let id_1 = create_test_sleep_run(&db, "agent-a");
+        db.update_sleep_run_success(&id_1, "[]", None, "[]", None, 10, 5)
+            .expect("success 1");
+
+        let id_2 = create_test_sleep_run(&db, "agent-a");
+        db.update_sleep_run_success(&id_2, "[]", None, "[]", None, 20, 10)
+            .expect("success 2");
+
+        let latest = db
+            .get_latest_successful_run("agent-a")
+            .expect("get latest")
+            .expect("should exist");
+        assert_eq!(latest.id, id_2);
+    }
+
+    #[test]
+    fn get_latest_successful_run_returns_none() {
+        let (db, _dir) = test_db();
+        let _id = create_test_sleep_run(&db, "agent-a");
+
+        let latest = db.get_latest_successful_run("agent-a").expect("get latest");
+        assert!(latest.is_none());
+    }
+
+    fn ensure_memory_snapshots_table(db: &Database) {
+        let conn = db.conn.lock().expect("lock");
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS memory_snapshots (
+                id TEXT PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                phase TEXT NOT NULL,
+                file TEXT NOT NULL,
+                content_before TEXT NOT NULL,
+                content_after TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .expect("create memory_snapshots table");
+    }
+
+    fn create_test_snapshot(
+        db: &Database,
+        run_id: &str,
+        agent_id: &str,
+        phase: SnapshotPhase,
+        file: MemoryFile,
+    ) -> String {
+        ensure_memory_snapshots_table(db);
+        db.create_memory_snapshot(
+            run_id,
+            agent_id,
+            phase,
+            file,
+            "before content",
+            "after content",
+        )
+        .expect("create snapshot")
+    }
+
+    #[test]
+    fn create_memory_snapshot_inserts_record() {
+        let (db, _dir) = test_db();
+        let id = create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+
+        let snapshots = db.get_snapshots_for_run("run-1").expect("get snapshots");
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].id, id);
+        assert_eq!(snapshots[0].run_id, "run-1");
+        assert_eq!(snapshots[0].agent_id, "agent-a");
+        assert_eq!(snapshots[0].phase, SnapshotPhase::Pruning);
+        assert_eq!(snapshots[0].file, MemoryFile::Episodic);
+        assert_eq!(snapshots[0].content_before, "before content");
+        assert_eq!(snapshots[0].content_after, "after content");
+    }
+
+    #[test]
+    fn create_memory_snapshot_generates_id_and_timestamp() {
+        let (db, _dir) = test_db();
+        let id = create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Consolidation,
+            MemoryFile::Semantic,
+        );
+        assert!(id.contains('-'), "UUID v4 should contain hyphens");
+
+        let snapshots = db.get_snapshots_for_run("run-1").expect("get snapshots");
+        assert!(
+            snapshots[0].created_at.contains('T'),
+            "RFC3339 timestamp should contain 'T'"
+        );
+    }
+
+    #[test]
+    fn get_snapshots_for_run() {
+        let (db, _dir) = test_db();
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Consolidation,
+            MemoryFile::Semantic,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Compression,
+            MemoryFile::Prospective,
+        );
+        create_test_snapshot(
+            &db,
+            "run-2",
+            "agent-b",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+
+        let run1_snapshots = db.get_snapshots_for_run("run-1").expect("get snapshots");
+        assert_eq!(run1_snapshots.len(), 3);
+        assert_eq!(run1_snapshots[0].phase, SnapshotPhase::Pruning);
+        assert_eq!(run1_snapshots[1].phase, SnapshotPhase::Consolidation);
+        assert_eq!(run1_snapshots[2].phase, SnapshotPhase::Compression);
+    }
+
+    #[test]
+    fn get_snapshots_for_run_empty() {
+        let (db, _dir) = test_db();
+        ensure_memory_snapshots_table(&db);
+        let snapshots = db
+            .get_snapshots_for_run("nonexistent")
+            .expect("get snapshots");
+        assert!(snapshots.is_empty());
+    }
+
+    #[test]
+    fn get_snapshots_for_agent() {
+        let (db, _dir) = test_db();
+        let id_a1 = create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let id_a2 = create_test_snapshot(
+            &db,
+            "run-2",
+            "agent-a",
+            SnapshotPhase::Consolidation,
+            MemoryFile::Semantic,
+        );
+        let _id_b = create_test_snapshot(
+            &db,
+            "run-3",
+            "agent-b",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+
+        let agent_a_snapshots = db
+            .get_snapshots_for_agent("agent-a", 10)
+            .expect("get snapshots");
+        assert_eq!(agent_a_snapshots.len(), 2);
+        assert_eq!(agent_a_snapshots[0].id, id_a2);
+        assert_eq!(agent_a_snapshots[1].id, id_a1);
+    }
+
+    #[test]
+    fn get_snapshots_filters_by_phase() {
+        let (db, _dir) = test_db();
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Consolidation,
+            MemoryFile::Episodic,
+        );
+
+        let snapshots = db.get_snapshots_for_run("run-1").expect("get snapshots");
+        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].phase, SnapshotPhase::Pruning);
+        assert_eq!(snapshots[1].phase, SnapshotPhase::Consolidation);
+    }
+
+    #[test]
+    fn get_snapshots_filters_by_file() {
+        let (db, _dir) = test_db();
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Consolidation,
+            MemoryFile::Semantic,
+        );
+
+        let latest_episodic = db
+            .get_latest_snapshot_for_file("agent-a", MemoryFile::Episodic)
+            .expect("get latest")
+            .expect("should exist");
+        assert_eq!(latest_episodic.file, MemoryFile::Episodic);
+
+        let latest_semantic = db
+            .get_latest_snapshot_for_file("agent-a", MemoryFile::Semantic)
+            .expect("get latest")
+            .expect("should exist");
+        assert_eq!(latest_semantic.file, MemoryFile::Semantic);
+    }
+
+    #[test]
+    fn get_latest_snapshot_for_file() {
+        let (db, _dir) = test_db();
+        create_test_snapshot(
+            &db,
+            "run-1",
+            "agent-a",
+            SnapshotPhase::Pruning,
+            MemoryFile::Episodic,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let id2 = create_test_snapshot(
+            &db,
+            "run-2",
+            "agent-a",
+            SnapshotPhase::Consolidation,
+            MemoryFile::Episodic,
+        );
+
+        let latest = db
+            .get_latest_snapshot_for_file("agent-a", MemoryFile::Episodic)
+            .expect("get latest")
+            .expect("should exist");
+        assert_eq!(latest.id, id2);
+    }
+
+    #[test]
+    fn get_latest_snapshot_returns_none() {
+        let (db, _dir) = test_db();
+        ensure_memory_snapshots_table(&db);
+        let result = db
+            .get_latest_snapshot_for_file("agent-a", MemoryFile::Episodic)
+            .expect("get latest");
+        assert!(result.is_none());
     }
 }


### PR DESCRIPTION
## Summary

睡眠バッチの実行履歴（`sleep_runs`）と記憶ファイル更新履歴（`memory_snapshots`）を追跡する DB テーブル・CRUD クエリを実装する。実際のバッチ実行・LLM 呼び出しは含まない。

Close #54

## 変更内容

| 対象 | 内容 |
|---|---|
| `src/storage/mod.rs` | `SleepRun` / `MemorySnapshot` 構造体、4 enum（`SleepRunStatus` / `SleepRunTrigger` / `SnapshotPhase` / `MemoryFile`）+ `Display` / `FromStr` 実装 |
| `src/storage/migration.rs` | Migration v5 追加（`sleep_runs` / `memory_snapshots` テーブル + 4 インデックス） |
| `src/storage/queries.rs` | `sleep_runs` CRUD（7 関数）+ `memory_snapshots` CRUD（4 関数） |
| `docs/db.md` | 新テーブル定義・ER 図・構造体マッピング更新 |
| `src/slash_commands.rs` | テストヘルパーの本番 DB 参照を修正 |

## テストケース（34 件）

- Rust 型 Display/FromStr: 8 件
- DB Migration v5: 6 件
- sleep_runs Queries: 11 件
- memory_snapshots Queries: 9 件

## DoD チェックリスト（#54）

- [x] `sleep_runs` テーブル作成（migration v5）
- [x] `memory_snapshots` テーブル作成（migration v5）
- [x] Rust 型定義（struct + enum + Display/FromStr）
- [x] CRUD クエリ実装
- [x] テスト全件通過（549 passed）
- [x] `cargo fmt` / `cargo clippy` 通過
- [x] `docs/db.md` 更新

## 備考

- `trigger` → `trigger_type` にリネーム（SQLite 予約語回避）
- 外部キー制約なし（既存方針通り）
- ID は UUID v4（既存パターン通り）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * スリープ実行の追跡機能を追加しました。
  * メモリスナップショット管理機能を追加しました。

* **Documentation**
  * データベーススキーマドキュメントを更新し、新テーブルと移行手順を追記しました。

* **Bug Fixes / Improvements**
  * ストレージでの競合を明示するエラー対応を追加しました。

* **Chores**
  * データベーススキーマバージョンを5にアップグレードしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->