### PR TITLE
feat(memory): Phase 3 — 入力収集 (input collection)

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -157,6 +157,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_chats_channel_external_chat_id
 - `resolve_chat_id(channel, external_chat_id)` — 既存チャットの検索
 - `resolve_or_create_chat_id(channel, external_chat_id, chat_title, chat_type)` — Upsert（`ON CONFLICT DO UPDATE`）
 - `get_chat_by_id(chat_id)` — chat_id からチャンネル情報を逆引き
+- `count_agent_messages_since(agent_id, since: Option<&str>)` — agent の新規メッセージ数をカウント（JOIN messages + chats）
+- `get_agent_sessions_since(agent_id, since: Option<&str>, limit)` — agent のセッション一覧を updated_at 降順で取得（JOIN chats + sessions）。message_count と estimated_tokens（chars/3 近似）を含む
 
 ---
 
@@ -370,7 +372,7 @@ CREATE INDEX IF NOT EXISTS idx_sleep_runs_agent_status
 - `update_sleep_run_skipped(id)` — status=skipped 更新
 - `get_sleep_run(id)` — id で取得
 - `list_sleep_runs(agent_id, limit)` — agent_id 絞り込み + started_at 降順
-- `get_latest_successful_run(agent_id)` — success の最新1件
+- `get_latest_successful_run(agent_id)` — success の最新1件。スリープ入力収集（Phase 3）のカットオフタイムスタンプ決定にも使用
 
 **設計ポイント**:
 - `trigger` は SQLite 予約語のため `trigger_type` にリネーム
@@ -474,6 +476,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 | `ChatInfo` | chats（一部） | chat_id, channel, external_chat_id, chat_type, agent_id |
 | `SessionSummary` | chats + messages（JOIN） | chat_id, channel, surface_thread, chat_title, last_message_time, last_message_preview, agent_id |
 | `SessionSnapshot` | sessions + messages | messages_json, updated_at, recent_messages: Vec\<StoredMessage\> |
+| `AgentSessionInfo` | chats + sessions（JOIN） | chat_id, channel, external_chat_id, updated_at, message_count, estimated_tokens |
 | `ToolCall` | tool_calls | id, chat_id, message_id, tool_name, tool_input, tool_output, timestamp |
 | `LlmUsageSummary` | llm_usage_logs（集計） | requests, input_tokens, output_tokens, total_tokens, last_request_at |
 | `LlmModelUsageSummary` | llm_usage_logs（モデル別集計） | model, requests, input_tokens, output_tokens, total_tokens |

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,6 +2,68 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::SystemTime;
 
+use crate::error::StorageError;
+use crate::storage::{AgentSessionInfo, Database};
+
+/// Threshold (≤ 4) at which sleep is skipped due to too few new messages.
+const SKIP_THRESHOLD: i64 = 4;
+/// Maximum number of source sessions included in sleep input.
+const MAX_SOURCE_SESSIONS: usize = 20;
+
+/// Decision from checking whether enough new messages exist for a sleep run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InputDecision {
+    /// Not enough new messages → skip the sleep run.
+    Skip {
+        /// Human-readable reason for the skip.
+        reason: String,
+        /// Number of new messages found (≤ SKIP_THRESHOLD).
+        new_message_count: i64,
+    },
+    /// Enough new messages → proceed with sleep run.
+    Proceed {
+        /// Source sessions (limited to MAX_SOURCE_SESSIONS).
+        sessions: Vec<AgentSessionInfo>,
+        /// JSON array of source chat metadata (for sleep_runs.source_chats_json).
+        source_chats_json: String,
+    },
+}
+
+/// Collects sleep input from the database: counts new messages since the last
+/// successful sleep run, and if above threshold, fetches source session info.
+///
+/// # Errors
+///
+/// Returns [`StorageError`] if DB queries fail.
+#[allow(dead_code)]
+pub(crate) fn collect_sleep_input(
+    db: &Database,
+    agent_id: &str,
+) -> Result<InputDecision, StorageError> {
+    let latest_run = db.get_latest_successful_run(agent_id)?;
+    let cutoff = latest_run.as_ref().and_then(|r| r.finished_at.as_deref());
+
+    let new_message_count = db.count_agent_messages_since(agent_id, cutoff)?;
+
+    if new_message_count <= SKIP_THRESHOLD {
+        let reason =
+            format!("new messages ({new_message_count}) at or below threshold ({SKIP_THRESHOLD})");
+        return Ok(InputDecision::Skip {
+            reason,
+            new_message_count,
+        });
+    }
+
+    let sessions = db.get_agent_sessions_since(agent_id, cutoff, MAX_SOURCE_SESSIONS)?;
+    let source_chats_json =
+        serde_json::to_string(&sessions).map_err(StorageError::SessionSerialize)?;
+
+    Ok(InputDecision::Proceed {
+        sessions,
+        source_chats_json,
+    })
+}
+
 /// Agent long-term memory content loaded from markdown files.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[allow(dead_code)]
@@ -329,5 +391,372 @@ mod tests {
             second.unwrap().episodic,
             Some("updated content".to_string())
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // collect_sleep_input tests
+    // -----------------------------------------------------------------------
+
+    use crate::storage::{Database, SleepRunTrigger};
+
+    fn test_db() -> (Database, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = Database::new(&db_path).expect("db");
+        (db, dir)
+    }
+
+    fn ensure_sleep_runs_table(db: &Database) {
+        let conn = db.conn.lock().expect("lock");
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sleep_runs (
+                id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'running',
+                trigger_type TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT,
+                source_chats_json TEXT NOT NULL DEFAULT '[]',
+                source_digest_md TEXT,
+                phases_json TEXT NOT NULL DEFAULT '[]',
+                summary_md TEXT,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                total_tokens INTEGER NOT NULL DEFAULT 0,
+                error_message TEXT
+            )",
+        )
+        .expect("create sleep_runs table");
+    }
+
+    fn store_msg(db: &Database, id: &str, chat_id: i64, content: &str, ts: &str) {
+        let conn = db.conn.lock().expect("lock");
+        conn.execute(
+            "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![id, chat_id, "alice", content, 0, ts],
+        )
+        .expect("store message");
+    }
+
+    fn create_chat(db: &Database, agent_id: &str, suffix: &str) -> i64 {
+        let ext_id = format!("test:chat{suffix}");
+        db.resolve_or_create_chat_id(
+            "test",
+            &ext_id,
+            Some(&format!("chat{suffix}")),
+            "direct",
+            agent_id,
+        )
+        .expect("create chat")
+    }
+
+    fn create_completed_sleep_run(db: &Database, agent_id: &str) -> String {
+        ensure_sleep_runs_table(db);
+        let run_id = db
+            .create_sleep_run(agent_id, SleepRunTrigger::Manual)
+            .expect("create sleep run");
+        db.update_sleep_run_success(&run_id, "[]", None, "[]", None, 10, 5)
+            .expect("complete sleep run");
+        run_id
+    }
+
+    // --- Test 1: no messages → Skip ---
+
+    #[test]
+    fn collect_returns_skip_when_no_messages() {
+        let (db, _dir) = test_db();
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        match result {
+            InputDecision::Skip {
+                reason,
+                new_message_count,
+            } => {
+                assert_eq!(new_message_count, 0);
+                assert!(reason.contains("0"));
+                assert!(reason.contains("threshold"));
+            }
+            other => panic!("expected Skip, got {other:?}"),
+        }
+    }
+
+    // --- Test 2: ≤ 4 messages → Skip ---
+
+    #[test]
+    fn collect_returns_skip_when_below_threshold() {
+        let (db, _dir) = test_db();
+        let chat_id = create_chat(&db, "test-agent", "");
+        store_msg(&db, "m-1", chat_id, "hi", "2025-01-01T00:00:01Z");
+        store_msg(&db, "m-2", chat_id, "hi", "2025-01-01T00:00:02Z");
+        store_msg(&db, "m-3", chat_id, "hi", "2025-01-01T00:00:03Z");
+        store_msg(&db, "m-4", chat_id, "hi", "2025-01-01T00:00:04Z");
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        match result {
+            InputDecision::Skip {
+                reason: _,
+                new_message_count,
+            } => {
+                assert_eq!(new_message_count, 4);
+            }
+            other => panic!("expected Skip, got {other:?}"),
+        }
+    }
+
+    // --- Test 3: 5 messages → Proceed ---
+
+    #[test]
+    fn collect_returns_proceed_above_threshold() {
+        let (db, _dir) = test_db();
+        let chat_id = create_chat(&db, "test-agent", "");
+        for i in 1..=5 {
+            store_msg(
+                &db,
+                &format!("m-{i}"),
+                chat_id,
+                "hi",
+                &format!("2025-01-01T00:00:{i:02}Z"),
+            );
+        }
+        db.save_session(chat_id, r#"[{"role":"user","content":"hi"}]"#)
+            .expect("save session");
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        match result {
+            InputDecision::Proceed {
+                sessions,
+                source_chats_json,
+            } => {
+                assert!(!sessions.is_empty());
+                assert!(!source_chats_json.is_empty());
+                assert!(source_chats_json.starts_with('['));
+            }
+            other => panic!("expected Proceed, got {other:?}"),
+        }
+    }
+
+    // --- Test 4: 10 messages → Proceed ---
+
+    #[test]
+    fn collect_returns_proceed_with_many_messages() {
+        let (db, _dir) = test_db();
+        let chat_id = create_chat(&db, "test-agent", "");
+        for i in 1..=10 {
+            store_msg(
+                &db,
+                &format!("m-{i}"),
+                chat_id,
+                "hi",
+                &format!("2025-01-01T00:00:{i:02}Z"),
+            );
+        }
+        db.save_session(chat_id, r#"[{"role":"user","content":"hi"}]"#)
+            .expect("save session");
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        assert!(matches!(result, InputDecision::Proceed { .. }));
+    }
+
+    // --- Test 5: cutoff = finished_at of last successful run ---
+
+    #[test]
+    fn collect_since_last_successful_run() {
+        let (db, _dir) = test_db();
+        let chat_id = create_chat(&db, "test-agent", "");
+
+        // Create a completed sleep run
+        let run_id = create_completed_sleep_run(&db, "test-agent");
+        let run = db.get_sleep_run(&run_id).expect("get run").expect("exists");
+        let _finished_at = run.finished_at.expect("has finished_at");
+
+        // Insert old messages (BEFORE finished_at) — should NOT be counted
+        store_msg(&db, "old-1", chat_id, "old", "2020-01-01T00:00:01Z");
+        store_msg(&db, "old-2", chat_id, "old", "2020-01-01T00:00:02Z");
+        store_msg(&db, "old-3", chat_id, "old", "2020-01-01T00:00:03Z");
+
+        // Create session
+        db.save_session(chat_id, r#"[{"role":"user","content":"hi"}]"#)
+            .expect("save session");
+
+        // Insert new messages (AFTER finished_at) — timestamps generated
+        // after the sleep run was completed, so they're guaranteed to be later
+        let after_cutoff = chrono::Utc::now().to_rfc3339();
+        store_msg(&db, "new-1", chat_id, "new", &after_cutoff);
+        store_msg(&db, "new-2", chat_id, "new", &after_cutoff);
+        store_msg(&db, "new-3", chat_id, "new", &after_cutoff);
+        store_msg(&db, "new-4", chat_id, "new", &after_cutoff);
+        store_msg(&db, "new-5", chat_id, "new", &after_cutoff);
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        assert!(
+            matches!(result, InputDecision::Proceed { .. }),
+            "5 new messages (> 4 threshold) should trigger Proceed"
+        );
+    }
+
+    // --- Test 6: first run — no previous run → all messages counted ---
+
+    #[test]
+    fn collect_first_run_no_previous_run() {
+        let (db, _dir) = test_db();
+        let chat_id = create_chat(&db, "test-agent", "");
+        for i in 1..=8 {
+            store_msg(
+                &db,
+                &format!("m-{i}"),
+                chat_id,
+                "hi",
+                &format!("2025-01-01T00:00:{i:02}Z"),
+            );
+        }
+        db.save_session(chat_id, r#"[{"role":"user","content":"hi"}]"#)
+            .expect("save session");
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        assert!(
+            matches!(result, InputDecision::Proceed { .. }),
+            "8 messages with no previous run should trigger Proceed"
+        );
+    }
+
+    // --- Test 7: respects MAX_SOURCE_SESSIONS limit (20) ---
+
+    #[test]
+    fn collect_respects_max_sessions_limit() {
+        let (db, _dir) = test_db();
+        for i in 0..25 {
+            let cid = create_chat(&db, "test-agent", &format!("-{i}"));
+            db.save_session(cid, r#"[{"role":"user","content":"hi"}]"#)
+                .expect("save session");
+            store_msg(&db, &format!("m{i}"), cid, "hi", "2025-06-01T00:00:00Z");
+        }
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        match result {
+            InputDecision::Proceed { sessions, .. } => {
+                assert_eq!(sessions.len(), MAX_SOURCE_SESSIONS);
+            }
+            other => panic!("expected Proceed, got {other:?}"),
+        }
+    }
+
+    // --- Test 8: source_chats_json has correct fields ---
+
+    #[test]
+    fn collect_source_chats_json_format() {
+        let (db, _dir) = test_db();
+        let chat_id = create_chat(&db, "test-agent", "");
+        for i in 1..=6 {
+            store_msg(
+                &db,
+                &format!("m-{i}"),
+                chat_id,
+                "hi",
+                &format!("2025-01-01T00:00:{i:02}Z"),
+            );
+        }
+        db.save_session(chat_id, r#"[{"role":"user","content":"hi"}]"#)
+            .expect("save session");
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        let json_str = match &result {
+            InputDecision::Proceed {
+                source_chats_json, ..
+            } => source_chats_json,
+            other => panic!("expected Proceed, got {other:?}"),
+        };
+
+        let parsed: Vec<serde_json::Value> =
+            serde_json::from_str(json_str).expect("valid JSON array");
+        assert!(!parsed.is_empty(), "should contain at least one entry");
+
+        let entry = &parsed[0];
+        assert!(entry.get("chat_id").is_some(), "missing chat_id");
+        assert!(entry.get("channel").is_some(), "missing channel");
+        assert!(
+            entry.get("external_chat_id").is_some(),
+            "missing external_chat_id"
+        );
+        assert!(entry.get("updated_at").is_some(), "missing updated_at");
+        assert!(
+            entry.get("message_count").is_some(),
+            "missing message_count"
+        );
+        assert!(
+            entry.get("estimated_tokens").is_some(),
+            "missing estimated_tokens"
+        );
+    }
+
+    // --- Test 9: source_chats_json sorted newest first ---
+
+    #[test]
+    fn collect_source_chats_json_sorted_newest_first() {
+        let (db, _dir) = test_db();
+        for i in 0..8 {
+            let cid = create_chat(&db, "test-agent", &format!("-{i}"));
+            store_msg(&db, &format!("m{i}"), cid, "hi", "2025-06-01T00:00:00Z");
+            db.save_session(cid, r#"[{"role":"user","content":"hi"}]"#)
+                .expect("save session");
+        }
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        let json_str = match &result {
+            InputDecision::Proceed {
+                source_chats_json, ..
+            } => source_chats_json,
+            other => panic!("expected Proceed, got {other:?}"),
+        };
+
+        let parsed: Vec<serde_json::Value> =
+            serde_json::from_str(json_str).expect("valid JSON array");
+        assert!(
+            parsed.len() >= 2,
+            "need at least 2 entries to check ordering"
+        );
+
+        let timestamps: Vec<String> = parsed
+            .iter()
+            .map(|v| v["updated_at"].as_str().unwrap_or("").to_string())
+            .collect();
+
+        // Verify DESC order (newest first)
+        for i in 0..timestamps.len() - 1 {
+            assert!(
+                timestamps[i] >= timestamps[i + 1],
+                "expected newest first: {i}='{}' < {j}='{}'",
+                timestamps[i],
+                timestamps[i + 1],
+                j = i + 1,
+            );
+        }
+    }
+
+    // --- Test 10: Skip variant includes reason and count ---
+
+    #[test]
+    fn collect_skip_includes_reason_and_count() {
+        let (db, _dir) = test_db();
+        let chat_id = create_chat(&db, "test-agent", "");
+        store_msg(&db, "m-1", chat_id, "hi", "2025-01-01T00:00:01Z");
+        store_msg(&db, "m-2", chat_id, "hi", "2025-01-01T00:00:02Z");
+        store_msg(&db, "m-3", chat_id, "hi", "2025-01-01T00:00:03Z");
+
+        let result = collect_sleep_input(&db, "test-agent").expect("collect");
+        match result {
+            InputDecision::Skip {
+                reason,
+                new_message_count,
+            } => {
+                assert!(!reason.is_empty(), "reason should not be empty");
+                assert!(reason.contains("3"), "reason should mention count");
+                assert!(
+                    reason.contains("threshold"),
+                    "reason should mention threshold"
+                );
+                assert_eq!(new_message_count, 3);
+            }
+            other => panic!("expected Skip, got {other:?}"),
+        }
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -53,6 +53,16 @@ pub(crate) struct SessionSnapshot {
     pub recent_messages: Vec<StoredMessage>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct AgentSessionInfo {
+    pub chat_id: i64,
+    pub channel: String,
+    pub external_chat_id: String,
+    pub updated_at: String,
+    pub message_count: i64,
+    pub estimated_tokens: i64,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ToolCall {
     pub id: String,

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -5,9 +5,9 @@ use rusqlite::{OptionalExtension, params};
 use crate::error::StorageError;
 
 use super::{
-    ChatInfo, Database, LlmUsageLogEntry, MemoryFile, MemorySnapshot, SessionSnapshot,
-    SessionSummary, SleepRun, SleepRunStatus, SleepRunTrigger, SnapshotPhase, StoredMessage,
-    ToolCall,
+    AgentSessionInfo, ChatInfo, Database, LlmUsageLogEntry, MemoryFile, MemorySnapshot,
+    SessionSnapshot, SessionSummary, SleepRun, SleepRunStatus, SleepRunTrigger, SnapshotPhase,
+    StoredMessage, ToolCall,
 };
 
 fn row_to_stored_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredMessage> {
@@ -651,6 +651,99 @@ impl Database {
         )
         .optional()
         .map_err(Into::into)
+    }
+
+    pub(crate) fn count_agent_messages_since(
+        &self,
+        agent_id: &str,
+        since: Option<&str>,
+    ) -> Result<i64, StorageError> {
+        let conn = self.lock_conn()?;
+        if let Some(cutoff) = since {
+            conn.query_row(
+                "SELECT COUNT(*)
+                 FROM messages m
+                 JOIN chats c ON m.chat_id = c.chat_id
+                 WHERE c.agent_id = ?1 AND m.timestamp > ?2",
+                params![agent_id, cutoff],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+        } else {
+            conn.query_row(
+                "SELECT COUNT(*)
+                 FROM messages m
+                 JOIN chats c ON m.chat_id = c.chat_id
+                 WHERE c.agent_id = ?1",
+                params![agent_id],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+        }
+    }
+
+    pub(crate) fn get_agent_sessions_since(
+        &self,
+        agent_id: &str,
+        since: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<AgentSessionInfo>, StorageError> {
+        let conn = self.lock_conn()?;
+        if let Some(cutoff) = since {
+            let mut stmt = conn.prepare(
+                "SELECT
+                    c.chat_id,
+                    c.channel,
+                    c.external_chat_id,
+                    s.updated_at,
+                    (SELECT COUNT(*) FROM messages WHERE chat_id = c.chat_id) AS message_count,
+                    LENGTH(COALESCE(s.messages_json, '')) / 3 AS estimated_tokens
+                 FROM chats c
+                 JOIN sessions s ON c.chat_id = s.chat_id
+                 WHERE c.agent_id = ?1 AND s.updated_at > ?2
+                 ORDER BY s.updated_at DESC
+                 LIMIT ?3",
+            )?;
+            stmt.query_map(params![agent_id, cutoff, limit as i64], |row| {
+                Ok(AgentSessionInfo {
+                    chat_id: row.get(0)?,
+                    channel: row.get(1)?,
+                    external_chat_id: row.get(2)?,
+                    updated_at: row.get(3)?,
+                    message_count: row.get(4)?,
+                    estimated_tokens: row.get(5)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+        } else {
+            let mut stmt = conn.prepare(
+                "SELECT
+                    c.chat_id,
+                    c.channel,
+                    c.external_chat_id,
+                    s.updated_at,
+                    (SELECT COUNT(*) FROM messages WHERE chat_id = c.chat_id) AS message_count,
+                    LENGTH(COALESCE(s.messages_json, '')) / 3 AS estimated_tokens
+                 FROM chats c
+                 JOIN sessions s ON c.chat_id = s.chat_id
+                 WHERE c.agent_id = ?1
+                 ORDER BY s.updated_at DESC
+                 LIMIT ?2",
+            )?;
+            stmt.query_map(params![agent_id, limit as i64], |row| {
+                Ok(AgentSessionInfo {
+                    chat_id: row.get(0)?,
+                    channel: row.get(1)?,
+                    external_chat_id: row.get(2)?,
+                    updated_at: row.get(3)?,
+                    message_count: row.get(4)?,
+                    estimated_tokens: row.get(5)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -1675,5 +1768,214 @@ mod tests {
             .get_latest_snapshot_for_file("agent-a", MemoryFile::Episodic)
             .expect("get latest");
         assert!(result.is_none());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Agent session enumeration tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn count_agent_messages_since_counts_correctly() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:msgs-a", None, "cli", "agent-a")
+            .expect("create chat");
+
+        store_msg(&db, "msg-1", chat_id, "old", "2024-01-01T00:00:00Z");
+        store_msg(&db, "msg-2", chat_id, "old2", "2024-01-01T00:00:01Z");
+        store_msg(&db, "msg-3", chat_id, "new", "2024-01-01T00:00:02Z");
+        store_msg(&db, "msg-4", chat_id, "new2", "2024-01-01T00:00:03Z");
+
+        let count = db
+            .count_agent_messages_since("agent-a", Some("2024-01-01T00:00:01Z"))
+            .expect("count");
+        assert_eq!(count, 2, "should count only messages after the cutoff");
+    }
+
+    #[test]
+    fn count_agent_messages_since_with_no_cutoff() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:no-cutoff", None, "cli", "agent-a")
+            .expect("create chat");
+
+        store_msg(&db, "msg-1", chat_id, "a", "2024-01-01T00:00:00Z");
+        store_msg(&db, "msg-2", chat_id, "b", "2024-01-01T00:00:01Z");
+        store_msg(&db, "msg-3", chat_id, "c", "2024-01-01T00:00:02Z");
+
+        let count = db
+            .count_agent_messages_since("agent-a", None)
+            .expect("count");
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn count_agent_messages_since_returns_zero_for_unknown_agent() {
+        let (db, _dir) = test_db();
+
+        let count = db
+            .count_agent_messages_since("nonexistent-agent", None)
+            .expect("count");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn count_agent_messages_since_excludes_other_agents() {
+        let (db, _dir) = test_db();
+
+        let chat_a = db
+            .resolve_or_create_chat_id("cli", "cli:chat-a", None, "cli", "agent-a")
+            .expect("create chat a");
+        let chat_b = db
+            .resolve_or_create_chat_id("cli", "cli:chat-b", None, "cli", "agent-b")
+            .expect("create chat b");
+
+        store_msg(&db, "msg-a1", chat_a, "hello", "2024-01-01T00:00:00Z");
+        store_msg(&db, "msg-a2", chat_a, "world", "2024-01-01T00:00:01Z");
+        store_msg(&db, "msg-b1", chat_b, "secret", "2024-01-01T00:00:02Z");
+
+        let count = db
+            .count_agent_messages_since("agent-a", None)
+            .expect("count");
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn get_agent_sessions_since_returns_sessions() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("web", "web:sess-a", Some("sess-a"), "web", "agent-a")
+            .expect("create chat");
+
+        db.save_session(chat_id, r#"{"msgs":[]}"#)
+            .expect("save session");
+
+        let sessions = db
+            .get_agent_sessions_since("agent-a", None, 10)
+            .expect("get sessions");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].chat_id, chat_id);
+        assert_eq!(sessions[0].channel, "web");
+        assert_eq!(sessions[0].external_chat_id, "web:sess-a");
+    }
+
+    #[test]
+    fn get_agent_sessions_since_ordered_by_updated_at_desc() {
+        let (db, _dir) = test_db();
+
+        let chat_1 = db
+            .resolve_or_create_chat_id("cli", "cli:chat-1", None, "cli", "agent-a")
+            .expect("create chat 1");
+        let chat_2 = db
+            .resolve_or_create_chat_id("cli", "cli:chat-2", None, "cli", "agent-a")
+            .expect("create chat 2");
+
+        // Create sessions with small delay so updated_at differs
+        db.save_session(chat_1, r#"{}"#).expect("save session 1");
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        db.save_session(chat_2, r#"{}"#).expect("save session 2");
+
+        let sessions = db
+            .get_agent_sessions_since("agent-a", None, 10)
+            .expect("get sessions");
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].chat_id, chat_2, "newest first");
+        assert_eq!(sessions[1].chat_id, chat_1, "oldest second");
+    }
+
+    #[test]
+    fn get_agent_sessions_since_respects_limit() {
+        let (db, _dir) = test_db();
+
+        for i in 0..5 {
+            let chat_id = db
+                .resolve_or_create_chat_id("cli", &format!("cli:limit-{i}"), None, "cli", "agent-a")
+                .expect("create chat");
+            db.save_session(chat_id, r#"{}"#).expect("save session");
+        }
+
+        let sessions = db
+            .get_agent_sessions_since("agent-a", None, 3)
+            .expect("get sessions");
+        assert_eq!(sessions.len(), 3);
+    }
+
+    #[test]
+    fn get_agent_sessions_since_with_no_cutoff() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:nocut", None, "cli", "agent-a")
+            .expect("create chat");
+        db.save_session(chat_id, r#"{}"#).expect("save session");
+
+        let sessions = db
+            .get_agent_sessions_since("agent-a", None, 10)
+            .expect("get sessions");
+        assert_eq!(sessions.len(), 1);
+    }
+
+    #[test]
+    fn get_agent_sessions_since_returns_empty_for_unknown_agent() {
+        let (db, _dir) = test_db();
+
+        let sessions = db
+            .get_agent_sessions_since("nonexistent-agent", None, 10)
+            .expect("get sessions");
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn get_agent_sessions_includes_message_count() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:msgcount", None, "cli", "agent-a")
+            .expect("create chat");
+
+        store_msg(&db, "m1", chat_id, "msg 1", "2024-01-01T00:00:00Z");
+        store_msg(&db, "m2", chat_id, "msg 2", "2024-01-01T00:00:01Z");
+        store_msg(&db, "m3", chat_id, "msg 3", "2024-01-01T00:00:02Z");
+
+        db.save_session(chat_id, r#"{}"#).expect("save session");
+
+        let sessions = db
+            .get_agent_sessions_since("agent-a", None, 10)
+            .expect("get sessions");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].message_count, 3);
+    }
+
+    #[test]
+    fn get_agent_sessions_includes_estimated_tokens() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:tokcount", None, "cli", "agent-a")
+            .expect("create chat");
+
+        // Use a known-length session JSON: 30 chars → estimated_tokens = 30/3 = 10
+        let session_json = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"; // 30 'A' chars
+        assert_eq!(
+            session_json.len(),
+            30,
+            "test fixture should be exactly 30 chars"
+        );
+
+        db.save_session(chat_id, session_json)
+            .expect("save session");
+
+        let sessions = db
+            .get_agent_sessions_since("agent-a", None, 10)
+            .expect("get sessions");
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].estimated_tokens > 0);
+        assert_eq!(
+            sessions[0].estimated_tokens,
+            (session_json.len() as i64) / 3
+        );
     }
 }


### PR DESCRIPTION
## Summary

long-term memory Phase 3 の実装。睡眠バッチの入力となるセッション情報を agent 単位で収集し、実行すべきかスキップすべきかを判定する。

Close #55

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/storage/mod.rs` | `AgentSessionInfo` 構造体追加（`serde::Serialize` 付き） |
| `src/storage/queries.rs` | `count_agent_messages_since` / `get_agent_sessions_since` クエリ追加（テスト 11 件） |
| `src/memory.rs` | `InputDecision` enum / `collect_sleep_input` 関数 / 定数追加（テスト 10 件） |
| `docs/db.md` | AgentSessionInfo マッピング、新クエリ操作一覧を追加 |

## 設計方針

- **メッセージ数でスキップ判定** — 新規メッセージ ≤ 4件（2往復以下）なら Skip、≥ 5件で Proceed
- **`finished_at` をカットオフに使用** — `started_at` だと実行中のメッセージを取りこぼすため
- **古いものから切る** — セッション数上限 (20) 超過時、`updated_at` 降順で最新 N 件のみ
- **Config は追加しない** — 閾値・上限値は定数ハードコード（将来 Phase 8 で設定化）

## コミット分割

1. `feat(storage): add queries for agent session enumeration and message counting`
2. `feat(memory): add sleep input collection with skip logic based on message count`
3. `docs: update db.md with agent session queries for sleep input collection`

## テストケース一覧（全 21 件）

### Storage Queries (11)
1. `count_agent_messages_since_counts_correctly`
2. `count_agent_messages_since_with_no_cutoff`
3. `count_agent_messages_since_returns_zero_for_unknown_agent`
4. `count_agent_messages_since_excludes_other_agents`
5. `get_agent_sessions_since_returns_sessions`
6. `get_agent_sessions_since_ordered_by_updated_at_desc`
7. `get_agent_sessions_since_respects_limit`
8. `get_agent_sessions_since_with_no_cutoff`
9. `get_agent_sessions_since_returns_empty_for_unknown_agent`
10. `get_agent_sessions_includes_message_count`
11. `get_agent_sessions_includes_estimated_tokens`

### Input Collection Logic (10)
12. `collect_returns_skip_when_no_messages`
13. `collect_returns_skip_when_below_threshold`
14. `collect_returns_proceed_above_threshold`
15. `collect_returns_proceed_with_many_messages`
16. `collect_since_last_successful_run`
17. `collect_first_run_no_previous_run`
18. `collect_respects_max_sessions_limit`
19. `collect_source_chats_json_format`
20. `collect_source_chats_json_sorted_newest_first`
21. `collect_skip_includes_reason_and_count`

## 検証

```
cargo fmt --check    ✓
cargo test -p egopulse    570 passed ✓
cargo clippy --all-targets --all-features -- -D warnings    ✓
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントのチャットセッション情報を追跡・集計する機能を追加しました。
  * スリープ実行機能を改善し、新規メッセージ数に基づいて自動判定するようになりました。

* **ドキュメント**
  * データベーススキーマドキュメントを新機能に対応して更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->