### PR TITLE
fix: split diff view showed same content in both columns

### DIFF
--- a/web/src/components/DiffViewer.tsx
+++ b/web/src/components/DiffViewer.tsx
@@ -79,12 +79,16 @@ function DiffLineSplit({
     );
   }
 
-  const isRelevant =
+  const belongsToThisSide =
     (side === "before" && line.type === "remove") ||
     (side === "after" && line.type === "add");
 
+  if (!belongsToThisSide) {
+    return <div className="diff-line-placeholder" />;
+  }
+
   return (
-    <div className={isRelevant ? `diff-line-${line.type}` : "diff-line-unchanged"}>
+    <div className={`diff-line-${line.type}`}>
       {line.content}
     </div>
   );


### PR DESCRIPTION
## 概要

Split表示モードのDiffViewerで、Before列に追加行のテキストが、After列に削除行のテキストが unchanged として表示され、両カラムが同じ内容に見えていたバグを修正。

## 原因

`DiffLineSplit` で `isRelevant=false` の行（相手側にのみ存在する行）を `line.content` で表示していたため、Before/After両方に全テキストが並んでいた。

## 修正内容

`DiffLineSplit` で `belongsToThisSide=false` の場合、空のプレースホルダー `<div>` を表示するよう変更。標準的なsplit diffツールと同じ挙動。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* **差分ビューアーの表示改善** - スプリットビュー形式で、各列に関連する行のみが正しく表示されるようになりました。不要な行は空のプレースホルダーで表示され、統一されたスタイリングが適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->