### PR TITLE
refactor: Message→Text 変換ロジックの3系統統一

### DIFF
--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -6,8 +6,8 @@
 use crate::agent_loop::SurfaceContext;
 use crate::agent_loop::compaction::{PromptContext, maybe_compact_messages};
 use crate::agent_loop::formatting::{
-    format_tool_result, preview_text, sanitize_assistant_response_text, strip_thinking,
-    summarize_tool_calls_with_content, tool_message_content,
+    format_tool_result, message_to_text, preview_text, sanitize_assistant_response_text,
+    strip_thinking, summarize_tool_calls_with_content, tool_message_content,
 };
 use crate::agent_loop::guards::{is_declarative_only_reply, runtime_guard_messages};
 pub(crate) use crate::agent_loop::prompt_builder::build_system_prompt;
@@ -595,7 +595,7 @@ async fn persist_tool_result_messages(
 fn summarize_tool_result_messages(tool_messages: &[Message]) -> String {
     let joined = tool_messages
         .iter()
-        .map(|message| message.content.as_text_lossy())
+        .map(message_to_text)
         .collect::<Vec<_>>()
         .join("\n");
     preview_text(&joined, 160)

--- a/src/sleep/batch.rs
+++ b/src/sleep/batch.rs
@@ -362,16 +362,31 @@ fn estimate_text_tokens(text: &str) -> usize {
 /// Tool results are truncated to 200 chars (matching compaction behavior),
 /// assistant thinking tags are stripped, and tool calls are rendered as
 /// `[tool_use: name(args)]` notation.
+///
+/// Falls back to raw `content` field extraction when the stored JSON cannot
+/// be deserialized as `Vec<Message>` (e.g. schema mismatch from an older
+/// version or a corrupted snapshot), so that session text is never silently
+/// dropped.
 fn extract_messages_text(messages_json: &Option<String>) -> String {
     let Some(json_str) = messages_json else {
         return String::new();
     };
-    let Ok(messages) = serde_json::from_str::<Vec<Message>>(json_str) else {
+    if let Ok(messages) = serde_json::from_str::<Vec<Message>>(json_str) {
+        return messages
+            .iter()
+            .map(message_to_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    // Fallback: extract raw "content" fields from whatever JSON structure
+    // is present, preserving session text even when the Message schema has
+    // changed or the snapshot is partially corrupt.
+    let Ok(values) = serde_json::from_str::<Vec<serde_json::Value>>(json_str) else {
         return String::new();
     };
-    messages
+    values
         .iter()
-        .map(message_to_text)
+        .filter_map(|v| v.get("content").and_then(|c| c.as_str()))
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/src/sleep/batch.rs
+++ b/src/sleep/batch.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use tracing::{info, warn};
 
 use crate::agent_loop::compaction::archive_conversation_blocking;
+use crate::agent_loop::formatting::message_to_text;
 use crate::llm::{LlmProvider, Message, MessagesResponse};
 use crate::memory::{MemoryContent, MemoryLoader, collect_sleep_input};
 use crate::runtime::AppState;
@@ -356,17 +357,21 @@ fn estimate_text_tokens(text: &str) -> usize {
     text.len().div_ceil(ESTIMATED_CHARS_PER_TOKEN)
 }
 
-/// Extracts message content from a JSON array of `{"role":"...","content":"..."}` objects.
+/// Extracts message text using [`message_to_text`] for uniform formatting.
+///
+/// Tool results are truncated to 200 chars (matching compaction behavior),
+/// assistant thinking tags are stripped, and tool calls are rendered as
+/// `[tool_use: name(args)]` notation.
 fn extract_messages_text(messages_json: &Option<String>) -> String {
     let Some(json_str) = messages_json else {
         return String::new();
     };
-    let Ok(values) = serde_json::from_str::<Vec<serde_json::Value>>(json_str) else {
+    let Ok(messages) = serde_json::from_str::<Vec<Message>>(json_str) else {
         return String::new();
     };
-    values
+    messages
         .iter()
-        .filter_map(|v| v.get("content").and_then(|c| c.as_str()))
+        .map(message_to_text)
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/src/sleep/batch.rs
+++ b/src/sleep/batch.rs
@@ -362,31 +362,16 @@ fn estimate_text_tokens(text: &str) -> usize {
 /// Tool results are truncated to 200 chars (matching compaction behavior),
 /// assistant thinking tags are stripped, and tool calls are rendered as
 /// `[tool_use: name(args)]` notation.
-///
-/// Falls back to raw `content` field extraction when the stored JSON cannot
-/// be deserialized as `Vec<Message>` (e.g. schema mismatch from an older
-/// version or a corrupted snapshot), so that session text is never silently
-/// dropped.
 fn extract_messages_text(messages_json: &Option<String>) -> String {
     let Some(json_str) = messages_json else {
         return String::new();
     };
-    if let Ok(messages) = serde_json::from_str::<Vec<Message>>(json_str) {
-        return messages
-            .iter()
-            .map(message_to_text)
-            .collect::<Vec<_>>()
-            .join("\n");
-    }
-    // Fallback: extract raw "content" fields from whatever JSON structure
-    // is present, preserving session text even when the Message schema has
-    // changed or the snapshot is partially corrupt.
-    let Ok(values) = serde_json::from_str::<Vec<serde_json::Value>>(json_str) else {
+    let Ok(messages) = serde_json::from_str::<Vec<Message>>(json_str) else {
         return String::new();
     };
-    values
+    messages
         .iter()
-        .filter_map(|v| v.get("content").and_then(|c| c.as_str()))
+        .map(message_to_text)
         .collect::<Vec<_>>()
         .join("\n")
 }


### PR DESCRIPTION

## 背景

メッセージ（`Message`）をテキスト表現に変換するロジックが、呼び出し箇所ごとに3系統に分散していた。

| 用途 | 関数 | tool result の扱い |
|---|---|---|
| Compaction（セッション要約） | `message_to_text()` | 200字切り詰め、`[tool_result]:` プレフィックス、thinking 除去 |
| UI 表示（`stored_messages.content`） | `summarize_tool_result_messages()` | `content.as_text_lossy()` で生の JSON payload を結合後 160字切り詰め |
| Sleep Batch（長期記憶生成） | `extract_messages_text()` | **切り詰めなし**。全文の `content` を改行結合 |

### 問題

1. **Sleep Batch のノイズ**: `extract_messages_text()` が tool result の JSON payload 全体（最大16,000字）をそのまま sleep batch の system prompt に注入していた。ビルドログ数千年、ソースコード全文、Web ページ全文などがノイズとして混入し、LLM が本質的な記憶抽出に集中できない状態だった。

2. **UI 表示の不一致**: `summarize_tool_result_messages()` が `content.as_text_lossy()` を使っていたため、`{"tool":"bash","status":"success","result":"..."}` という JSON がそのまま UI のプレビューに表示されていた。

3. **ロジックの重複**: 同じ「メッセージをテキスト化する」目的で3つの独立した実装が存在し、閾値やフォーマットがバラバラだった。

## 目的

`message_to_text()`（`formatting.rs`）を **Message → text 変換の唯一の正規パス** とし、3系統を統一する。

## 変更内容

### `src/sleep/batch.rs` — `extract_messages_text()`

**Before**: `serde_json::Value` から `content` フィールドを生抜きして改行結合（切り詰めなし）
**After**: `Vec<Message>` にデシリアライズ後、`message_to_text()` で統一フォーマット化

```
# Before
{"tool":"bash","status":"success","result":"Compiling egopulse...\n...3000行...\nFinished"}
{"tool":"read","status":"success","result":"use std::sync::Arc;\n...500行..."}

# After
[tool_result]: Compiling egopulse...
[tool_result]: use std::sync::Arc;...
```

### `src/agent_loop/turn.rs` — `summarize_tool_result_messages()`

**Before**: `content.as_text_lossy()` で JSON payload をそのまま取得
**After**: `message_to_text()` で `[tool_result]:` / `[tool_error]:` プレフィックス付きの統一フォーマットを取得

## 影響範囲

- Sleep batch の LLM 呼び出しに対する入力テキストが大幅に削減される（tool result が最大16,000字 → 200字）
- UI の `stored_messages.content` に `[tool_result]:` プレフィックスが付くようになる
- Compaction は既に `message_to_text()` を使用しているため変更なし
- ドキュメントへの影響なし（該当する具体的な関数名の記載なし）

## 検証

- `cargo fmt --check`: OK
- `cargo clippy --all-targets --all-features -- -D warnings`: OK
- `cargo test`: 994 tests passed (991 + 3 + 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ツール結果メッセージおよびセッションメッセージの処理方法を統一し、内部的な一貫性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->