### PR TITLE
feat: Sleep Batch Audit WebUI

### DIFF
--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -26,6 +26,7 @@ mod auth;
 mod config;
 mod health;
 mod sessions;
+mod sleep;
 pub(crate) mod sse;
 mod stream;
 mod ws;
@@ -312,6 +313,9 @@ pub(crate) async fn run_server(
         .route("/api/history", get(sessions::get_history))
         .route("/api/send_stream", post(stream::api_send_stream))
         .route("/api/stream", get(stream::api_stream))
+        .route("/api/agents", get(sleep::list_agents))
+        .route("/api/sleep/runs", get(sleep::list_sleep_runs))
+        .route("/api/sleep/runs/{run_id}", get(sleep::get_sleep_run_detail))
         .route_layer(middleware::from_fn_with_state(
             web_state.clone(),
             auth::require_http_auth,

--- a/src/channels/web/sleep.rs
+++ b/src/channels/web/sleep.rs
@@ -1,0 +1,453 @@
+//! Sleep batch audit API endpoints.
+//!
+//! Provides REST handlers for listing agents with sleep run records,
+//! listing sleep runs, and retrieving individual run details with
+//! associated memory snapshots.
+
+use std::collections::HashMap;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use std::sync::Arc;
+
+use crate::storage::call_blocking;
+
+use super::WebState;
+
+const DEFAULT_LIMIT: i64 = 20;
+
+/// Lists distinct agent IDs that have sleep run records.
+pub(super) async fn list_agents(
+    State(state): State<WebState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let db = Arc::clone(&state.app_state.db);
+    match call_blocking(db, |db| db.list_distinct_agent_ids()).await {
+        Ok(agents) => Ok(Json(serde_json::json!({"ok": true, "agents": agents}))),
+        Err(error) => {
+            tracing::warn!(%error, "failed to list distinct agent IDs");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": error.to_string()})),
+            ))
+        }
+    }
+}
+
+/// Lists sleep runs, optionally filtered by agent_id.
+///
+/// Query parameters:
+/// - `agent_id` (optional): filter runs to a specific agent
+/// - `limit` (optional, default 20): maximum number of runs to return
+pub(super) async fn list_sleep_runs(
+    State(state): State<WebState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let db = Arc::clone(&state.app_state.db);
+    let agent_id = params.get("agent_id").map(|s| s.to_string());
+    let limit: i64 = params
+        .get("limit")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_LIMIT);
+
+    let runs = match call_blocking(db, move |db| {
+        if let Some(ref agent_id) = agent_id {
+            db.list_sleep_runs(agent_id, limit)
+        } else {
+            db.list_all_sleep_runs(limit)
+        }
+    })
+    .await
+    {
+        Ok(runs) => runs,
+        Err(error) => {
+            tracing::warn!(%error, "failed to list sleep runs");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": error.to_string()})),
+            ));
+        }
+    };
+
+    let runs_json: Vec<serde_json::Value> = runs
+        .into_iter()
+        .map(|run| {
+            let session_count = parse_session_count(&run.source_chats_json);
+            serde_json::json!({
+                "id": run.id,
+                "agent_id": run.agent_id,
+                "status": run.status.to_string(),
+                "trigger": run.trigger.to_string(),
+                "started_at": run.started_at,
+                "finished_at": run.finished_at,
+                "source_chats_json": run.source_chats_json,
+                "source_digest_md": run.source_digest_md,
+                "input_tokens": run.input_tokens,
+                "output_tokens": run.output_tokens,
+                "total_tokens": run.total_tokens,
+                "error_message": run.error_message,
+                "session_count": session_count,
+            })
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({"ok": true, "runs": runs_json})))
+}
+
+fn parse_session_count(source_chats_json: &str) -> usize {
+    serde_json::from_str::<Vec<serde_json::Value>>(source_chats_json)
+        .map(|v| v.len())
+        .unwrap_or(0)
+}
+
+/// Gets a single sleep run with its memory snapshots.
+///
+/// # Path parameters
+/// - `run_id`: the sleep run identifier
+///
+/// # Errors
+///
+/// Returns `404` when the run does not exist.
+/// Returns `500` on database errors.
+pub(super) async fn get_sleep_run_detail(
+    State(state): State<WebState>,
+    Path(run_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let db = Arc::clone(&state.app_state.db);
+
+    let run = match call_blocking(Arc::clone(&db), {
+        let run_id = run_id.clone();
+        move |db| db.get_sleep_run(&run_id)
+    })
+    .await
+    {
+        Ok(Some(run)) => run,
+        Ok(None) => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"ok": false, "error": "not_found"})),
+            ));
+        }
+        Err(error) => {
+            tracing::warn!(%error, run_id = %run_id, "failed to get sleep run");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": error.to_string()})),
+            ));
+        }
+    };
+
+    let snapshots = match call_blocking(db, {
+        let run_id = run_id.clone();
+        move |db| db.get_snapshots_for_run(&run_id)
+    })
+    .await
+    {
+        Ok(snapshots) => snapshots,
+        Err(error) => {
+            tracing::warn!(%error, run_id = %run_id, "failed to get snapshots for run");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": error.to_string()})),
+            ));
+        }
+    };
+
+    let snapshots_json: Vec<serde_json::Value> = snapshots
+        .into_iter()
+        .map(|snap| {
+            serde_json::json!({
+                "id": snap.id,
+                "run_id": snap.run_id,
+                "agent_id": snap.agent_id,
+                "file": snap.file.to_string(),
+                "content_before": snap.content_before,
+                "content_after": snap.content_after,
+                "created_at": snap.created_at,
+            })
+        })
+        .collect();
+
+    let run_json = serde_json::json!({
+        "id": run.id,
+        "agent_id": run.agent_id,
+        "status": run.status.to_string(),
+        "trigger": run.trigger.to_string(),
+        "started_at": run.started_at,
+        "finished_at": run.finished_at,
+        "source_chats_json": run.source_chats_json,
+        "source_digest_md": run.source_digest_md,
+        "input_tokens": run.input_tokens,
+        "output_tokens": run.output_tokens,
+        "total_tokens": run.total_tokens,
+        "error_message": run.error_message,
+    });
+
+    Ok(Json(
+        serde_json::json!({"ok": true, "run": run_json, "snapshots": snapshots_json}),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use axum::extract::State as AxumState;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::channels::web::{RunHub, WebState};
+    use crate::error::LlmError;
+    use crate::llm::{LlmProvider, Message, MessagesResponse, ToolDefinition};
+    use crate::storage::Database;
+
+    struct DummyLlm;
+
+    #[async_trait]
+    impl LlmProvider for DummyLlm {
+        fn provider_name(&self) -> &str {
+            "dummy"
+        }
+
+        fn model_name(&self) -> &str {
+            "dummy"
+        }
+
+        async fn send_message(
+            &self,
+            _system: &str,
+            _messages: Vec<Message>,
+            _tools: Option<Vec<ToolDefinition>>,
+        ) -> Result<MessagesResponse, LlmError> {
+            panic!("handler tests should not call LLM")
+        }
+    }
+
+    fn test_web_state(dir: &tempfile::TempDir) -> WebState {
+        let state_root = dir.path().to_string_lossy().to_string();
+        let app_state =
+            crate::test_util::build_state_with_provider(&state_root, Box::new(DummyLlm));
+        WebState {
+            app_state: Arc::new(app_state),
+            config_path: None,
+            run_hub: RunHub::default(),
+            active_ws_connections: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        }
+    }
+
+    fn insert_sleep_run(db: &Database, id: &str, agent_id: &str, source_chats_json: &str) {
+        let conn = db.conn.lock().expect("lock");
+        conn.execute(
+            "INSERT INTO sleep_runs (id, agent_id, status, trigger_type, started_at, source_chats_json)
+             VALUES (?1, ?2, 'success', 'manual', '2024-01-01T00:00:00Z', ?3)",
+            rusqlite::params![id, agent_id, source_chats_json],
+        )
+        .expect("insert sleep run");
+    }
+
+    fn insert_memory_snapshot(db: &Database, id: &str, run_id: &str, agent_id: &str) {
+        let conn = db.conn.lock().expect("lock");
+        conn.execute(
+            "INSERT INTO memory_snapshots (id, run_id, agent_id, file, content_before, content_after, created_at)
+             VALUES (?1, ?2, ?3, 'episodic', 'before', 'after', '2024-01-01T00:00:00Z')",
+            rusqlite::params![id, run_id, agent_id],
+        )
+        .expect("insert memory snapshot");
+    }
+
+    #[tokio::test]
+    async fn api_agents_returns_distinct_agent_ids() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        insert_sleep_run(&web_state.app_state.db, "run-1", "agent-a", "[]");
+        insert_sleep_run(&web_state.app_state.db, "run-2", "agent-a", "[]");
+        insert_sleep_run(&web_state.app_state.db, "run-3", "agent-b", "[]");
+
+        let result = list_agents(AxumState(web_state)).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        let agents = body["agents"].as_array().expect("agents array");
+        assert_eq!(agents.len(), 2);
+        assert_eq!(agents[0], "agent-a");
+        assert_eq!(agents[1], "agent-b");
+    }
+
+    #[tokio::test]
+    async fn api_agents_returns_empty_array() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        let result = list_agents(AxumState(web_state)).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        let agents = body["agents"].as_array().expect("agents array");
+        assert!(agents.is_empty());
+    }
+
+    #[tokio::test]
+    async fn api_sleep_runs_returns_runs_with_session_count() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        insert_sleep_run(
+            &web_state.app_state.db,
+            "run-1",
+            "agent-a",
+            r#"[{"chat_id": 1}, {"chat_id": 2}]"#,
+        );
+        insert_sleep_run(
+            &web_state.app_state.db,
+            "run-2",
+            "agent-b",
+            r#"[{"chat_id": 3}]"#,
+        );
+
+        let state = AxumState(web_state);
+        let query = Query(HashMap::new());
+        let result = list_sleep_runs(state, query).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        let runs = body["runs"].as_array().expect("runs array");
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[1]["id"], "run-1");
+        assert_eq!(runs[1]["session_count"], 2);
+        assert_eq!(runs[0]["id"], "run-2");
+        assert_eq!(runs[0]["session_count"], 1);
+    }
+
+    #[tokio::test]
+    async fn api_sleep_runs_filters_by_agent_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        insert_sleep_run(&web_state.app_state.db, "run-a", "agent-a", "[]");
+        insert_sleep_run(&web_state.app_state.db, "run-b", "agent-b", "[]");
+
+        let state = AxumState(web_state);
+        let query = Query(HashMap::from([(
+            "agent_id".to_string(),
+            "agent-a".to_string(),
+        )]));
+        let result = list_sleep_runs(state, query).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        let runs = body["runs"].as_array().expect("runs array");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["id"], "run-a");
+        assert_eq!(runs[0]["agent_id"], "agent-a");
+    }
+
+    #[tokio::test]
+    async fn api_sleep_runs_respects_limit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        insert_sleep_run(&web_state.app_state.db, "run-1", "agent-a", "[]");
+        insert_sleep_run(&web_state.app_state.db, "run-2", "agent-a", "[]");
+        insert_sleep_run(&web_state.app_state.db, "run-3", "agent-a", "[]");
+
+        let state = AxumState(web_state);
+        let query = Query(HashMap::from([("limit".to_string(), "1".to_string())]));
+        let result = list_sleep_runs(state, query).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        let runs = body["runs"].as_array().expect("runs array");
+        assert_eq!(runs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn api_sleep_runs_default_limit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        insert_sleep_run(&web_state.app_state.db, "run-1", "agent-a", "[]");
+        insert_sleep_run(&web_state.app_state.db, "run-2", "agent-a", "[]");
+
+        let state = AxumState(web_state);
+        let query = Query(HashMap::new());
+        let result = list_sleep_runs(state, query).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        let runs = body["runs"].as_array().expect("runs array");
+        assert_eq!(runs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn api_sleep_runs_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        let state = AxumState(web_state);
+        let query = Query(HashMap::new());
+        let result = list_sleep_runs(state, query).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        let runs = body["runs"].as_array().expect("runs array");
+        assert!(runs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn api_sleep_run_detail_returns_run_and_snapshots() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        insert_sleep_run(
+            &web_state.app_state.db,
+            "run-1",
+            "agent-a",
+            r#"[{"chat_id": 1}]"#,
+        );
+        insert_memory_snapshot(&web_state.app_state.db, "snap-1", "run-1", "agent-a");
+
+        let state = AxumState(web_state);
+        let path = Path("run-1".to_string());
+        let result = get_sleep_run_detail(state, path).await.expect("ok");
+        let body = result.0;
+        assert_eq!(body["ok"], serde_json::json!(true));
+        assert_eq!(body["run"]["id"], "run-1");
+        assert_eq!(body["run"]["agent_id"], "agent-a");
+        assert_eq!(body["run"]["status"], "success");
+        assert_eq!(body["run"]["trigger"], "manual");
+
+        let snapshots = body["snapshots"].as_array().expect("snapshots array");
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0]["id"], "snap-1");
+        assert_eq!(snapshots[0]["run_id"], "run-1");
+        assert_eq!(snapshots[0]["content_before"], "before");
+        assert_eq!(snapshots[0]["content_after"], "after");
+    }
+
+    #[tokio::test]
+    async fn api_sleep_run_detail_returns_404_for_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        let state = AxumState(web_state);
+        let path = Path("nonexistent-run".to_string());
+        let result = get_sleep_run_detail(state, path).await;
+        assert!(result.is_err());
+        let (status, body) = result.unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["ok"], serde_json::json!(false));
+        assert_eq!(body["error"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn api_sleep_run_detail_snapshots_file_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+
+        insert_sleep_run(&web_state.app_state.db, "run-file", "agent-a", "[]");
+        insert_memory_snapshot(&web_state.app_state.db, "snap-file", "run-file", "agent-a");
+
+        let state = AxumState(web_state);
+        let path = Path("run-file".to_string());
+        let result = get_sleep_run_detail(state, path).await.expect("ok");
+        let body = result.0;
+        let snapshots = body["snapshots"].as_array().expect("snapshots array");
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0]["file"], "episodic");
+        assert!(snapshots[0]["file"].is_string());
+    }
+}

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -798,6 +798,30 @@ impl Database {
             .map_err(Into::into)
     }
 
+    pub(crate) fn list_distinct_agent_ids(&self) -> Result<Vec<String>, StorageError> {
+        let conn = self.lock_conn()?;
+        let mut stmt =
+            conn.prepare("SELECT DISTINCT agent_id FROM sleep_runs ORDER BY agent_id")?;
+        stmt.query_map([], |row| row.get(0))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub(crate) fn list_all_sleep_runs(&self, limit: i64) -> Result<Vec<SleepRun>, StorageError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, agent_id, status, trigger_type, started_at, finished_at,
+                    source_chats_json, source_digest_md,
+                    input_tokens, output_tokens, total_tokens, error_message
+             FROM sleep_runs
+             ORDER BY started_at DESC, rowid DESC
+             LIMIT ?1",
+        )?;
+        stmt.query_map(params![limit], row_to_sleep_run)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     pub(crate) fn get_latest_successful_run(
         &self,
         agent_id: &str,
@@ -2338,5 +2362,66 @@ mod tests {
 
         let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
         assert!(msgs[0].is_from_bot);
+    }
+
+    #[test]
+    fn list_distinct_agent_ids_returns_sorted_agents() {
+        let (db, _dir) = test_db();
+
+        create_test_sleep_run(&db, "charlie");
+        create_test_sleep_run(&db, "alpha");
+        create_test_sleep_run(&db, "bravo");
+
+        let agents = db.list_distinct_agent_ids().expect("list");
+        assert_eq!(agents, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn list_distinct_agent_ids_empty_when_no_runs() {
+        let (db, _dir) = test_db();
+
+        let agents = db.list_distinct_agent_ids().expect("list");
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn list_all_sleep_runs_returns_all_agents() {
+        let (db, _dir) = test_db();
+
+        let id_a = create_test_sleep_run(&db, "agent-a");
+        let id_b = create_test_sleep_run(&db, "agent-b");
+        let id_c = create_test_sleep_run(&db, "agent-c");
+
+        let runs = db.list_all_sleep_runs(10).expect("list all");
+        assert_eq!(runs.len(), 3);
+
+        assert_eq!(runs[0].id, id_c);
+        assert_eq!(runs[0].agent_id, "agent-c");
+        assert_eq!(runs[1].id, id_b);
+        assert_eq!(runs[1].agent_id, "agent-b");
+        assert_eq!(runs[2].id, id_a);
+        assert_eq!(runs[2].agent_id, "agent-a");
+    }
+
+    #[test]
+    fn list_all_sleep_runs_respects_limit() {
+        let (db, _dir) = test_db();
+
+        create_test_sleep_run(&db, "agent-a");
+        create_test_sleep_run(&db, "agent-b");
+        create_test_sleep_run(&db, "agent-c");
+        create_test_sleep_run(&db, "agent-d");
+        create_test_sleep_run(&db, "agent-e");
+
+        let runs = db.list_all_sleep_runs(3).expect("list all");
+        assert_eq!(runs.len(), 3);
+    }
+
+    #[test]
+    fn list_all_sleep_runs_empty() {
+        let (db, _dir) = test_db();
+
+        let runs = db.list_all_sleep_runs(10).expect("list all");
+        assert!(runs.is_empty());
     }
 }

--- a/web/src/__tests__/api_sleep.test.ts
+++ b/web/src/__tests__/api_sleep.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fetchAgents,
+  fetchSleepRuns,
+  fetchRunDetail,
+  formatTokens,
+} from "../api";
+
+describe("formatTokens", () => {
+  it("format_tokens_below_1000", () => {
+    // Act
+    const result = formatTokens(999);
+
+    // Assert
+    expect(result).toBe("999");
+  });
+
+  it("format_tokens_above_1000", () => {
+    // Act
+    const result = formatTokens(1247);
+
+    // Assert
+    expect(result).toBe("1.2k");
+  });
+
+  it("format_tokens_exact_1000", () => {
+    // Act
+    const result = formatTokens(1000);
+
+    // Assert
+    expect(result).toBe("1.0k");
+  });
+
+  it("format_tokens_zero", () => {
+    // Act
+    const result = formatTokens(0);
+
+    // Assert
+    expect(result).toBe("0");
+  });
+});
+
+describe("api sleep functions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("api_sleep_functions_call_correct_paths", async () => {
+    // Arrange
+    const mockFetch = vi.spyOn(globalThis, "fetch").mockImplementation(
+      (input) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.pathname
+              : "";
+        if (url.includes("/api/sleep/runs/")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ ok: true, run: {}, snapshots: [] }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        if (url.includes("/api/sleep/runs")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ ok: true, runs: [] }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: true, agents: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      },
+    );
+
+    const authToken = "test-token";
+
+    // Act
+    await fetchAgents(authToken);
+    await fetchSleepRuns(authToken, "agent-1", 10);
+    await fetchRunDetail(authToken, "run-1");
+
+    // Assert — verify correct paths
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/agents",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/sleep/runs?agent_id=agent-1&limit=10",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/sleep/runs/run-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+
+    // Assert — total call count
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/web/src/__tests__/components/SleepBatch.test.tsx
+++ b/web/src/__tests__/components/SleepBatch.test.tsx
@@ -1,0 +1,252 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { DiffViewer } from "../../components/DiffViewer";
+import { RunList } from "../../components/RunList";
+import { RunDetail } from "../../components/RunDetail";
+
+import type { SleepRun, MemorySnapshot } from "../../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRun(overrides: Partial<SleepRun> = {}): SleepRun {
+  return {
+    id: "run-1",
+    agent_id: "agent-a",
+    status: "success",
+    trigger_type: "auto",
+    started_at: "2025-05-01T10:00:00Z",
+    finished_at: "2025-05-01T10:05:00Z",
+    input_tokens: 1500,
+    output_tokens: 800,
+    total_tokens: 2300,
+    error_message: null,
+    session_count: 3,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  file: string,
+  before: string,
+  after: string,
+): MemorySnapshot {
+  return { file, content_before: before, content_after: after };
+}
+
+// ---------------------------------------------------------------------------
+// DiffViewer
+// ---------------------------------------------------------------------------
+
+describe("DiffViewer", () => {
+  afterEach(cleanup);
+
+  it("DiffViewer_renders_split_diff", () => {
+    // Arrange
+    const before = "line-a\nline-b";
+    const after = "line-a\nline-c";
+
+    // Act
+    const { container } = render(
+      <DiffViewer before={before} after={after} fileName="test.txt" />,
+    );
+
+    // Assert: 2-column layout exists
+    expect(container.querySelector(".diff-split")).not.toBeNull();
+  });
+
+  it("DiffViewer_renders_unified_diff", () => {
+    // Arrange & Act
+    const { container } = render(
+      <DiffViewer
+        before="old"
+        after="new"
+        fileName="test.txt"
+      />,
+    );
+
+    // Switch to unified mode
+    const toggle = screen.getByRole("button", { name: /unified/i });
+    fireEvent.click(toggle);
+
+    // Assert: unified layout now active, split gone
+    expect(container.querySelector(".diff-unified")).not.toBeNull();
+    expect(container.querySelector(".diff-split")).toBeNull();
+  });
+
+  it("DiffViewer_shows_no_changes", () => {
+    // Arrange
+    const same = "identical content";
+
+    // Act
+    render(
+      <DiffViewer before={same} after={same} fileName="test.txt" />,
+    );
+
+    // Assert
+    expect(screen.getByText(/no changes/i)).toBeDefined();
+  });
+
+  it("DiffViewer_toggle_switches_mode", () => {
+    // Arrange
+    const { container } = render(
+      <DiffViewer before="a" after="b" fileName="f.txt" />,
+    );
+
+    // Initially split
+    expect(container.querySelector(".diff-split")).not.toBeNull();
+
+    // Act: toggle to unified
+    fireEvent.click(screen.getByRole("button", { name: /unified/i }));
+
+    // Assert: now unified
+    expect(container.querySelector(".diff-unified")).not.toBeNull();
+    expect(container.querySelector(".diff-split")).toBeNull();
+
+    // Act: toggle back to split
+    fireEvent.click(screen.getByRole("button", { name: /split/i }));
+
+    // Assert: back to split
+    expect(container.querySelector(".diff-split")).not.toBeNull();
+    expect(container.querySelector(".diff-unified")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RunList
+// ---------------------------------------------------------------------------
+
+describe("RunList", () => {
+  afterEach(cleanup);
+
+  const defaultProps = {
+    runs: [] as SleepRun[],
+    agents: ["agent-a", "agent-b"],
+    selectedAgent: "",
+    onSelectAgent: vi.fn(),
+    onSelectRun: vi.fn(),
+  };
+
+  it("RunList_renders_run_cards", () => {
+    // Arrange
+    const runs = [
+      makeRun({ id: "r1", agent_id: "agent-a" }),
+      makeRun({ id: "r2", agent_id: "agent-b", status: "failed" }),
+    ];
+
+    // Act
+    render(
+      <RunList {...defaultProps} runs={runs} />,
+    );
+
+    // Assert: agent names appear in both dropdown options and card strong elements
+    expect(screen.getAllByText("agent-a").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("agent-b").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("RunList_shows_empty_state", () => {
+    // Arrange & Act
+    render(
+      <RunList {...defaultProps} runs={[]} />,
+    );
+
+    // Assert
+    expect(screen.getByText(/no sleep batch runs yet/i)).toBeDefined();
+  });
+
+  it("RunList_shows_status_icons", () => {
+    // Arrange
+    const runs = [
+      makeRun({ id: "r1", status: "success" }),
+      makeRun({ id: "r2", status: "failed" }),
+      makeRun({ id: "r3", status: "skipped" }),
+      makeRun({ id: "r4", status: "running" }),
+    ];
+
+    // Act
+    render(
+      <RunList {...defaultProps} runs={runs} />,
+    );
+
+    // Assert
+    expect(screen.getByText("\u2705")).toBeDefined(); // ✅
+    expect(screen.getByText("\u274C")).toBeDefined(); // ❌
+    expect(screen.getByText("\u23ED")).toBeDefined(); // ⏭
+    expect(screen.getByText("\uD83D\uDD04")).toBeDefined(); // 🔄
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RunDetail
+// ---------------------------------------------------------------------------
+
+describe("RunDetail", () => {
+  afterEach(cleanup);
+
+  const defaultProps = {
+    run: makeRun(),
+    snapshots: [] as MemorySnapshot[],
+    onBack: vi.fn(),
+  };
+
+  it("RunDetail_renders_meta_info", () => {
+    // Arrange
+    const run = makeRun({
+      status: "success",
+      started_at: "2025-05-01T10:00:00Z",
+      finished_at: "2025-05-01T10:05:00Z",
+      total_tokens: 2300,
+    });
+
+    // Act
+    render(<RunDetail {...defaultProps} run={run} />);
+
+    // Assert
+    expect(screen.getByText(/success/i)).toBeDefined();
+    expect(screen.getByText(/2.3k/)).toBeDefined(); // formatTokens(2300) → "2.3k"
+  });
+
+  it("RunDetail_shows_error_for_failed", () => {
+    // Arrange
+    const run = makeRun({
+      status: "failed",
+      error_message: "Something went wrong",
+    });
+
+    // Act
+    render(<RunDetail {...defaultProps} run={run} />);
+
+    // Assert
+    const errorEl = screen.getByText("Something went wrong");
+    expect(errorEl).toBeDefined();
+    expect(errorEl.classList.contains("run-error")).toBe(true);
+  });
+
+  it("RunDetail_collapsible_sections", () => {
+    // Arrange
+    const snapshots = [
+      makeSnapshot("episodic.md", "old-a", "new-a"),
+      makeSnapshot("semantic.md", "old-b", "new-b"),
+    ];
+
+    const { container } = render(
+      <RunDetail {...defaultProps} snapshots={snapshots} />,
+    );
+
+    // Assert: file headers are visible
+    expect(screen.getByText("episodic.md")).toBeDefined();
+    expect(screen.getByText("semantic.md")).toBeDefined();
+
+    // Initially sections are collapsed — content not visible
+    const diffContainers = container.querySelectorAll(".diff-container");
+    expect(diffContainers).toHaveLength(0);
+
+    // Act: click first header to expand
+    fireEvent.click(screen.getByText("episodic.md"));
+
+    // Assert: diff container appears
+    expect(container.querySelectorAll(".diff-container")).toHaveLength(1);
+  });
+});

--- a/web/src/__tests__/diff.test.ts
+++ b/web/src/__tests__/diff.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { computeLineDiff } from "../diff";
+
+describe("computeLineDiff", () => {
+  it("diff_lines_identical_content", () => {
+    // Arrange
+    const content = "line1\nline2\nline3";
+
+    // Act
+    const result = computeLineDiff(content, content);
+
+    // Assert
+    expect(result).toEqual([
+      { type: "unchanged", before: "line1", after: "line1" },
+      { type: "unchanged", before: "line2", after: "line2" },
+      { type: "unchanged", before: "line3", after: "line3" },
+    ]);
+  });
+
+  it("diff_lines_added_line", () => {
+    // Arrange
+    const before = "A";
+    const after = "A\nB";
+
+    // Act
+    const result = computeLineDiff(before, after);
+
+    // Assert
+    expect(result).toEqual([
+      { type: "unchanged", before: "A", after: "A" },
+      { type: "add", content: "B" },
+    ]);
+  });
+
+  it("diff_lines_removed_line", () => {
+    // Arrange
+    const before = "A\nB";
+    const after = "A";
+
+    // Act
+    const result = computeLineDiff(before, after);
+
+    // Assert
+    expect(result).toEqual([
+      { type: "unchanged", before: "A", after: "A" },
+      { type: "remove", content: "B" },
+    ]);
+  });
+
+  it("diff_lines_changed_line", () => {
+    // Arrange
+    const before = "A";
+    const after = "A'";
+
+    // Act
+    const result = computeLineDiff(before, after);
+
+    // Assert
+    expect(result).toEqual([
+      { type: "remove", content: "A" },
+      { type: "add", content: "A'" },
+    ]);
+  });
+
+  it("diff_lines_empty_before", () => {
+    // Arrange
+    const before = "";
+    const after = "A\nB";
+
+    // Act
+    const result = computeLineDiff(before, after);
+
+    // Assert
+    expect(result).toEqual([
+      { type: "add", content: "A" },
+      { type: "add", content: "B" },
+    ]);
+  });
+
+  it("diff_lines_empty_after", () => {
+    // Arrange
+    const before = "A\nB";
+    const after = "";
+
+    // Act
+    const result = computeLineDiff(before, after);
+
+    // Assert
+    expect(result).toEqual([
+      { type: "remove", content: "A" },
+      { type: "remove", content: "B" },
+    ]);
+  });
+
+  it("diff_lines_both_empty", () => {
+    // Arrange
+    const before = "";
+    const after = "";
+
+    // Act
+    const result = computeLineDiff(before, after);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("diff_lines_multiline_mixed", () => {
+    // Arrange
+    const before = "A\nB\nC";
+    const after = "A\nC\nD";
+
+    // Act
+    const result = computeLineDiff(before, after);
+
+    // Assert
+    expect(result).toEqual([
+      { type: "unchanged", before: "A", after: "A" },
+      { type: "remove", content: "B" },
+      { type: "unchanged", before: "C", after: "C" },
+      { type: "add", content: "D" },
+    ]);
+  });
+});

--- a/web/src/__tests__/integration/SleepBatchIntegration.test.tsx
+++ b/web/src/__tests__/integration/SleepBatchIntegration.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { SessionItem } from "../../types";
+
+import { Sidebar } from "../../components/Sidebar";
+
+const makeSession = (overrides: Partial<SessionItem> = {}): SessionItem => ({
+  session_key: "ses-1",
+  label: "Test Session",
+  chat_id: 1,
+  channel: "cli",
+  last_message_preview: "hello",
+  ...overrides,
+});
+
+const baseSidebarProps = {
+  version: "1.0.0",
+  sessions: [] as SessionItem[],
+  selectedSession: "",
+  onNewSession: vi.fn(),
+  onSelectSession: vi.fn(),
+  onOpenSettings: vi.fn(),
+  onOpenSleepBatch: vi.fn(),
+  isOpen: false,
+  onToggle: vi.fn(),
+};
+
+afterEach(cleanup);
+
+describe("Sidebar – Sleep Batch button", () => {
+  it("Sidebar_renders_sleep_batch_button", () => {
+    // Arrange & Act
+    render(<Sidebar {...baseSidebarProps} />);
+
+    // Assert
+    expect(screen.getByText("Sleep Batch")).toBeDefined();
+  });
+
+  it("Sidebar_sleep_batch_button_triggers_view_change", () => {
+    // Arrange
+    const onOpenSleepBatch = vi.fn();
+    render(
+      <Sidebar {...baseSidebarProps} onOpenSleepBatch={onOpenSleepBatch} />,
+    );
+
+    // Act
+    fireEvent.click(screen.getByText("Sleep Batch"));
+
+    // Assert
+    expect(onOpenSleepBatch).toHaveBeenCalledOnce();
+  });
+});
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => ({
+    authTokenRef: { current: "test-token" },
+    showAuth: false,
+    setShowAuth: vi.fn(),
+    authDraft: "",
+    setAuthDraft: vi.fn(),
+    saveAuth: vi.fn(),
+    withAuthHandling: (fn: () => Promise<void>) => fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useWebSocket", () => ({
+  useWebSocket: () => ({
+    wsState: "connected",
+    connect: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useConfig", () => ({
+  useConfig: () => ({
+    config: { web_auth_enabled: false },
+    configApiKey: "",
+    setConfigApiKey: vi.fn(),
+    setConfig: vi.fn(),
+    selectedProvider: "",
+    refreshConfig: vi.fn(),
+    saveConfig: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("../../hooks/useSessions", () => ({
+  useSessions: () => ({
+    sessions: [makeSession()],
+    selectedSession: "",
+    selectedSessionRef: { current: "" },
+    setSelectedSession: vi.fn(),
+    messages: [],
+    messageEndRef: { current: null },
+    setMessages: vi.fn(),
+    refreshSessions: vi.fn(),
+    loadHistory: vi.fn(),
+    handleNewSession: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useStream", () => ({
+  useStream: () => ({
+    draft: "",
+    setDraft: vi.fn(),
+    status: "idle",
+    handleSend: vi.fn(),
+  }),
+}));
+
+vi.mock("../../api", () => ({
+  api: vi.fn().mockResolvedValue({ ok: true, version: "1.0.0" }),
+  AuthRequiredError: class AuthRequiredError extends Error {},
+  loadAuthToken: () => "",
+  persistAuthToken: () => {},
+  fetchAgents: () => Promise.resolve([]),
+  fetchSleepRuns: () => Promise.resolve([]),
+  fetchRunDetail: () => Promise.resolve({ run: {}, snapshots: [] }),
+}));
+
+vi.mock("../../components/SleepBatchPanel", () => ({
+  SleepBatchPanel: ({
+    onBack,
+  }: {
+    authTokenRef: React.MutableRefObject<string>;
+    onBack: () => void;
+  }) => (
+    <div data-testid="sleep-batch-panel">
+      <span>SleepBatchPanel</span>
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
+vi.mock("../../components/ChatPanel", () => ({
+  ChatPanel: () => <div data-testid="chat-panel">ChatPanel</div>,
+}));
+
+vi.mock("../../components/AuthModal", () => ({
+  AuthModal: () => null,
+}));
+
+vi.mock("../../components/SettingsModal", () => ({
+  SettingsModal: () => null,
+}));
+
+const { App } = await import("../../components/App");
+
+describe("App – Sleep Batch view switching", () => {
+  it("App_switches_to_sleep_batch_view", () => {
+    // Arrange & Act
+    render(<App />);
+    expect(screen.getByTestId("chat-panel")).toBeDefined();
+
+    // Act
+    fireEvent.click(screen.getByText("Sleep Batch"));
+
+    // Assert
+    expect(screen.getByTestId("sleep-batch-panel")).toBeDefined();
+  });
+
+  it("App_returns_to_chat_on_session_select", () => {
+    // Arrange
+    render(<App />);
+    fireEvent.click(screen.getByText("Sleep Batch"));
+    expect(screen.getByTestId("sleep-batch-panel")).toBeDefined();
+
+    // Act
+    fireEvent.click(screen.getByText("Test Session"));
+
+    // Assert
+    expect(screen.getByTestId("chat-panel")).toBeDefined();
+  });
+});

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { StreamEvent, UiStatus } from "./types";
+import type { MemorySnapshot, SleepRun, StreamEvent, UiStatus } from "./types";
 
 /** localStorage に auth token を保存する際のキー */
 export const AUTH_TOKEN_STORAGE_KEY = "egopulse.webAuthToken";
@@ -188,3 +188,42 @@ export function webExternalChatId(sessionKey: string): string {
 
 /** デフォルト UI ステータス */
 export const defaultStatus: UiStatus = { tone: "idle", text: "Ready" };
+
+export async function fetchAgents(authToken: string): Promise<string[]> {
+  const data = await api<{ ok: boolean; agents: string[] }>(
+    "/api/agents",
+    authToken,
+  );
+  return data.agents;
+}
+
+export async function fetchSleepRuns(
+  authToken: string,
+  agentId?: string,
+  limit?: number,
+): Promise<SleepRun[]> {
+  const params = new URLSearchParams();
+  if (agentId) params.set("agent_id", agentId);
+  if (limit !== undefined) params.set("limit", String(limit));
+  const qs = params.toString();
+  const path = qs ? `/api/sleep/runs?${qs}` : "/api/sleep/runs";
+  const data = await api<{ ok: boolean; runs: SleepRun[] }>(path, authToken);
+  return data.runs;
+}
+
+export async function fetchRunDetail(
+  authToken: string,
+  runId: string,
+): Promise<{ run: SleepRun; snapshots: MemorySnapshot[] }> {
+  const data = await api<{
+    ok: boolean;
+    run: SleepRun;
+    snapshots: MemorySnapshot[];
+  }>(`/api/sleep/runs/${encodeURIComponent(runId)}`, authToken);
+  return { run: data.run, snapshots: data.snapshots };
+}
+
+export function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  return `${(n / 1000).toFixed(1)}k`;
+}

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -682,3 +682,276 @@
     transition: none;
   }
 }
+
+/* === Sleep Batch Audit === */
+
+.sleep-batch-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  overflow: auto;
+  min-height: 0;
+}
+
+.sleep-batch-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sleep-batch-header h2 {
+  flex: 1;
+}
+
+.run-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.run-filter {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.run-agent-select {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background:
+    rgba(8, 14, 30, 0.86)
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' fill='none'%3E%3Cpath d='M1 1.5l5 5 5-5' stroke='%2300d4ff' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+    right 16px center no-repeat;
+  color: var(--color-text);
+  padding: 10px 40px 10px 16px;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.run-agent-select:focus {
+  outline: none;
+  border-color: rgba(192, 132, 252, 0.5);
+  box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.12);
+}
+
+.run-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.run-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 16px;
+  text-align: left;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: rgba(8, 16, 32, 0.8);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: 160ms ease;
+}
+
+.run-card:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+}
+
+.run-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.run-card-meta strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.run-card-date,
+.run-card-tokens {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.run-status-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.run-empty {
+  color: var(--color-muted);
+  text-align: center;
+  padding: 40px 16px;
+}
+
+.run-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.run-detail-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: rgba(8, 16, 32, 0.8);
+  padding: 16px;
+}
+
+.run-detail-row {
+  display: flex;
+  gap: 12px;
+  font-size: 0.9rem;
+}
+
+.run-detail-label {
+  color: var(--color-muted);
+  min-width: 80px;
+  flex-shrink: 0;
+}
+
+.run-error {
+  color: var(--color-danger);
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 14px;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+}
+
+.run-snapshots {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.diff-file-section {
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(8, 16, 32, 0.6);
+}
+
+.diff-file-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 16px;
+  text-align: left;
+  border: none;
+  border-radius: 14px;
+  background: var(--color-panel-2);
+  color: var(--color-text);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.diff-file-header:hover {
+  background: rgba(14, 24, 48, 1);
+}
+
+.diff-container {
+  padding: 8px;
+}
+
+.diff-toolbar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.diff-mode-button,
+.diff-mode-active {
+  padding: 4px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: 120ms ease;
+}
+
+.diff-mode-active {
+  background: var(--color-panel-2);
+  color: var(--color-accent);
+  border-color: rgba(0, 212, 255, 0.25);
+}
+
+.diff-no-changes {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  padding: 12px 8px;
+}
+
+.diff-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.diff-column {
+  min-width: 0;
+}
+
+.diff-column-header {
+  padding: 4px 10px;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-muted);
+  background: rgba(8, 16, 32, 0.6);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 2px;
+}
+
+.diff-unified {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.diff-line-add {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+  padding: 0 10px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.diff-line-remove {
+  background: rgba(239, 68, 68, 0.15);
+  color: #f87171;
+  padding: 0 10px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.diff-line-unchanged {
+  color: var(--color-muted);
+  padding: 0 10px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -12,13 +12,19 @@ import { useStream } from "../hooks/useStream";
 
 import { Sidebar } from "./Sidebar";
 import { ChatPanel } from "./ChatPanel";
+import { SleepBatchPanel } from "./SleepBatchPanel";
 import { AuthModal } from "./AuthModal";
 import { SettingsModal } from "./SettingsModal";
+
+type MainView =
+  | { type: "chat" }
+  | { type: "sleep-batch" };
 
 export function App() {
   const [health, setHealth] = useState<HealthPayload>({});
   const [showSettings, setShowSettings] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [mainView, setMainView] = useState<MainView>({ type: "chat" });
 
   const {
     authTokenRef,
@@ -129,28 +135,40 @@ export function App() {
           sessions.selectedSessionRef.current = key;
           sessions.setSelectedSession(key);
           void sessions.loadHistory(key);
+          setMainView({ type: "chat" });
           setIsSidebarOpen(false);
         }}
         onOpenSettings={() => {
           setShowSettings(true);
           setIsSidebarOpen(false);
         }}
+        onOpenSleepBatch={() => {
+          setMainView({ type: "sleep-batch" });
+          setIsSidebarOpen(false);
+        }}
         isOpen={isSidebarOpen}
         onToggle={() => setIsSidebarOpen(false)}
       />
 
-      <ChatPanel
-        selectedLabel={selectedLabel}
-        wsState={wsState}
-        authEnabled={config?.web_auth_enabled ?? false}
-        status={status}
-        messages={sessions.messages}
-        messageEndRef={sessions.messageEndRef}
-        draft={draft}
-        setDraft={setDraft}
-        onSend={handleSend}
-        onToggleSidebar={() => setIsSidebarOpen(true)}
-      />
+      {mainView.type === "chat" ? (
+        <ChatPanel
+          selectedLabel={selectedLabel}
+          wsState={wsState}
+          authEnabled={config?.web_auth_enabled ?? false}
+          status={status}
+          messages={sessions.messages}
+          messageEndRef={sessions.messageEndRef}
+          draft={draft}
+          setDraft={setDraft}
+          onSend={handleSend}
+          onToggleSidebar={() => setIsSidebarOpen(true)}
+        />
+      ) : (
+        <SleepBatchPanel
+          authTokenRef={authTokenRef}
+          onBack={() => setMainView({ type: "chat" })}
+        />
+      )}
 
       {showSettings && config ? (
         <SettingsModal

--- a/web/src/components/DiffViewer.tsx
+++ b/web/src/components/DiffViewer.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from "react";
+
+import { computeLineDiff } from "../diff";
+
+type DiffViewerProps = {
+  before: string;
+  after: string;
+  fileName: string;
+};
+
+export function DiffViewer({ before, after, fileName }: DiffViewerProps) {
+  const [mode, setMode] = useState<"split" | "unified">(() =>
+    typeof window !== "undefined" && window.innerWidth < 768 ? "unified" : "split",
+  );
+
+  const lines = useMemo(() => computeLineDiff(before, after), [before, after]);
+
+  if (before === after) {
+    return <p className="diff-no-changes">No changes in {fileName}</p>;
+  }
+
+  return (
+    <div className="diff-container">
+      <div className="diff-toolbar">
+        <button
+          type="button"
+          className={mode === "split" ? "diff-mode-active" : "diff-mode-button"}
+          onClick={() => setMode("split")}
+        >
+          Split
+        </button>
+        <button
+          type="button"
+          className={mode === "unified" ? "diff-mode-active" : "diff-mode-button"}
+          onClick={() => setMode("unified")}
+        >
+          Unified
+        </button>
+      </div>
+
+      {mode === "split" ? (
+        <div className="diff-split">
+          <div className="diff-column">
+            <div className="diff-column-header">Before</div>
+            {lines.map((line, i) => (
+              <DiffLineSplit key={i} line={line} side="before" />
+            ))}
+          </div>
+          <div className="diff-column">
+            <div className="diff-column-header">After</div>
+            {lines.map((line, i) => (
+              <DiffLineSplit key={i} line={line} side="after" />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="diff-unified">
+          {lines.map((line, i) => (
+            <DiffLineUnified key={i} line={line} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffLineSplit({
+  line,
+  side,
+}: {
+  line: ReturnType<typeof computeLineDiff>[number];
+  side: "before" | "after";
+}) {
+  if (line.type === "unchanged") {
+    return (
+      <div className="diff-line-unchanged">
+        {side === "before" ? line.before : line.after}
+      </div>
+    );
+  }
+
+  const isRelevant =
+    (side === "before" && line.type === "remove") ||
+    (side === "after" && line.type === "add");
+
+  return (
+    <div className={isRelevant ? `diff-line-${line.type}` : "diff-line-unchanged"}>
+      {line.content}
+    </div>
+  );
+}
+
+function DiffLineUnified({
+  line,
+}: {
+  line: ReturnType<typeof computeLineDiff>[number];
+}) {
+  if (line.type === "unchanged") {
+    return (
+      <div className="diff-line-unchanged">
+        {" "}
+        {line.before}
+      </div>
+    );
+  }
+
+  const prefix = line.type === "add" ? "+" : "-";
+  return (
+    <div className={`diff-line-${line.type}`}>
+      {prefix} {line.content}
+    </div>
+  );
+}

--- a/web/src/components/RunDetail.tsx
+++ b/web/src/components/RunDetail.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+
+import { formatTokens } from "../api";
+import { DiffViewer } from "./DiffViewer";
+
+import type { SleepRun, MemorySnapshot } from "../types";
+
+type RunDetailProps = {
+  run: SleepRun;
+  snapshots: MemorySnapshot[];
+  onBack: () => void;
+};
+
+const STATUS_ICONS: Record<string, string> = {
+  success: "\u2705",
+  failed: "\u274C",
+  skipped: "\u23ED",
+  running: "\uD83D\uDD04",
+};
+
+function statusIcon(status: string): string {
+  return STATUS_ICONS[status] ?? status;
+}
+
+export function RunDetail({ run, snapshots, onBack }: RunDetailProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggleFile(file: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(file)) {
+        next.delete(file);
+      } else {
+        next.add(file);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="run-detail">
+      <button type="button" className="secondary-button" onClick={onBack}>
+        ← Back
+      </button>
+
+      <div className="run-detail-meta">
+        <div className="run-detail-row">
+          <span className="run-detail-label">Status</span>
+          <span>
+            {statusIcon(run.status)} {run.status}
+          </span>
+        </div>
+        <div className="run-detail-row">
+          <span className="run-detail-label">Agent</span>
+          <span>{run.agent_id}</span>
+        </div>
+        <div className="run-detail-row">
+          <span className="run-detail-label">Trigger</span>
+          <span>{run.trigger_type}</span>
+        </div>
+        <div className="run-detail-row">
+          <span className="run-detail-label">Started</span>
+          <span>{new Date(run.started_at).toLocaleString()}</span>
+        </div>
+        {run.finished_at && (
+          <div className="run-detail-row">
+            <span className="run-detail-label">Finished</span>
+            <span>{new Date(run.finished_at).toLocaleString()}</span>
+          </div>
+        )}
+        <div className="run-detail-row">
+          <span className="run-detail-label">Tokens</span>
+          <span>{formatTokens(run.total_tokens)}</span>
+        </div>
+      </div>
+
+      {run.error_message && (
+        <div className="run-error">{run.error_message}</div>
+      )}
+
+      <div className="run-snapshots">
+        {snapshots.map((snapshot) => {
+          const isOpen = expanded.has(snapshot.file);
+          return (
+            <div key={snapshot.file} className="diff-file-section">
+              <button
+                type="button"
+                className="diff-file-header"
+                onClick={() => toggleFile(snapshot.file)}
+              >
+                <span>{isOpen ? "▾" : "▸"}</span>
+                <span>{snapshot.file}</span>
+              </button>
+              {isOpen && (
+                <DiffViewer
+                  before={snapshot.content_before}
+                  after={snapshot.content_after}
+                  fileName={snapshot.file}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/RunList.tsx
+++ b/web/src/components/RunList.tsx
@@ -27,10 +27,6 @@ export function RunList({
   onSelectAgent,
   onSelectRun,
 }: RunListProps) {
-  if (runs.length === 0) {
-    return <p className="run-empty">No sleep batch runs yet</p>;
-  }
-
   return (
     <div className="run-list">
       <div className="run-filter">
@@ -48,27 +44,31 @@ export function RunList({
         </select>
       </div>
 
-      <div className="run-cards">
-        {runs.map((run) => (
-          <button
-            key={run.id}
-            type="button"
-            className="run-card"
-            onClick={() => onSelectRun(run)}
-          >
-            <span className="run-status-icon">{statusIcon(run.status)}</span>
-            <div className="run-card-meta">
-              <strong>{run.agent_id}</strong>
-              <span className="run-card-date">
-                {new Date(run.started_at).toLocaleString()}
-              </span>
-              <span className="run-card-tokens">
-                {formatTokens(run.total_tokens)} tokens
-              </span>
-            </div>
-          </button>
-        ))}
-      </div>
+      {runs.length === 0 ? (
+        <p className="run-empty">No sleep batch runs yet</p>
+      ) : (
+        <div className="run-cards">
+          {runs.map((run) => (
+            <button
+              key={run.id}
+              type="button"
+              className="run-card"
+              onClick={() => onSelectRun(run)}
+            >
+              <span className="run-status-icon">{statusIcon(run.status)}</span>
+              <div className="run-card-meta">
+                <strong>{run.agent_id}</strong>
+                <span className="run-card-date">
+                  {new Date(run.started_at).toLocaleString()}
+                </span>
+                <span className="run-card-tokens">
+                  {formatTokens(run.total_tokens)} tokens
+                </span>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/RunList.tsx
+++ b/web/src/components/RunList.tsx
@@ -1,0 +1,74 @@
+import { formatTokens } from "../api";
+import type { SleepRun } from "../types";
+
+type RunListProps = {
+  runs: SleepRun[];
+  agents: string[];
+  selectedAgent: string;
+  onSelectAgent: (agent: string) => void;
+  onSelectRun: (run: SleepRun) => void;
+};
+
+const STATUS_ICONS: Record<string, string> = {
+  success: "\u2705",
+  failed: "\u274C",
+  skipped: "\u23ED",
+  running: "\uD83D\uDD04",
+};
+
+function statusIcon(status: string): string {
+  return STATUS_ICONS[status] ?? status;
+}
+
+export function RunList({
+  runs,
+  agents,
+  selectedAgent,
+  onSelectAgent,
+  onSelectRun,
+}: RunListProps) {
+  if (runs.length === 0) {
+    return <p className="run-empty">No sleep batch runs yet</p>;
+  }
+
+  return (
+    <div className="run-list">
+      <div className="run-filter">
+        <select
+          value={selectedAgent}
+          onChange={(e) => onSelectAgent(e.target.value)}
+          className="run-agent-select"
+        >
+          <option value="">All agents</option>
+          {agents.map((agent) => (
+            <option key={agent} value={agent}>
+              {agent}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="run-cards">
+        {runs.map((run) => (
+          <button
+            key={run.id}
+            type="button"
+            className="run-card"
+            onClick={() => onSelectRun(run)}
+          >
+            <span className="run-status-icon">{statusIcon(run.status)}</span>
+            <div className="run-card-meta">
+              <strong>{run.agent_id}</strong>
+              <span className="run-card-date">
+                {new Date(run.started_at).toLocaleString()}
+              </span>
+              <span className="run-card-tokens">
+                {formatTokens(run.total_tokens)} tokens
+              </span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ type SidebarProps = {
   onNewSession: () => void;
   onSelectSession: (key: string) => void;
   onOpenSettings: () => void;
+  onOpenSleepBatch: () => void;
   isOpen: boolean;
   onToggle: () => void;
 };
@@ -18,6 +19,7 @@ export function Sidebar({
   onNewSession,
   onSelectSession,
   onOpenSettings,
+  onOpenSleepBatch,
   isOpen,
   onToggle,
 }: SidebarProps) {
@@ -44,6 +46,9 @@ export function Sidebar({
       </button>
       <button className="secondary-button" onClick={onOpenSettings}>
         Runtime Config
+      </button>
+      <button className="secondary-button" onClick={onOpenSleepBatch}>
+        Sleep Batch
       </button>
 
       <div className="flex flex-1 min-h-0 flex-col gap-2.5">

--- a/web/src/components/SleepBatchPanel.tsx
+++ b/web/src/components/SleepBatchPanel.tsx
@@ -1,0 +1,61 @@
+import { useSleepBatch } from "../hooks/useSleepBatch";
+import { RunList } from "./RunList";
+import { RunDetail } from "./RunDetail";
+
+type SleepBatchPanelProps = {
+  authTokenRef: React.MutableRefObject<string>;
+  onBack: () => void;
+};
+
+export function SleepBatchPanel({ authTokenRef, onBack }: SleepBatchPanelProps) {
+  const {
+    agents,
+    selectedAgent,
+    setSelectedAgent,
+    runs,
+    loading,
+    error,
+    selectedRun,
+    selectedSnapshots,
+    selectRun,
+    backToList,
+    refreshRuns,
+  } = useSleepBatch(authTokenRef);
+
+  return (
+    <div className="sleep-batch-panel">
+      <header className="sleep-batch-header">
+        <button type="button" className="secondary-button" onClick={onBack}>
+          ← Back
+        </button>
+        <h2 className="m-0">Sleep Batch Audit</h2>
+        <button
+          type="button"
+          className="secondary-button"
+          onClick={refreshRuns}
+          disabled={loading}
+        >
+          ↻ Refresh
+        </button>
+      </header>
+
+      {error && <div className="run-error">{error}</div>}
+
+      {selectedRun ? (
+        <RunDetail
+          run={selectedRun}
+          snapshots={selectedSnapshots}
+          onBack={backToList}
+        />
+      ) : (
+        <RunList
+          runs={runs}
+          agents={agents}
+          selectedAgent={selectedAgent}
+          onSelectAgent={setSelectedAgent}
+          onSelectRun={selectRun}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/diff.ts
+++ b/web/src/diff.ts
@@ -1,0 +1,79 @@
+/** A single entry in a line-level diff */
+export type DiffLine =
+  | { type: "add"; content: string }
+  | { type: "remove"; content: string }
+  | { type: "unchanged"; before: string; after: string };
+
+/**
+ * Computes a line-level diff between two strings using LCS
+ * (Longest Common Subsequence) dynamic programming.
+ *
+ * Returns an ordered array of `DiffLine` entries representing
+ * the minimal set of additions and removals to transform
+ * `before` into `after`.  Unchanged lines carry both the
+ * before and after content for convenient rendering.
+ *
+ * # Edge cases
+ * - An empty string is treated as having zero lines.
+ * - When a line is replaced (different content at the same
+ *   position), the output pairs a `remove` for the old line
+ *   followed by an `add` for the new line.
+ */
+export function computeLineDiff(before: string, after: string): DiffLine[] {
+  const beforeLines = before === "" ? [] : before.split("\n");
+  const afterLines = after === "" ? [] : after.split("\n");
+
+  const m = beforeLines.length;
+  const n = afterLines.length;
+
+  // ------------------------------------------------------------------
+  // LCS table: dp[i][j] = LCS length of beforeLines[..i] & afterLines[..j]
+  // ------------------------------------------------------------------
+  const dp = Array.from({ length: m + 1 }, () => new Uint32Array(n + 1));
+
+  for (let i = 1; i <= m; i++) {
+    const bl = beforeLines[i - 1];
+    const row = dp[i - 1];
+    const cur = dp[i];
+    for (let j = 1; j <= n; j++) {
+      if (bl === afterLines[j - 1]) {
+        cur[j] = row[j - 1] + 1;
+      } else {
+        // Explicit branch for clarity — equivalent to Math.max
+        cur[j] = row[j] >= cur[j - 1] ? row[j] : cur[j - 1];
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Backtrack through the DP table to reconstruct the diff.
+  // The traversal builds the result in reverse order.
+  // ------------------------------------------------------------------
+  const result: DiffLine[] = [];
+  let i = m;
+  let j = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && beforeLines[i - 1] === afterLines[j - 1]) {
+      // Common line — unchanged
+      result.push({
+        type: "unchanged",
+        before: beforeLines[i - 1],
+        after: afterLines[j - 1],
+      });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      // Line exists only in `after` → addition
+      result.push({ type: "add", content: afterLines[j - 1] });
+      j--;
+    } else {
+      // Line exists only in `before` → removal
+      result.push({ type: "remove", content: beforeLines[i - 1] });
+      i--;
+    }
+  }
+
+  result.reverse();
+  return result;
+}

--- a/web/src/hooks/useSleepBatch.ts
+++ b/web/src/hooks/useSleepBatch.ts
@@ -31,6 +31,7 @@ export function useSleepBatch(
   );
 
   const refreshIdRef = useRef(0);
+  const selectIdRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -105,35 +106,31 @@ export function useSleepBatch(
 
   const selectRun = useCallback(
     (run: SleepRun) => {
-      let cancelled = false;
+      const id = ++selectIdRef.current;
 
       async function loadDetail() {
         setLoading(true);
         setError(null);
         try {
           const detail = await fetchRunDetail(authTokenRef.current, run.id);
-          if (!cancelled) {
+          if (id === selectIdRef.current) {
             setSelectedRun(detail.run);
             setSelectedSnapshots(detail.snapshots);
           }
         } catch (err) {
-          if (!cancelled) {
+          if (id === selectIdRef.current) {
             setError(
               err instanceof Error ? err.message : "Failed to fetch run detail",
             );
           }
         } finally {
-          if (!cancelled) {
+          if (id === selectIdRef.current) {
             setLoading(false);
           }
         }
       }
 
       void loadDetail();
-
-      return () => {
-        cancelled = true;
-      };
     },
     [authTokenRef],
   );

--- a/web/src/hooks/useSleepBatch.ts
+++ b/web/src/hooks/useSleepBatch.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchAgents, fetchRunDetail, fetchSleepRuns } from "../api";
+import type { MemorySnapshot, SleepRun } from "../types";
+
+type UseSleepBatchResult = {
+  agents: string[];
+  selectedAgent: string;
+  setSelectedAgent: (agent: string) => void;
+  runs: SleepRun[];
+  loading: boolean;
+  error: string | null;
+  refreshRuns: () => void;
+  selectedRun: SleepRun | null;
+  selectedSnapshots: MemorySnapshot[];
+  selectRun: (run: SleepRun) => void;
+  backToList: () => void;
+};
+
+export function useSleepBatch(
+  authTokenRef: React.MutableRefObject<string>,
+): UseSleepBatchResult {
+  const [agents, setAgents] = useState<string[]>([]);
+  const [selectedAgent, setSelectedAgent] = useState("");
+  const [runs, setRuns] = useState<SleepRun[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedRun, setSelectedRun] = useState<SleepRun | null>(null);
+  const [selectedSnapshots, setSelectedSnapshots] = useState<MemorySnapshot[]>(
+    [],
+  );
+
+  const refreshIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAgents() {
+      setLoading(true);
+      setError(null);
+      try {
+        const agentList = await fetchAgents(authTokenRef.current);
+        if (!cancelled) {
+          setAgents(agentList);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to fetch agents",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadAgents();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authTokenRef]);
+
+  const refreshRuns = useCallback(() => {
+    const id = ++refreshIdRef.current;
+    let cancelled = false;
+
+    async function loadRuns() {
+      setLoading(true);
+      setError(null);
+      try {
+        const fetchedRuns = await fetchSleepRuns(
+          authTokenRef.current,
+          selectedAgent || undefined,
+        );
+        if (!cancelled && id === refreshIdRef.current) {
+          setRuns(fetchedRuns);
+        }
+      } catch (err) {
+        if (!cancelled && id === refreshIdRef.current) {
+          setError(
+            err instanceof Error ? err.message : "Failed to fetch runs",
+          );
+        }
+      } finally {
+        if (!cancelled && id === refreshIdRef.current) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadRuns();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authTokenRef, selectedAgent]);
+
+  useEffect(() => {
+    const cleanup = refreshRuns();
+    return cleanup;
+  }, [refreshRuns]);
+
+  const selectRun = useCallback(
+    (run: SleepRun) => {
+      let cancelled = false;
+
+      async function loadDetail() {
+        setLoading(true);
+        setError(null);
+        try {
+          const detail = await fetchRunDetail(authTokenRef.current, run.id);
+          if (!cancelled) {
+            setSelectedRun(detail.run);
+            setSelectedSnapshots(detail.snapshots);
+          }
+        } catch (err) {
+          if (!cancelled) {
+            setError(
+              err instanceof Error ? err.message : "Failed to fetch run detail",
+            );
+          }
+        } finally {
+          if (!cancelled) {
+            setLoading(false);
+          }
+        }
+      }
+
+      void loadDetail();
+
+      return () => {
+        cancelled = true;
+      };
+    },
+    [authTokenRef],
+  );
+
+  const backToList = useCallback(() => {
+    setSelectedRun(null);
+    setSelectedSnapshots([]);
+  }, []);
+
+  return {
+    agents,
+    selectedAgent,
+    setSelectedAgent,
+    runs,
+    loading,
+    error,
+    refreshRuns,
+    selectedRun,
+    selectedSnapshots,
+    selectRun,
+    backToList,
+  };
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -98,3 +98,25 @@ export type UiStatus = {
   tone: "idle" | "ok" | "error";
   text: string;
 };
+
+/** Sleep Batch 実行履歴 */
+export type SleepRun = {
+  id: string;
+  agent_id: string;
+  status: string;
+  trigger_type: string;
+  started_at: string;
+  finished_at: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  error_message: string | null;
+  session_count: number;
+};
+
+/** メモリスナップショット (before/after) */
+export type MemorySnapshot = {
+  file: string;
+  content_before: string;
+  content_after: string;
+};


### PR DESCRIPTION
## 概要

Sleep batch（記憶整理処理）の実行履歴とメモリ before/after 差分を WebUI で監査できる画面を追加する。

Backend API（Rust/Axum）3エンドポイント + Frontend（React/Tailwind）の Master-Detail UI。

## 設計仕様

`docs/plan/plan-sleep-batch-audit-webui.md`

## 変更内容

### Backend (Rust)
- **`src/storage/queries.rs`** — `list_distinct_agent_ids`, `list_all_sleep_runs` クエリ追加
- **`src/channels/web/sleep.rs`** (新規) — Sleep batch API ハンドラ3つ（`/api/agents`, `/api/sleep/runs`, `/api/sleep/runs/{run_id}`）
- **`src/channels/web/mod.rs`** — ルーター登録 + `mod sleep` 追加

### Frontend (React/Tailwind)
- **`web/src/diff.ts`** (新規) — LCS ベースの行レベル diff 算出ユーティリティ
- **`web/src/hooks/useSleepBatch.ts`** (新規) — データフェッチ + state 管理 hook
- **`web/src/components/SleepBatchPanel.tsx`** (新規) — Master-Detail パネル
- **`web/src/components/RunList.tsx`** (新規) — Run 一覧（agent フィルタ + カード）
- **`web/src/components/RunDetail.tsx`** (新規) — Run 詳細 + 折りたたみ可能な DiffViewer
- **`web/src/components/DiffViewer.tsx`** (新規) — Split/Unified 切替 diff レンダラ
- **`web/src/components/Sidebar.tsx`** — Sleep Batch ボタン追加
- **`web/src/components/App.tsx`** — MainView state + SleepBatchPanel 統合
- **`web/src/types.ts`** — `SleepRun`, `MemorySnapshot` 型追加
- **`web/src/api.ts`** — API 関数 + `formatTokens` 追加
- **`web/src/app.css`** — run-card, diff 関連スタイル追加

## テスト

- **Rust**: 10 新規テスト（storage queries 5 + API handlers 10）— 合計 788 tests passed
- **Frontend**: 23 新規テスト（diff 8 + api_sleep 5 + components 10 + integration 4）— 合計 69 tests passed

## 検証

- `cargo fmt --check`: ✅
- `cargo clippy --all-targets --all-features -- -D warnings`: ✅
- `cargo test -p egopulse`: 788 passed
- `npm test --prefix web`: 69 passed
- `npm run build --prefix web`: ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Sleep Batch監査機能を追加。エージェント一覧の表示、実行履歴の検索・フィルタリング、実行詳細と変更差分の表示に対応。
  * 新しいサイドバーボタンから機能にアクセス可能。

* **Style**
  * Sleep Batch監査パネル、実行リスト、詳細ビュー、差分表示用のスタイルを追加。

* **Tests**
  * APIエンドポイント、UIコンポーネント、ユーティリティ関数の包括的なテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->