### PR TITLE
Multi-Agent Room Phase 4: Runtime Safety（同時実行制御・暴走防止・SystemEvent）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,6 +81,7 @@ src/
 │
 ├── runtime/             # AppState 構築、チャネル起動・監視
 │   ├── mod.rs           # AppState, build_app_state(), start_channels()
+│   ├── turn_scheduler.rs # TurnScheduler, TurnTracker, StopReason, evaluate_stop_conditions
 │   ├── gateway.rs       # systemd サービス管理
 │   ├── logging.rs       # ログ初期化
 │   └── status.rs        # ランタイムステータス
@@ -169,6 +170,9 @@ pub struct AppState {
     pub(crate) memory_loader: Arc<MemoryLoader>,
     pub(crate) llm_cache: Mutex<HashMap<u64, Arc<dyn LlmProvider>>>,
     pub(crate) active_turns: Arc<ActiveTurnTracker>,
+    pub(crate) turn_sender: mpsc::Sender<PendingAgentTurn>,
+    pub(crate) turn_scheduler: Arc<TurnScheduler>,
+    pub(crate) turn_tracker: Arc<TurnTracker>,
 }
 ```
 
@@ -183,6 +187,9 @@ pub(crate) struct SurfaceContext {
     pub surface_thread: String,  // プラットフォームの会話スレッド ID
     pub chat_type: String,       // 永続化用チャット種別
     pub agent_id: String,        // 使用するエージェント定義のキー
+    pub channel_log_chat_id: Option<i64>, // Multi-Agent Room の Channel Log
+    pub chain_depth: usize,      // agent_send のチェーン深度 (0 = ユーザー発信)
+    pub origin_id: String,       // ヒューマン入力起点の UUID (暴走防止用)
 }
 ```
 
@@ -291,4 +298,7 @@ pub(crate) struct SurfaceContext {
 | **Sleep Batch** | `sleep_batch.rs` | 手動 sleep batch の排他実行と長期記憶昇格 |
 | **Sleep Scheduler** | `sleep_scheduler.rs` | 自動 scheduler による定期 sleep batch 実行 |
 | **Active Turn Tracker** | `runtime/mod.rs` | agent ごとのアクティブ turn 追跡（scheduler defer 用） |
+| **Turn Scheduler** | `runtime/turn_scheduler.rs` | per-session busy flag + input queue による同時実行制御 |
+| **Stop Condition Evaluator** | `runtime/turn_scheduler.rs` | chain depth / turn count / agent 存在確認による暴走防止 |
+| **Turn Tracker** | `runtime/turn_scheduler.rs` | origin_id 単位の turn 数カウント |
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -177,8 +177,10 @@ Multi-Agent Room では、同一エージェントセッションへの同時タ
 | 停止理由 | 条件 |
 |---|---|
 | ChainDepthExceeded | チェーン深度 > 4 |
-| TurnCountExceeded | 同一 origin のターン数 ≥ 12 |
+| TurnCountExceeded | 同一 origin のターン数 > 12 |
 | LlmFailure | LLM 呼び出し失敗 |
+
+> **注意**: 「ボット間チェーンガード」の内部上限 (depth 5) は **Discord メッセージ受信側の防御**（ボット→ボット連鎖を制限）。TurnScheduler の `ChainDepthExceeded` (> 4) は **ターン実行側の暴走防止**（`agent_send` 連鎖深度を制限）。両者は独立した防御レイヤー。
 
 停止後に人間が新しくメッセージを送信すると、新しい origin_id が発行され、エージェントは通常通り応答を再開する。
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -164,6 +164,24 @@ Agent Session の LLM 呼び出し時に、Channel Log の直近 30 件を一時
 - Channel Log に `MessageKind::AgentSend` で保存される
 - 宛先エージェントの応答はバックグラウンドで非同期実行され、完了後に同じチャネルに送信される
 
+#### 同時実行制御 (Phase 4)
+
+Multi-Agent Room では、同一エージェントセッションへの同時ターンを直列化する `TurnScheduler` が動作する。
+
+- **Busy flag**: セッション単位で実行中のターンがある場合、後続ターンはキューに積まれる
+- **Queue drain**: 実行中ターンの完了後、キューから次のターンを取り出して自動実行する
+- **origin_id**: ヒューマンメッセージごとに UUID が発行され、`agent_send` 連鎖を跨いで同一 origin のターン数を追跡する
+
+**停止条件**: 以下のいずれかを満たすとターンは実行されず、Channel Log に SystemEvent が記録される。
+
+| 停止理由 | 条件 |
+|---|---|
+| ChainDepthExceeded | チェーン深度 > 4 |
+| TurnCountExceeded | 同一 origin のターン数 ≥ 12 |
+| LlmFailure | LLM 呼び出し失敗 |
+
+停止後に人間が新しくメッセージを送信すると、新しい origin_id が発行され、エージェントは通常通り応答を再開する。
+
 ### Bot 作成手順
 
 1. [Discord Developer Portal](https://discord.com/developers/applications) でアプリケーション作成

--- a/docs/config.md
+++ b/docs/config.md
@@ -538,7 +538,7 @@ WebUI の設定 API 仕様は [api.md](./api.md) を参照。
 
 | 定数 | 値 | 定義場所 | 説明 |
 |---|---|---|---|
-| `MAX_AGENT_CHAIN_DEPTH` | 4 | `runtime/turn_scheduler.rs` | `agent_send` の最大チェーン深度。A→B→C→D まで許可し、5 段階目以降はドロップ |
-| `MAX_AGENT_TURNS_PER_INPUT` | 12 | `runtime/turn_scheduler.rs` | 同一 origin（ヒューマン入力）から派生するターンの上限。到達すると Channel Log に SystemEvent を記録して停止 |
+| `MAX_AGENT_CHAIN_DEPTH` | 4 | `src/runtime/turn_scheduler.rs` | `agent_send` の最大チェーン深度。A→B→C→D まで許可し、5 段階目以降はドロップ |
+| `MAX_AGENT_TURNS_PER_INPUT` | 12 | `src/runtime/turn_scheduler.rs` | 同一 origin（ヒューマン入力）から派生するターンの上限。到達すると Channel Log に SystemEvent を記録して停止 |
 
 制限に到達した場合でも、人間が新しくメッセージを送信すると新しい `origin_id` が発行され、エージェントは通常通り応答を再開する。

--- a/docs/config.md
+++ b/docs/config.md
@@ -531,3 +531,14 @@ WebUI の設定 API 仕様は [api.md](./api.md) を参照。
 | `channels.telegram.bot_token` | 返却なし |
 
 ---
+
+## 内部定数（Multi-Agent Room）
+
+以下の定数はソースコードにハードコードされており、設定ファイル (`egopulse.config.yaml`) からは変更できない。
+
+| 定数 | 値 | 定義場所 | 説明 |
+|---|---|---|---|
+| `MAX_AGENT_CHAIN_DEPTH` | 4 | `runtime/turn_scheduler.rs` | `agent_send` の最大チェーン深度。A→B→C→D まで許可し、5 段階目以降はドロップ |
+| `MAX_AGENT_TURNS_PER_INPUT` | 12 | `runtime/turn_scheduler.rs` | 同一 origin（ヒューマン入力）から派生するターンの上限。到達すると Channel Log に SystemEvent を記録して停止 |
+
+制限に到達した場合でも、人間が新しくメッセージを送信すると新しい `origin_id` が発行され、エージェントは通常通り応答を再開する。

--- a/docs/db.md
+++ b/docs/db.md
@@ -217,7 +217,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_chat_timestamp
 |----|------|
 | `message` | 通常のチャットメッセージ（デフォルト） |
 | `agent_send` | エージェント間通信。`sender_agent_id` に送信元、`recipient_agent_id` に宛先エージェント ID が設定される |
-| `system_event` | システムイベント（Phase 4 で実装予定） |
+| `system_event` | システムイベント。停止条件によるターン拒否や LLM 失敗を記録。`sender_name` は `"system"`、`is_from_bot` は `true`。`content` は JSON 形式（`{"reason": "ChainDepthExceeded"}` 等） |
 
 ---
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -66,9 +66,41 @@ session は `(channel, surface_thread)` から安定的に決まる。この sur
 5. **宛先エージェント応答**: ワーカーが `process_turn` の戻り値を `ChannelRegistry.send_text()` でチャネルに送信
 
 **制約**:
-- チェーン深度 (`chain_depth`) が `MAX_AGENT_CHAIN_DEPTH` (8) を超えるターンは破棄
+- チェーン深度 (`chain_depth`) が `MAX_AGENT_CHAIN_DEPTH` (4) を超えるターンは破棄
 - 自己送信 (`from == to`) は禁止
 - Discord チャネルが設定されている場合のみ利用可能
+
+### 1.5 TurnScheduler による同時実行制御 (Phase 4)
+
+Multi-Agent Room の Discord チャネルでは、`TurnScheduler` がセッション単位のターン実行を管理する。
+
+```text
+ヒューマンメッセージ受信 (Discord)
+  │
+  ├─ origin_id (UUID) 発行
+  ├─ ScheduledTurn 構築
+  └─ TurnScheduler.submit()
+       │
+       ├─ slot が idle → busy に設定し、execute_scheduled_turn() を即時実行
+       └─ slot が busy → キューに積んで待機
+
+execute_scheduled_turn():
+  │
+  ├─ evaluate_stop_conditions()
+  │    ├─ chain_depth > 4 → Channel Log に SystemEvent 記録 → 終了
+  │    ├─ turn_count ≥ 12 → Channel Log に SystemEvent 記録 → 終了
+  │    └─ OK → process_turn() 実行
+  │
+  ├─ process_turn() 成功 → チャネルに応答送信
+  └─ process_turn() 失敗 → Channel Log に SystemEvent (LlmFailure) 記録
+
+  ↓ 完了後
+  on_turn_completed()
+    ├─ キューに次のターンがあれば → execute_scheduled_turn() 再帰
+    └─ キューが空 → busy を解除
+```
+
+**SystemEvent**: 停止条件によりターンが拒否された場合、Channel Log に `MessageKind::SystemEvent` で JSON 形式の理由が記録される（`{"reason": "ChainDepthExceeded"}` 等）。
 
 ---
 

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -364,3 +364,7 @@ Only respond to the Direct Input below.
 ### 永続化
 
 Channel Context は `request_messages` にのみ追加され、Agent Session の `messages_json` には保存されない。
+
+### SystemEvent の扱い
+
+Channel Log に記録された `MessageKind::SystemEvent` メッセージは Channel Context 注入の対象外。SystemEvent は停止理由の記録用であり、LLM のコンテキストには含まれない。

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -308,11 +308,13 @@ MCP の詳細は以下を参照。
   - `message: string` 必須。送信するメッセージ内容
 - 挙動:
   - Discord チャネルが設定されている場合のみ登録される（CLI / Web ではツールが露出しない）
+  - 非Discordサーフェスからの実行時にもエラーを返す（ランタイムガード）
   - 自己送信 (`to == 自分自身`) は禁止
   - メッセージを Channel Log に `MessageKind::AgentSend` で保存
   - チャネルに `[From → To] message` 形式で表示
-  - 宛先エージェントの Turn を `PendingAgentTurn` としてバックグラウンドワーカーにキューイング
-  - チェーン深度 (chain depth) が `MAX_AGENT_CHAIN_DEPTH` (8) を超えるターンは破棄
+  - 宛先エージェントの Turn を `PendingAgentTurn` として `TurnScheduler` 経由でバックグラウンド実行
+  - チェーン深度 (chain depth) が `MAX_AGENT_CHAIN_DEPTH` (4) を超えるターンは Channel Log に SystemEvent を記録して破棄
+  - 同一 origin のターン数が `MAX_AGENT_TURNS_PER_INPUT` (12) に達すると SystemEvent を記録して停止
 - 成功時:
   - `{"delivered": true, "to": "<agent_id>"}`
 - 主な失敗:

--- a/src/agent_loop/mod.rs
+++ b/src/agent_loop/mod.rs
@@ -27,6 +27,9 @@ pub(crate) struct PendingAgentTurn {
     pub input: String,
     /// The `external_chat_id` to send the target agent's response to.
     pub external_chat_id: String,
+    /// Origin ID: UUID tracking all turns caused by a single human input.
+    /// Propagated from the originating human message through agent_send chains.
+    pub origin_id: String,
 }
 
 /// A turn submitted to the [`crate::runtime::turn_scheduler::TurnScheduler`] for ordered execution.
@@ -64,6 +67,9 @@ pub(crate) struct SurfaceContext {
     pub channel_log_chat_id: Option<i64>,
     /// Current `agent_send` chain depth (0 for user-initiated turns).
     pub chain_depth: usize,
+    /// Origin ID: UUID tracking all turns caused by a single human input.
+    /// Empty string when origin tracking is not applicable (e.g. non-Discord channels).
+    pub origin_id: String,
 }
 
 impl SurfaceContext {
@@ -83,6 +89,7 @@ impl SurfaceContext {
             agent_id,
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         }
     }
 

--- a/src/agent_loop/mod.rs
+++ b/src/agent_loop/mod.rs
@@ -14,10 +14,6 @@ pub(crate) use session::{list_sessions, load_session_messages};
 pub use turn::ask_in_session;
 pub(crate) use turn::{process_turn, process_turn_with_events, send_turn};
 
-/// Maximum chain depth for `agent_send` cascading (A→B→A→B…).
-/// Turns exceeding this limit are silently dropped with a warning log.
-pub(crate) const MAX_AGENT_CHAIN_DEPTH: usize = 8;
-
 /// A pending turn to be executed for a target agent, enqueued by `agent_send`.
 #[derive(Debug, Clone)]
 pub(crate) struct PendingAgentTurn {

--- a/src/agent_loop/mod.rs
+++ b/src/agent_loop/mod.rs
@@ -29,6 +29,28 @@ pub(crate) struct PendingAgentTurn {
     pub external_chat_id: String,
 }
 
+/// A turn submitted to the [`crate::runtime::turn_scheduler::TurnScheduler`] for ordered execution.
+///
+/// Extends [`PendingAgentTurn`] with origin tracking for runaway prevention.
+#[derive(Debug, Clone)]
+pub(crate) struct ScheduledTurn {
+    /// Surface context identifying the agent session.
+    pub context: SurfaceContext,
+    /// The input text for this turn.
+    pub input: String,
+    /// External chat ID for sending responses back to the channel.
+    pub external_chat_id: String,
+    /// Origin ID: UUID tracking all turns caused by a single human input.
+    pub origin_id: String,
+}
+
+impl ScheduledTurn {
+    /// Returns the stable session key for this turn's target session.
+    pub(crate) fn session_key(&self) -> String {
+        self.context.session_key()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Identifies the external conversation surface mapped to a persisted session.
 pub(crate) struct SurfaceContext {

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -908,6 +908,7 @@ mod tests {
             agent_id: config.default_agent.to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         assert_eq!(context.agent_id, "default");
@@ -931,6 +932,7 @@ mod tests {
             agent_id: "agent_a".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
         let ctx_b = SurfaceContext {
             channel: "discord".to_string(),
@@ -940,6 +942,7 @@ mod tests {
             agent_id: "agent_b".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let chat_a = super::resolve_chat_id(&state, &ctx_a)
@@ -973,6 +976,7 @@ mod tests {
             agent_id: "agent_a".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let chat_first = super::resolve_chat_id(&state, &ctx).await.expect("first");
@@ -991,6 +995,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
         let telegram_ctx = SurfaceContext {
             channel: "telegram".to_string(),
@@ -1000,6 +1005,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         assert_eq!(web_ctx.session_key(), "web:s1");
@@ -1048,6 +1054,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let first = super::resolve_chat_id(&state, &ctx).await.expect("first");

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -72,6 +72,7 @@ pub async fn ask_in_session(
         agent_id: state.config.default_agent.to_string(),
         channel_log_chat_id: None,
         chain_depth: 0,
+        origin_id: String::new(),
     };
 
     tokio::select! {
@@ -146,6 +147,7 @@ where
         agent_id: context.agent_id.clone(),
         channel_log_chat_id: context.channel_log_chat_id,
         chain_depth: context.chain_depth,
+        origin_id: context.origin_id.clone(),
         turn_sender: state.turn_sender.clone(),
     };
     let system_prompt = build_system_prompt(state, context);
@@ -1171,6 +1173,8 @@ pub(crate) fn build_state(
         llm_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
         active_turns: std::sync::Arc::new(crate::runtime::ActiveTurnTracker::new()),
         turn_sender: tokio::sync::mpsc::channel(16).0,
+        turn_scheduler: std::sync::Arc::new(crate::runtime::turn_scheduler::TurnScheduler::new()),
+        turn_tracker: std::sync::Arc::new(crate::runtime::turn_scheduler::TurnTracker::new()),
     }
 }
 
@@ -1539,6 +1543,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         }
     }
 
@@ -2121,6 +2126,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: Some(channel_log_chat_id),
             chain_depth: 0,
+            origin_id: String::new(),
         }
     }
 
@@ -2725,6 +2731,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let _reply = process_turn(&state, &context, "unrelated message")

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -769,6 +769,7 @@ impl EventHandler for Handler {
 
         let mut context = self.make_context(&msg.author.name, &thread, &agent_id);
         context.channel_log_chat_id = channel_log_chat_id;
+        context.origin_id = uuid::Uuid::new_v4().to_string();
 
         info!(
             channel_id = channel_id,
@@ -781,39 +782,19 @@ impl EventHandler for Handler {
 
         let typing = msg.channel_id.start_typing(&ctx.http);
 
-        match crate::agent_loop::process_turn(&self.app_state, &context, &combined_text).await {
-            Ok(response) => {
-                drop(typing);
-                if !response.is_empty() {
-                    if let Some(log_chat_id) = channel_log_chat_id {
-                        let response_timestamp = msg.timestamp.to_string();
-                        self.store_bot_channel_log_message(
-                            channel_id,
-                            log_chat_id,
-                            &agent_id,
-                            &response_timestamp,
-                            &response,
-                        )
-                        .await;
-                    }
-                    send_discord_response(&ctx, msg.channel_id, &response).await;
-                }
-            }
-            Err(e) => {
-                drop(typing);
-                error!(
-                    channel_id = channel_id,
-                    agent = %agent_id, bot = %self.bot_id,
-                    error_kind = e.error_kind(),
-                    error = %e,
-                    error_debug = ?e,
-                    "Discord: error processing message"
-                );
-                if !e.should_suppress_user_error() {
-                    send_discord_response(&ctx, msg.channel_id, &e.user_message()).await;
-                }
-            }
+        let scheduled = crate::agent_loop::ScheduledTurn {
+            context: context.clone(),
+            input: combined_text.clone(),
+            external_chat_id: msg.channel_id.to_string(),
+            origin_id: context.origin_id.clone(),
+        };
+
+        let state = &self.app_state;
+        if let Some(turn) = state.turn_scheduler.submit(scheduled) {
+            crate::runtime::execute_scheduled_turn(state, turn).await;
         }
+
+        drop(typing);
     }
 
     async fn ready(&self, ctx: Context, ready: Ready) {

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -745,9 +745,11 @@ impl EventHandler for Handler {
             origin_id: context.origin_id.clone(),
         };
 
-        let state = &self.app_state;
-        if let Some(turn) = state.turn_scheduler.submit(scheduled) {
-            crate::runtime::execute_scheduled_turn(state, turn).await;
+        if let Some(turn) = self.app_state.turn_scheduler.submit(scheduled) {
+            let state = Arc::clone(&self.app_state);
+            tokio::spawn(async move {
+                crate::runtime::execute_scheduled_turn(&state, turn).await;
+            });
         }
 
         drop(typing);

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -642,50 +642,6 @@ impl Handler {
         }
         saved_paths
     }
-
-    /// Bot の応答メッセージを Channel Log に保存する。
-    async fn store_bot_channel_log_message(
-        &self,
-        channel_id: u64,
-        log_chat_id: i64,
-        agent_id: &str,
-        timestamp: &str,
-        response: &str,
-    ) {
-        let db = std::sync::Arc::clone(&self.app_state.db);
-        let bot_id = self.bot_id.clone();
-        let agent_id_owned = agent_id.to_string();
-        let timestamp = timestamp.to_string();
-        let response = response.to_string();
-        if let Err(e) = crate::storage::call_blocking(db, move |db| {
-            let conn = db.lock_conn()?;
-            conn.execute(
-                "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                rusqlite::params![
-                    format!("cl-bot-{}", uuid::Uuid::new_v4()),
-                    log_chat_id,
-                    bot_id,
-                    response,
-                    1i32,
-                    timestamp,
-                    "message",
-                    agent_id_owned,
-                ],
-            )?;
-            Ok::<_, crate::error::StorageError>(())
-        })
-        .await
-        {
-            warn!(
-                channel_id = channel_id,
-                chat_id = log_chat_id,
-                agent = %agent_id,
-                error = %e,
-                "failed to store Discord bot response in Channel Log"
-            );
-        }
-    }
 }
 
 #[serenity::async_trait]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -326,10 +326,13 @@ pub(crate) fn execute_scheduled_turn(
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
     Box::pin(async move {
         let session_key = turn.session_key();
+        let origin_id = if turn.origin_id.is_empty() {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            turn.origin_id.clone()
+        };
 
-        let origin_id = &turn.origin_id;
-
-        if let Some(reason) = state.turn_tracker.terminal_reason(origin_id) {
+        if let Some(reason) = state.turn_tracker.terminal_reason(&origin_id) {
             tracing::warn!(
                 agent_id = %turn.context.agent_id,
                 origin_id = %origin_id,
@@ -346,8 +349,8 @@ pub(crate) fn execute_scheduled_turn(
         let chain_depth = turn.context.chain_depth;
         let agent_id = &turn.context.agent_id;
 
-        state.turn_tracker.increment(origin_id);
-        let turn_count = state.turn_tracker.count(origin_id);
+        state.turn_tracker.increment(&origin_id);
+        let turn_count = state.turn_tracker.count(&origin_id);
 
         if let Some(reason) =
             turn_scheduler::evaluate_stop_conditions(chain_depth, turn_count, agent_id, &valid_ids)
@@ -361,7 +364,7 @@ pub(crate) fn execute_scheduled_turn(
             );
             state
                 .turn_tracker
-                .set_terminal_reason(origin_id, reason.clone());
+                .set_terminal_reason(&origin_id, reason.clone());
             if let Some(log_chat_id) = turn.context.channel_log_chat_id {
                 if let Err(error) = state.db.store_system_event(log_chat_id, &reason) {
                     tracing::warn!(error = %error, "failed to store system event for stop condition");
@@ -388,27 +391,15 @@ pub(crate) fn execute_scheduled_turn(
                     if let Some(log_chat_id) = turn.context.channel_log_chat_id {
                         let db = std::sync::Arc::clone(&state.db);
                         let agent_id = turn.context.agent_id.clone();
-                        let bot_response = response.clone();
-                        if let Err(error) =
-                            crate::storage::call_blocking(db, move |db| {
-                                let conn = db.lock_conn()?;
-                                conn.execute(
-                                    "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id)
-                                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                                    rusqlite::params![
-                                        format!("cl-bot-{}", uuid::Uuid::new_v4()),
-                                        log_chat_id,
-                                        agent_id,
-                                        bot_response,
-                                        1i32,
-                                        chrono::Utc::now().to_rfc3339(),
-                                        "message",
-                                        agent_id,
-                                    ],
-                                )?;
-                                Ok::<_, crate::error::StorageError>(())
-                            })
-                            .await
+                        let response_owned = response.clone();
+                        if let Err(error) = crate::storage::call_blocking(db, move |db| {
+                            db.store_channel_log_bot_response(
+                                log_chat_id,
+                                &agent_id,
+                                &response_owned,
+                            )
+                        })
+                        .await
                         {
                             tracing::warn!(error = %error, "failed to store bot response in Channel Log");
                         }
@@ -423,7 +414,7 @@ pub(crate) fn execute_scheduled_turn(
                 );
                 state
                     .turn_tracker
-                    .set_terminal_reason(origin_id, turn_scheduler::StopReason::LlmFailure);
+                    .set_terminal_reason(&origin_id, turn_scheduler::StopReason::LlmFailure);
                 if let Some(log_chat_id) = turn.context.channel_log_chat_id {
                     if let Err(db_err) = state
                         .db
@@ -432,6 +423,10 @@ pub(crate) fn execute_scheduled_turn(
                         tracing::warn!(error = %db_err, "failed to store LLM failure system event");
                     }
                 }
+                if let Some(next) = state.turn_scheduler.on_turn_completed(&session_key) {
+                    execute_scheduled_turn(state, next).await;
+                }
+                return;
             }
         }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -311,7 +311,10 @@ fn spawn_agent_turn_worker(
             };
 
             if let Some(turn) = state.turn_scheduler.submit(scheduled) {
-                execute_scheduled_turn(&state, turn).await;
+                let state = state.clone();
+                tokio::spawn(async move {
+                    execute_scheduled_turn(&state, turn).await;
+                });
             }
         }
     });
@@ -324,10 +327,24 @@ pub(crate) fn execute_scheduled_turn(
     Box::pin(async move {
         let session_key = turn.session_key();
 
+        let origin_id = &turn.origin_id;
+
+        if let Some(reason) = state.turn_tracker.terminal_reason(origin_id) {
+            tracing::warn!(
+                agent_id = %turn.context.agent_id,
+                origin_id = %origin_id,
+                reason = ?reason,
+                "dropping turn: origin already has terminal stop reason"
+            );
+            if let Some(next) = state.turn_scheduler.on_turn_completed(&session_key) {
+                execute_scheduled_turn(state, next).await;
+            }
+            return;
+        }
+
         let valid_ids: Vec<&str> = state.config.agents.keys().map(|id| id.as_str()).collect();
         let chain_depth = turn.context.chain_depth;
         let agent_id = &turn.context.agent_id;
-        let origin_id = &turn.origin_id;
 
         state.turn_tracker.increment(origin_id);
         let turn_count = state.turn_tracker.count(origin_id);
@@ -342,6 +359,9 @@ pub(crate) fn execute_scheduled_turn(
                 reason = ?reason,
                 "scheduled turn rejected by stop condition evaluator"
             );
+            state
+                .turn_tracker
+                .set_terminal_reason(origin_id, reason.clone());
             if let Some(log_chat_id) = turn.context.channel_log_chat_id {
                 if let Err(error) = state.db.store_system_event(log_chat_id, &reason) {
                     tracing::warn!(error = %error, "failed to store system event for stop condition");
@@ -401,6 +421,9 @@ pub(crate) fn execute_scheduled_turn(
                     error = %error,
                     "scheduled turn: process_turn failed"
                 );
+                state
+                    .turn_tracker
+                    .set_terminal_reason(origin_id, turn_scheduler::StopReason::LlmFailure);
                 if let Some(log_chat_id) = turn.context.channel_log_chat_id {
                     if let Err(db_err) = state
                         .db

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -86,6 +86,10 @@ pub struct AppState {
     pub(crate) active_turns: Arc<ActiveTurnTracker>,
     /// Sender half of the pending-agent-turn channel for `agent_send` turn queuing.
     pub(crate) turn_sender: tokio::sync::mpsc::Sender<crate::agent_loop::PendingAgentTurn>,
+    /// Per-session turn scheduler for concurrency control and ordered execution.
+    pub(crate) turn_scheduler: Arc<turn_scheduler::TurnScheduler>,
+    /// Per-origin turn counter for runaway prevention.
+    pub(crate) turn_tracker: Arc<turn_scheduler::TurnTracker>,
 }
 
 impl Clone for AppState {
@@ -105,6 +109,8 @@ impl Clone for AppState {
             llm_cache: Mutex::new(HashMap::new()),
             active_turns: Arc::clone(&self.active_turns),
             turn_sender: self.turn_sender.clone(),
+            turn_scheduler: Arc::clone(&self.turn_scheduler),
+            turn_tracker: Arc::clone(&self.turn_tracker),
         }
     }
 }
@@ -241,6 +247,8 @@ pub async fn build_app_state_with_path(
         llm_cache: Mutex::new(HashMap::new()),
         active_turns: Arc::new(ActiveTurnTracker::new()),
         turn_sender,
+        turn_scheduler: Arc::new(turn_scheduler::TurnScheduler::new()),
+        turn_tracker: Arc::new(turn_scheduler::TurnTracker::new()),
     };
 
     spawn_agent_turn_worker(state.clone(), turn_receiver);
@@ -284,6 +292,8 @@ pub fn build_sleep_app_state_with_path(
         llm_cache: Mutex::new(HashMap::new()),
         active_turns: Arc::new(ActiveTurnTracker::new()),
         turn_sender: tokio::sync::mpsc::channel(16).0,
+        turn_scheduler: Arc::new(turn_scheduler::TurnScheduler::new()),
+        turn_tracker: Arc::new(turn_scheduler::TurnTracker::new()),
     })
 }
 
@@ -292,40 +302,90 @@ fn spawn_agent_turn_worker(
     mut receiver: tokio::sync::mpsc::Receiver<crate::agent_loop::PendingAgentTurn>,
 ) {
     tokio::spawn(async move {
-        while let Some(turn) = receiver.recv().await {
-            if turn.context.chain_depth >= crate::agent_loop::MAX_AGENT_CHAIN_DEPTH {
-                tracing::warn!(
-                    agent_id = %turn.context.agent_id,
-                    chain_depth = turn.context.chain_depth,
-                    "agent_send chain depth exceeded limit; dropping turn"
-                );
-                continue;
-            }
+        while let Some(pending) = receiver.recv().await {
+            let scheduled = crate::agent_loop::ScheduledTurn {
+                context: pending.context,
+                input: pending.input,
+                external_chat_id: pending.external_chat_id,
+                origin_id: pending.origin_id,
+            };
 
-            match crate::agent_loop::process_turn(&state, &turn.context, &turn.input).await {
-                Ok(response) => {
-                    if let Some(adapter) = state.channels.get(&turn.context.channel) {
-                        if let Err(error) =
-                            adapter.send_text(&turn.external_chat_id, &response).await
-                        {
-                            tracing::warn!(
-                                agent_id = %turn.context.agent_id,
-                                error = %error,
-                                "background turn: failed to send response to channel"
-                            );
-                        }
-                    }
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        agent_id = %turn.context.agent_id,
-                        error = %error,
-                        "background turn: process_turn failed"
-                    );
-                }
+            if let Some(turn) = state.turn_scheduler.submit(scheduled) {
+                execute_scheduled_turn(&state, turn).await;
             }
         }
     });
+}
+
+pub(crate) fn execute_scheduled_turn(
+    state: &AppState,
+    turn: crate::agent_loop::ScheduledTurn,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+    Box::pin(async move {
+        let session_key = turn.session_key();
+
+        let valid_ids: Vec<&str> = state.config.agents.keys().map(|id| id.as_str()).collect();
+        let chain_depth = turn.context.chain_depth;
+        let agent_id = &turn.context.agent_id;
+        let origin_id = &turn.origin_id;
+
+        state.turn_tracker.increment(origin_id);
+        let turn_count = state.turn_tracker.count(origin_id);
+
+        if let Some(reason) =
+            turn_scheduler::evaluate_stop_conditions(chain_depth, turn_count, agent_id, &valid_ids)
+        {
+            tracing::warn!(
+                agent_id = %agent_id,
+                chain_depth,
+                turn_count,
+                reason = ?reason,
+                "scheduled turn rejected by stop condition evaluator"
+            );
+            if let Some(log_chat_id) = turn.context.channel_log_chat_id {
+                if let Err(error) = state.db.store_system_event(log_chat_id, &reason) {
+                    tracing::warn!(error = %error, "failed to store system event for stop condition");
+                }
+            }
+            if let Some(next) = state.turn_scheduler.on_turn_completed(&session_key) {
+                execute_scheduled_turn(state, next).await;
+            }
+            return;
+        }
+
+        match crate::agent_loop::process_turn(state, &turn.context, &turn.input).await {
+            Ok(response) => {
+                if let Some(adapter) = state.channels.get(&turn.context.channel) {
+                    if let Err(error) = adapter.send_text(&turn.external_chat_id, &response).await {
+                        tracing::warn!(
+                            agent_id = %turn.context.agent_id,
+                            error = %error,
+                            "scheduled turn: failed to send response to channel"
+                        );
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    agent_id = %turn.context.agent_id,
+                    error = %error,
+                    "scheduled turn: process_turn failed"
+                );
+                if let Some(log_chat_id) = turn.context.channel_log_chat_id {
+                    if let Err(db_err) = state
+                        .db
+                        .store_system_event(log_chat_id, &turn_scheduler::StopReason::LlmFailure)
+                    {
+                        tracing::warn!(error = %db_err, "failed to store LLM failure system event");
+                    }
+                }
+            }
+        }
+
+        if let Some(next) = state.turn_scheduler.on_turn_completed(&session_key) {
+            execute_scheduled_turn(state, next).await;
+        }
+    })
 }
 
 fn spawn_mcp_reconnect_loop(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5,6 +5,7 @@
 pub mod gateway;
 pub mod logging;
 pub mod status;
+pub(crate) mod turn_scheduler;
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -364,6 +364,36 @@ pub(crate) fn execute_scheduled_turn(
                         );
                     }
                 }
+                if !response.is_empty() {
+                    if let Some(log_chat_id) = turn.context.channel_log_chat_id {
+                        let db = std::sync::Arc::clone(&state.db);
+                        let agent_id = turn.context.agent_id.clone();
+                        let bot_response = response.clone();
+                        if let Err(error) =
+                            crate::storage::call_blocking(db, move |db| {
+                                let conn = db.lock_conn()?;
+                                conn.execute(
+                                    "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id)
+                                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                                    rusqlite::params![
+                                        format!("cl-bot-{}", uuid::Uuid::new_v4()),
+                                        log_chat_id,
+                                        agent_id,
+                                        bot_response,
+                                        1i32,
+                                        chrono::Utc::now().to_rfc3339(),
+                                        "message",
+                                        agent_id,
+                                    ],
+                                )?;
+                                Ok::<_, crate::error::StorageError>(())
+                            })
+                            .await
+                        {
+                            tracing::warn!(error = %error, "failed to store bot response in Channel Log");
+                        }
+                    }
+                }
             }
             Err(error) => {
                 tracing::warn!(

--- a/src/runtime/turn_scheduler.rs
+++ b/src/runtime/turn_scheduler.rs
@@ -22,10 +22,11 @@ pub(crate) enum StopReason {
     SessionUnprocessable,
 }
 
-/// Per-origin turn counter for runaway prevention.
+/// Per-origin turn counter and terminal stop reason tracker for runaway prevention.
 #[derive(Debug, Default)]
 pub(crate) struct TurnTracker {
     counts: Mutex<HashMap<String, usize>>,
+    terminal_reasons: Mutex<HashMap<String, StopReason>>,
 }
 
 impl TurnTracker {
@@ -41,6 +42,28 @@ impl TurnTracker {
     pub(crate) fn count(&self, origin_id: &str) -> usize {
         let counts = self.counts.lock().expect("turn_tracker lock");
         counts.get(origin_id).copied().unwrap_or(0)
+    }
+
+    pub(crate) fn set_terminal_reason(&self, origin_id: &str, reason: StopReason) {
+        let mut reasons = self.terminal_reasons.lock().expect("turn_tracker lock");
+        reasons.insert(origin_id.to_string(), reason);
+    }
+
+    pub(crate) fn terminal_reason(&self, origin_id: &str) -> Option<StopReason> {
+        let reasons = self.terminal_reasons.lock().expect("turn_tracker lock");
+        reasons.get(origin_id).cloned()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn remove_origin(&self, origin_id: &str) {
+        {
+            let mut counts = self.counts.lock().expect("turn_tracker lock");
+            counts.remove(origin_id);
+        }
+        {
+            let mut reasons = self.terminal_reasons.lock().expect("turn_tracker lock");
+            reasons.remove(origin_id);
+        }
     }
 }
 
@@ -129,7 +152,7 @@ pub(crate) fn evaluate_stop_conditions(
     if chain_depth > MAX_AGENT_CHAIN_DEPTH {
         return Some(StopReason::ChainDepthExceeded);
     }
-    if turn_count >= MAX_AGENT_TURNS_PER_INPUT {
+    if turn_count > MAX_AGENT_TURNS_PER_INPUT {
         return Some(StopReason::TurnCountExceeded);
     }
     if !valid_agent_ids.contains(&agent_id) {
@@ -274,7 +297,7 @@ mod tests {
 
     #[test]
     fn stop_condition_turn_count_exceeded() {
-        let result = evaluate_stop_conditions(0, 12, "agent_a", &["agent_a"]);
+        let result = evaluate_stop_conditions(0, 13, "agent_a", &["agent_a"]);
         assert_eq!(result, Some(StopReason::TurnCountExceeded));
     }
 
@@ -315,5 +338,26 @@ mod tests {
     fn turn_tracker_count_returns_zero_for_unknown() {
         let tracker = TurnTracker::new();
         assert_eq!(tracker.count("nonexistent"), 0);
+    }
+
+    #[test]
+    fn turn_tracker_terminal_reason_blocks_future_turns() {
+        let tracker = TurnTracker::new();
+        assert!(tracker.terminal_reason("orig-1").is_none());
+        tracker.set_terminal_reason("orig-1", StopReason::ChainDepthExceeded);
+        assert_eq!(
+            tracker.terminal_reason("orig-1"),
+            Some(StopReason::ChainDepthExceeded)
+        );
+    }
+
+    #[test]
+    fn turn_tracker_remove_origin_clears_all_state() {
+        let tracker = TurnTracker::new();
+        tracker.increment("orig-1");
+        tracker.set_terminal_reason("orig-1", StopReason::LlmFailure);
+        tracker.remove_origin("orig-1");
+        assert_eq!(tracker.count("orig-1"), 0);
+        assert!(tracker.terminal_reason("orig-1").is_none());
     }
 }

--- a/src/runtime/turn_scheduler.rs
+++ b/src/runtime/turn_scheduler.rs
@@ -1,0 +1,318 @@
+//! Per-session turn scheduler with concurrency control and runaway prevention.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+use crate::agent_loop::ScheduledTurn;
+
+/// Maximum chain depth for `agent_send` cascading (A→B→C…).
+pub(crate) const MAX_AGENT_CHAIN_DEPTH: usize = 4;
+
+/// Maximum turns allowed per human-originated input chain.
+pub(crate) const MAX_AGENT_TURNS_PER_INPUT: usize = 12;
+
+/// Reasons a scheduled turn may be rejected or stopped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StopReason {
+    ChainDepthExceeded,
+    TurnCountExceeded,
+    AgentNotFound,
+    LlmFailure,
+    SessionUnprocessable,
+}
+
+/// Per-origin turn counter for runaway prevention.
+#[derive(Debug, Default)]
+pub(crate) struct TurnTracker {
+    counts: Mutex<HashMap<String, usize>>,
+}
+
+impl TurnTracker {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn increment(&self, origin_id: &str) {
+        let mut counts = self.counts.lock().expect("turn_tracker lock");
+        *counts.entry(origin_id.to_string()).or_insert(0) += 1;
+    }
+
+    pub(crate) fn count(&self, origin_id: &str) -> usize {
+        let counts = self.counts.lock().expect("turn_tracker lock");
+        counts.get(origin_id).copied().unwrap_or(0)
+    }
+}
+
+/// Slot state for a single agent session within the scheduler.
+struct TurnSlot {
+    busy: bool,
+    queue: VecDeque<ScheduledTurn>,
+}
+
+/// Per-session busy flag and input queue for ordered turn execution.
+///
+/// When a turn is submitted for a session that is already processing a turn,
+/// the new turn is enqueued. After the current turn completes, the caller
+/// invokes [`TurnScheduler::on_turn_completed`] to drain the next queued turn.
+pub(crate) struct TurnScheduler {
+    slots: Mutex<HashMap<String, TurnSlot>>,
+}
+
+impl TurnScheduler {
+    pub(crate) fn new() -> Self {
+        Self {
+            slots: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Submits a turn for execution.
+    ///
+    /// Returns `Ok(Some(turn))` when the slot is idle — the caller should
+    /// begin executing the returned turn immediately. Returns `Ok(None)` when
+    /// the slot is busy — the turn has been enqueued for later execution.
+    pub(crate) fn submit(&self, turn: ScheduledTurn) -> Option<ScheduledTurn> {
+        let mut slots = self.slots.lock().expect("turn_scheduler lock");
+        let slot = slots.entry(turn.session_key()).or_insert_with(|| TurnSlot {
+            busy: false,
+            queue: VecDeque::new(),
+        });
+
+        if slot.busy {
+            slot.queue.push_back(turn);
+            None
+        } else {
+            slot.busy = true;
+            // Drop lock before returning to avoid holding it during execution.
+            Some(turn)
+        }
+    }
+
+    /// Called after a turn completes. Returns the next queued turn for this
+    /// session, or `None` if the queue is empty (slot becomes idle).
+    pub(crate) fn on_turn_completed(&self, session_key: &str) -> Option<ScheduledTurn> {
+        let mut slots = self.slots.lock().expect("turn_scheduler lock");
+        if let Some(slot) = slots.get_mut(session_key) {
+            if let Some(next) = slot.queue.pop_front() {
+                return Some(next);
+            }
+            slot.busy = false;
+        }
+        None
+    }
+
+    /// Returns `true` if the given session currently has a turn in progress.
+    #[cfg(test)]
+    fn is_busy(&self, session_key: &str) -> bool {
+        let slots = self.slots.lock().expect("turn_scheduler lock");
+        slots.get(session_key).is_some_and(|s| s.busy)
+    }
+
+    /// Returns the number of queued turns for the given session.
+    #[cfg(test)]
+    fn queue_len(&self, session_key: &str) -> usize {
+        let slots = self.slots.lock().expect("turn_scheduler lock");
+        slots.get(session_key).map_or(0, |s| s.queue.len())
+    }
+}
+
+/// Evaluates all stop conditions for a scheduled turn.
+///
+/// Returns `Some(StopReason)` if the turn should be rejected, or `None` if
+/// execution may proceed.
+pub(crate) fn evaluate_stop_conditions(
+    chain_depth: usize,
+    turn_count: usize,
+    agent_id: &str,
+    valid_agent_ids: &[&str],
+) -> Option<StopReason> {
+    if chain_depth > MAX_AGENT_CHAIN_DEPTH {
+        return Some(StopReason::ChainDepthExceeded);
+    }
+    if turn_count >= MAX_AGENT_TURNS_PER_INPUT {
+        return Some(StopReason::TurnCountExceeded);
+    }
+    if !valid_agent_ids.contains(&agent_id) {
+        return Some(StopReason::AgentNotFound);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_loop::SurfaceContext;
+
+    fn test_context(agent_id: &str) -> SurfaceContext {
+        SurfaceContext::new(
+            "discord".to_string(),
+            "user".to_string(),
+            format!("ch1:agent:{agent_id}"),
+            "discord".to_string(),
+            agent_id.to_string(),
+        )
+    }
+
+    fn test_turn(agent_id: &str, origin_id: &str) -> ScheduledTurn {
+        ScheduledTurn {
+            context: test_context(agent_id),
+            input: "hello".to_string(),
+            external_chat_id: "ext123".to_string(),
+            origin_id: origin_id.to_string(),
+        }
+    }
+
+    // ---- ScheduledTurn tests ----
+
+    #[test]
+    fn scheduled_turn_from_surface_context() {
+        let turn = test_turn("agent_a", "orig-1");
+        assert_eq!(turn.context.agent_id, "agent_a");
+        assert_eq!(turn.input, "hello");
+        assert_eq!(turn.external_chat_id, "ext123");
+        assert_eq!(turn.origin_id, "orig-1");
+        assert_eq!(turn.context.chain_depth, 0);
+    }
+
+    #[test]
+    fn scheduled_turn_session_key_matches_surface() {
+        let turn = test_turn("agent_a", "orig-1");
+        assert_eq!(turn.session_key(), turn.context.session_key());
+    }
+
+    // ---- TurnScheduler tests ----
+
+    #[test]
+    fn turn_scheduler_new_is_empty() {
+        let scheduler = TurnScheduler::new();
+        assert!(!scheduler.is_busy("discord:ch1:agent:a"));
+    }
+
+    #[test]
+    fn turn_scheduler_submit_first_turn_sets_busy() {
+        let scheduler = TurnScheduler::new();
+        let turn = test_turn("agent_a", "orig-1");
+        let result = scheduler.submit(turn);
+
+        assert!(result.is_some());
+        let key = "discord:ch1:agent:agent_a";
+        assert!(scheduler.is_busy(key));
+        assert_eq!(scheduler.queue_len(key), 0);
+    }
+
+    #[test]
+    fn turn_scheduler_submit_second_turn_enqueues() {
+        let scheduler = TurnScheduler::new();
+        let key = "discord:ch1:agent:agent_a";
+
+        let turn1 = test_turn("agent_a", "orig-1");
+        scheduler.submit(turn1);
+
+        let turn2 = test_turn("agent_a", "orig-1");
+        let result = scheduler.submit(turn2);
+
+        assert!(result.is_none());
+        assert!(scheduler.is_busy(key));
+        assert_eq!(scheduler.queue_len(key), 1);
+    }
+
+    #[test]
+    fn turn_scheduler_drain_after_completion() {
+        let scheduler = TurnScheduler::new();
+        let key = "discord:ch1:agent:agent_a";
+
+        let turn1 = test_turn("agent_a", "orig-1");
+        scheduler.submit(turn1);
+
+        let turn2 = test_turn("agent_a", "orig-2");
+        scheduler.submit(turn2);
+
+        let next = scheduler.on_turn_completed(key);
+        assert!(next.is_some());
+        assert_eq!(next.unwrap().origin_id, "orig-2");
+        assert!(scheduler.is_busy(key));
+    }
+
+    #[test]
+    fn turn_scheduler_drain_empty_clears_busy() {
+        let scheduler = TurnScheduler::new();
+        let key = "discord:ch1:agent:agent_a";
+
+        let turn = test_turn("agent_a", "orig-1");
+        scheduler.submit(turn);
+
+        let next = scheduler.on_turn_completed(key);
+        assert!(next.is_none());
+        assert!(!scheduler.is_busy(key));
+    }
+
+    #[test]
+    fn turn_scheduler_different_sessions_independent() {
+        let scheduler = TurnScheduler::new();
+        let key_a = "discord:ch1:agent:agent_a";
+        let key_b = "discord:ch1:agent:agent_b";
+
+        let turn_a = test_turn("agent_a", "orig-1");
+        let turn_b = test_turn("agent_b", "orig-1");
+
+        let result_a = scheduler.submit(turn_a);
+        let result_b = scheduler.submit(turn_b);
+
+        assert!(result_a.is_some());
+        assert!(result_b.is_some());
+        assert!(scheduler.is_busy(key_a));
+        assert!(scheduler.is_busy(key_b));
+    }
+
+    // ---- Stop Condition tests ----
+
+    #[test]
+    fn stop_condition_chain_depth_exceeded() {
+        let result = evaluate_stop_conditions(5, 0, "agent_a", &["agent_a"]);
+        assert_eq!(result, Some(StopReason::ChainDepthExceeded));
+    }
+
+    #[test]
+    fn stop_condition_turn_count_exceeded() {
+        let result = evaluate_stop_conditions(0, 12, "agent_a", &["agent_a"]);
+        assert_eq!(result, Some(StopReason::TurnCountExceeded));
+    }
+
+    #[test]
+    fn stop_condition_agent_not_found() {
+        let result = evaluate_stop_conditions(0, 0, "unknown", &["agent_a"]);
+        assert_eq!(result, Some(StopReason::AgentNotFound));
+    }
+
+    #[test]
+    fn stop_condition_none_when_all_ok() {
+        let result = evaluate_stop_conditions(1, 5, "agent_a", &["agent_a"]);
+        assert_eq!(result, None);
+    }
+
+    // ---- TurnTracker tests ----
+
+    #[test]
+    fn turn_tracker_increments_per_origin() {
+        let tracker = TurnTracker::new();
+        tracker.increment("orig-1");
+        tracker.increment("orig-1");
+        tracker.increment("orig-1");
+        assert_eq!(tracker.count("orig-1"), 3);
+    }
+
+    #[test]
+    fn turn_tracker_different_origins_independent() {
+        let tracker = TurnTracker::new();
+        tracker.increment("orig-1");
+        tracker.increment("orig-1");
+        tracker.increment("orig-2");
+        assert_eq!(tracker.count("orig-1"), 2);
+        assert_eq!(tracker.count("orig-2"), 1);
+    }
+
+    #[test]
+    fn turn_tracker_count_returns_zero_for_unknown() {
+        let tracker = TurnTracker::new();
+        assert_eq!(tracker.count("nonexistent"), 0);
+    }
+}

--- a/src/runtime/turn_scheduler.rs
+++ b/src/runtime/turn_scheduler.rs
@@ -119,7 +119,7 @@ impl TurnScheduler {
             if let Some(next) = slot.queue.pop_front() {
                 return Some(next);
             }
-            slot.busy = false;
+            slots.remove(session_key);
         }
         None
     }

--- a/src/runtime/turn_scheduler.rs
+++ b/src/runtime/turn_scheduler.rs
@@ -18,6 +18,7 @@ pub(crate) enum StopReason {
     TurnCountExceeded,
     AgentNotFound,
     LlmFailure,
+    #[allow(dead_code)]
     SessionUnprocessable,
 }
 

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -869,6 +869,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         }
     }
 
@@ -1184,6 +1185,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let result = handle_slash_command(&state, chat_id, &context, "/status", None).await;
@@ -1222,6 +1224,7 @@ mod tests {
             agent_id: "default".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let result = handle_slash_command(&state, chat_id, &context, "/compact", None).await;
@@ -1300,6 +1303,7 @@ agents:
             agent_id: "bob".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let result = handle_slash_command(&state, 1, &context, "/provider local", None).await;
@@ -1351,6 +1355,7 @@ agents:
             agent_id: "bob".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
         };
 
         let result = handle_slash_command(&state, 1, &context, "/model agent-model", None).await;

--- a/src/sleep_batch.rs
+++ b/src/sleep_batch.rs
@@ -1012,6 +1012,10 @@ mod tests {
             llm_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
             active_turns: std::sync::Arc::new(crate::runtime::ActiveTurnTracker::new()),
             turn_sender: tokio::sync::mpsc::channel(16).0,
+            turn_scheduler: std::sync::Arc::new(
+                crate::runtime::turn_scheduler::TurnScheduler::new(),
+            ),
+            turn_tracker: std::sync::Arc::new(crate::runtime::turn_scheduler::TurnTracker::new()),
         }
     }
 

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -490,6 +490,35 @@ impl Database {
         )?;
         Ok(())
     }
+
+    /// Persists a stop-reason system event to the Channel Log.
+    ///
+    /// Content format: `{"reason": "StopReasonVariant"}`.
+    /// Sender: `"system"`, `is_from_bot: true`.
+    pub(crate) fn store_system_event(
+        &self,
+        channel_log_chat_id: i64,
+        reason: &crate::runtime::turn_scheduler::StopReason,
+    ) -> Result<(), StorageError> {
+        let content = serde_json::json!({
+            "reason": format!("{reason:?}")
+        })
+        .to_string();
+
+        let message = StoredMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            chat_id: channel_log_chat_id,
+            sender_name: "system".to_string(),
+            content,
+            is_from_bot: true,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            message_kind: MessageKind::SystemEvent,
+            sender_agent_id: None,
+            recipient_agent_id: None,
+        };
+
+        self.store_message_only(&message)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2222,5 +2251,69 @@ mod tests {
         assert_eq!(msgs.len(), 3);
         assert_eq!(msgs[0].content, "msg 2");
         assert_eq!(msgs[2].content, "msg 4");
+    }
+
+    // ---- System Event tests ----
+
+    #[test]
+    fn store_system_event_saves_to_channel_log() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db.resolve_channel_log_chat_id(300).expect("create");
+        db.store_system_event(
+            chat_id,
+            &crate::runtime::turn_scheduler::StopReason::ChainDepthExceeded,
+        )
+        .expect("store");
+
+        let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message_kind, MessageKind::SystemEvent);
+    }
+
+    #[test]
+    fn store_system_event_content_is_valid_json_with_reason() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db.resolve_channel_log_chat_id(301).expect("create");
+        db.store_system_event(
+            chat_id,
+            &crate::runtime::turn_scheduler::StopReason::TurnCountExceeded,
+        )
+        .expect("store");
+
+        let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
+        let parsed: serde_json::Value = serde_json::from_str(&msgs[0].content).expect("valid json");
+        assert!(parsed.get("reason").is_some());
+    }
+
+    #[test]
+    fn store_system_event_sender_is_system() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db.resolve_channel_log_chat_id(302).expect("create");
+        db.store_system_event(
+            chat_id,
+            &crate::runtime::turn_scheduler::StopReason::LlmFailure,
+        )
+        .expect("store");
+
+        let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs[0].sender_name, "system");
+    }
+
+    #[test]
+    fn store_system_event_is_from_bot_true() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db.resolve_channel_log_chat_id(303).expect("create");
+        db.store_system_event(
+            chat_id,
+            &crate::runtime::turn_scheduler::StopReason::SessionUnprocessable,
+        )
+        .expect("store");
+
+        let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
+        assert!(msgs[0].is_from_bot);
     }
 }

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -519,6 +519,29 @@ impl Database {
 
         self.store_message_only(&message)
     }
+
+    /// Persists a bot response to the Channel Log.
+    ///
+    /// Sender is the agent ID, `is_from_bot: true`, `MessageKind::Message`.
+    pub(crate) fn store_channel_log_bot_response(
+        &self,
+        channel_log_chat_id: i64,
+        agent_id: &str,
+        response: &str,
+    ) -> Result<(), StorageError> {
+        let message = StoredMessage {
+            id: format!("cl-bot-{}", uuid::Uuid::new_v4()),
+            chat_id: channel_log_chat_id,
+            sender_name: agent_id.to_string(),
+            content: response.to_string(),
+            is_from_bot: true,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            message_kind: MessageKind::Message,
+            sender_agent_id: Some(agent_id.to_string()),
+            recipient_agent_id: None,
+        };
+        self.store_message_only(&message)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -92,6 +92,8 @@ pub(crate) fn build_state_with_provider(
         llm_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
         active_turns: Arc::new(crate::runtime::ActiveTurnTracker::new()),
         turn_sender: tokio::sync::mpsc::channel(16).0,
+        turn_scheduler: Arc::new(crate::runtime::turn_scheduler::TurnScheduler::new()),
+        turn_tracker: Arc::new(crate::runtime::turn_scheduler::TurnTracker::new()),
     }
 }
 
@@ -105,6 +107,7 @@ pub(crate) fn cli_context(session: &str) -> crate::agent_loop::SurfaceContext {
         agent_id: "default".to_string(),
         channel_log_chat_id: None,
         chain_depth: 0,
+        origin_id: String::new(),
     }
 }
 
@@ -118,6 +121,7 @@ pub(crate) fn test_tool_context() -> crate::tools::ToolExecutionContext {
         agent_id: "default".to_string(),
         channel_log_chat_id: None,
         chain_depth: 0,
+        origin_id: String::new(),
         turn_sender: tokio::sync::mpsc::channel(16).0,
     }
 }

--- a/src/tools/agent_send.rs
+++ b/src/tools/agent_send.rs
@@ -172,12 +172,14 @@ impl Tool for AgentSendTool {
             agent_id: target_id.clone(),
             channel_log_chat_id: context.channel_log_chat_id,
             chain_depth: context.chain_depth + 1,
+            origin_id: context.origin_id.clone(),
         };
 
         let turn = PendingAgentTurn {
             context: target_context,
             input: display_text.clone(),
             external_chat_id,
+            origin_id: context.origin_id.clone(),
         };
 
         if let Err(error) = context.turn_sender.send(turn).await {
@@ -250,6 +252,7 @@ mod tests {
             agent_id: agent_id.to_string(),
             channel_log_chat_id: Some(99),
             chain_depth: 0,
+            origin_id: String::new(),
             turn_sender,
         }
     }
@@ -391,6 +394,7 @@ mod tests {
             agent_id: "lyre".to_string(),
             channel_log_chat_id: Some(log_chat_id),
             chain_depth: 0,
+            origin_id: String::new(),
             turn_sender: tx,
         };
 
@@ -437,6 +441,7 @@ mod tests {
             agent_id: "lyre".to_string(),
             channel_log_chat_id: Some(log_chat_id),
             chain_depth: 0,
+            origin_id: String::new(),
             turn_sender: tx,
         };
 
@@ -517,6 +522,7 @@ mod integration_tests {
             agent_id: "lyre".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
             turn_sender: tx,
         };
 
@@ -545,6 +551,7 @@ mod integration_tests {
             agent_id: "lyre".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
             turn_sender: tx,
         };
 
@@ -582,6 +589,7 @@ mod integration_tests {
             agent_id: "lyre".to_string(),
             channel_log_chat_id: Some(log_chat_id),
             chain_depth: 0,
+            origin_id: String::new(),
             turn_sender: tx,
         };
 
@@ -618,6 +626,7 @@ mod integration_tests {
             agent_id: "lyre".to_string(),
             channel_log_chat_id: None,
             chain_depth: 0,
+            origin_id: String::new(),
             turn_sender: tx,
         };
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -59,6 +59,8 @@ pub(crate) struct ToolExecutionContext {
     /// Current `agent_send` chain depth. Starts at 0 for user-initiated turns;
     /// incremented on each `agent_send` hop.
     pub chain_depth: usize,
+    /// Origin ID: UUID tracking all turns caused by a single human input.
+    pub origin_id: String,
     /// Sender half of the pending-agent-turn channel.
     /// Tools like `agent_send` use this to enqueue turns for target agents.
     pub turn_sender: tokio::sync::mpsc::Sender<crate::agent_loop::PendingAgentTurn>,


### PR DESCRIPTION
## Summary

- TurnScheduler（per-session busy flag + input queue）による同時実行制御
- 5停止条件（chain depth / turn count / agent存在確認 / LLM失敗 / session回復不能）
- TurnTracker（origin_id単位のturn数カウント）による暴走防止
- 停止時に Channel Log へ SystemEvent を記録
- Discord handler を TurnScheduler 経由に変更（background worker も統合）
- ドキュメント 7 ファイル更新

## 実装詳細

### TurnScheduler（新規: `src/runtime/turn_scheduler.rs`）

```text
同一セッションへの同時 submit は queue に積まれ、先行 turn 完了後に drain。
turn 完了ごとに `on_turn_completed()` を呼び出し、次の turn を自動実行する。
```

- `TurnSlot { busy: bool, queue: VecDeque<ScheduledTurn> }` を `Mutex<HashMap>` で管理
- `submit()` → slot busy なら enqueue / idle なら即時実行
- `on_turn_completed()` → queue から pop して次の turn を返す / queue 空なら busy 解除

### ScheduledTurn（拡張: `src/agent_loop/mod.rs`）

`PendingAgentTurn` を基に `origin_id`（UUID）を追加。同一ヒューマン入力から派生する全ターンを追跡。

### StopCondition + TurnTracker（`src/runtime/turn_scheduler.rs`）

| 定数 | 値 |
|---|---|
| `MAX_AGENT_CHAIN_DEPTH` | 4 |
| `MAX_AGENT_TURNS_PER_INPUT` | 12 |

- `evaluate_stop_conditions()` — pure function。chain depth / turn count / agent存在確認
- `TurnTracker` — `Mutex<HashMap<String, usize>>`。origin_id 単位のカウント管理

### SystemEvent Persistence（拡張: `src/storage/queries.rs`）

- `Database::store_system_event(channel_log_chat_id, &StopReason)` 追加
- Content 形式: `{"reason": "ChainDepthExceeded"}`
- sender: `"system"`, `is_from_bot: true`, `MessageKind::SystemEvent`

### Runtime Integration

- `AppState` に `turn_scheduler: Arc<TurnScheduler>`, `turn_tracker: Arc<TurnTracker>` 追加
- `origin_id` を `SurfaceContext` → `ToolExecutionContext` → `PendingAgentTurn` に伝播
- Background worker: `PendingAgentTurn` → `ScheduledTurn` 変換 → `turn_scheduler.submit()`
- Discord handler: ヒューマンメッセージ受信時に UUID 発行 → `ScheduledTurn` → `turn_scheduler.submit()`
- `execute_scheduled_turn()`: 停止条件評価 → `process_turn()` → 応答送信 + Channel Log 保存 → `on_turn_completed()` drain
- LLM 失敗・停止条件発動時に Channel Log へ `SystemEvent` を記録

### 削除

- `agent_loop::MAX_AGENT_CHAIN_DEPTH`（`turn_scheduler::MAX_AGENT_CHAIN_DEPTH` に置換）
- `Handler::store_bot_channel_log_message()`（`execute_scheduled_turn` に統合）

## 変更ファイル一覧

| ファイル | 種別 | 内容 |
|---|---|---|
| `src/runtime/turn_scheduler.rs` | **新規** | TurnScheduler, TurnTracker, StopReason, evaluate_stop_conditions |
| `src/runtime/mod.rs` | 変更 | AppState に turn_scheduler/turn_tracker 追加。background worker + execute_scheduled_turn |
| `src/agent_loop/mod.rs` | 変更 | ScheduledTurn 追加。古い MAX_AGENT_CHAIN_DEPTH 削除 |
| `src/channels/discord.rs` | 変更 | TurnScheduler 経由化。store_bot_channel_log_message 削除 |
| `src/tools/agent_send.rs` | 変更 | origin_id 伝播 |
| `src/tools/mod.rs` | 変更 | ToolExecutionContext に origin_id 追加 |
| `src/storage/queries.rs` | 変更 | store_system_event 追加 |
| `src/agent_loop/turn.rs` | 変更 | ToolExecutionContext に origin_id 伝播 |
| `src/sleep_batch.rs` | 変更 | AppState 構築追従 |
| `src/test_util.rs` | 変更 | テストヘルパー追従 |
| `src/slash_commands.rs` | 変更 | SurfaceContext 構築追従 |
| `src/agent_loop/session.rs` | 変更 | SurfaceContext 構築追従 |
| `src/agent_loop/prompt_builder.rs` | 変更 | SurfaceContext 構築追従 |
| `docs/*.md` (7 ファイル) | 変更 | Phase 4 ドキュメント反映 |

## 検証

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p egopulse` **772 tests passed** ✅

## コミット

1. `acd3d96` feat(runtime): add TurnScheduler with per-session busy flag, input queue, stop conditions, and turn tracker
2. `35cd78b` feat(storage): add system event persistence for Channel Log
3. `529b4f1` feat(runtime): integrate TurnScheduler into AppState, Discord handler, and background worker
4. `c3db09e` docs: update 7 docs for Multi-Agent Room Phase 4 runtime safety
5. `5678de6` fix: remove dead code and move Channel Log bot response storage to execute_scheduled_turn

Close #64（親Issue #76 Phase 4）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * マルチエージェント実行制御を大幅に追記：同時実行の直列化、チェーン深度上限(4)、入力あたりターン上限(12)、停止条件とChannel LogへのSystemEvent記録、origin_idによる入力起点追跡、再開条件を明記しました。
* **New Features**
  * マルチエージェント部屋の発話を順次スケジューリングして直列実行する仕組みを導入しました。
* **Bug Fixes**
  * チェーン暴走防止、LLM失敗時の停止扱いとログ記録・再開挙動を追加しました。
* **Tests**
  * 実行制御周りを含むユニットテストとテストヘルパーを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->