### PR TITLE
feat: messages テーブルの送信者表現を sender_id/sender_kind に統合

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -48,9 +48,9 @@ egopulse.db (SQLite / WAL mode)
 │    chats         │1    * │    messages      │
 │──────────────────│───────│──────────────────│
 │ chat_id (PK)     │       │ (id, chat_id) PK │
-│ chat_title       │       │ sender_name      │
+│ chat_title       │       │ sender_id        │
 │ chat_type        │       │ content          │
-│ last_message_time│       │ is_from_bot      │
+│ last_message_time│       │ sender_kind      │
 │ channel          │       │ timestamp        │
 │ external_chat_id │       └──────────────────┘
 │ agent_id         │
@@ -208,12 +208,11 @@ Multi-Agent Room では共有の Channel Log チャットが作成される。
 CREATE TABLE IF NOT EXISTS messages (
     id TEXT NOT NULL,
     chat_id INTEGER NOT NULL,
-    sender_name TEXT NOT NULL,
+    sender_id TEXT NOT NULL,
     content TEXT NOT NULL,
-    is_from_bot INTEGER NOT NULL DEFAULT 0,
+    sender_kind TEXT NOT NULL DEFAULT 'user',
     timestamp TEXT NOT NULL,
     message_kind TEXT NOT NULL DEFAULT 'message',
-    sender_agent_id TEXT,
     recipient_agent_id TEXT,
     PRIMARY KEY (id, chat_id)
 );
@@ -226,12 +225,11 @@ CREATE INDEX IF NOT EXISTS idx_messages_chat_timestamp
 |--------|----|------|------|
 | id | TEXT | PK（複合） | プラットフォーム固有のメッセージID |
 | chat_id | INTEGER | PK（複合） | chats.chat_id への参照 |
-| sender_name | TEXT | NOT NULL | 送信者表示名 |
+| sender_id | TEXT | NOT NULL | 統一送信者識別子（例: `"lyre"`, `"user:discord:123"`, `"system"`, `"pulse"`） |
 | content | TEXT | NOT NULL | メッセージ本文 |
-| is_from_bot | INTEGER | NOT NULL DEFAULT 0 | ボット発言フラグ（0/1） |
+| sender_kind | TEXT | NOT NULL DEFAULT 'user' | 送信者種別（`user`, `assistant`, `system`, `tool`） |
 | timestamp | TEXT | NOT NULL | RFC3339 タイムスタンプ |
 | message_kind | TEXT | NOT NULL DEFAULT 'message' | メッセージ種別（`message`, `agent_send`, `system_event`） |
-| sender_agent_id | TEXT | nullable | 送信エージェント ID。Multi-Agent Room で使用 |
 | recipient_agent_id | TEXT | nullable | 受信エージェント ID。Multi-Agent Room で使用 |
 
 **操作**:
@@ -245,8 +243,8 @@ CREATE INDEX IF NOT EXISTS idx_messages_chat_timestamp
 | 値 | 説明 |
 |----|------|
 | `message` | 通常のチャットメッセージ（デフォルト） |
-| `agent_send` | エージェント間通信。`sender_agent_id` に送信元、`recipient_agent_id` に宛先エージェント ID が設定される |
-| `system_event` | システムイベント。停止条件によるターン拒否や LLM 失敗を記録。`sender_name` は `"system"`、`is_from_bot` は `true`。`content` は JSON 形式（`{"reason": "ChainDepthExceeded"}` 等） |
+| `agent_send` | エージェント間通信。`sender_kind` は `tool`、`recipient_agent_id` に宛先エージェント ID が設定される |
+| `system_event` | システムイベント。停止条件によるターン拒否や LLM 失敗を記録。`sender_id` は `"system"`、`sender_kind` は `system`。`content` は JSON 形式（`{"reason": "ChainDepthExceeded"}` 等） |
 
 ---
 
@@ -656,7 +654,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 
 | 構造体 | テーブル | フィールド |
 |--------|----------|-----------|
-| `StoredMessage` | messages | id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id |
+| `StoredMessage` | messages | id, chat_id, sender_id, content, sender_kind, timestamp, message_kind, recipient_agent_id |
 | `ChatInfo` | chats（一部） | chat_id, channel, external_chat_id, chat_type, agent_id |
 | `SessionSummary` | chats + messages（JOIN） | chat_id, channel, surface_thread, chat_title, last_message_time, last_message_preview, agent_id |
 | `SessionSnapshot` | sessions + messages | messages_json, updated_at, recent_messages: Vec\<StoredMessage\> |

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -10,7 +10,7 @@ use crate::assets::AssetStore;
 use crate::error::{EgoPulseError, StorageError};
 use crate::llm::{Message, MessageContent, MessageContentPart};
 use crate::runtime::AppState;
-use crate::storage::{SessionSnapshot, SessionSummary, StoredMessage, call_blocking};
+use crate::storage::{SenderKind, SessionSnapshot, SessionSummary, StoredMessage, call_blocking};
 
 #[derive(Debug, Clone)]
 /// Holds the messages loaded for a turn together with the snapshot version.
@@ -71,14 +71,12 @@ pub(crate) async fn load_session_messages(
     Ok(history
         .into_iter()
         .map(|message| {
-            Message::text(
-                if message.is_from_bot {
-                    "assistant"
-                } else {
-                    "user"
-                },
-                message.content,
-            )
+            let role = match message.sender_kind {
+                SenderKind::Assistant | SenderKind::Tool => "assistant",
+                SenderKind::User => "user",
+                SenderKind::System => "system",
+            };
+            Message::text(role, message.content)
         })
         .collect())
 }
@@ -260,14 +258,12 @@ fn loaded_from_recent(snapshot: &SessionSnapshot) -> LoadedSession {
             .recent_messages
             .iter()
             .map(|message| {
-                Message::text(
-                    if message.is_from_bot {
-                        "assistant"
-                    } else {
-                        "user"
-                    },
-                    message.content.clone(),
-                )
+                let role = match message.sender_kind {
+                    SenderKind::Assistant | SenderKind::Tool => "assistant",
+                    SenderKind::User => "user",
+                    SenderKind::System => "system",
+                };
+                Message::text(role, message.content.clone())
             })
             .collect(),
         session_updated_at: snapshot.updated_at.clone(),
@@ -434,7 +430,7 @@ mod tests {
         LlmProvider, Message, MessageContent, MessageContentPart, MessagesResponse, ToolCall,
     };
     use crate::runtime::AppState;
-    use crate::storage::{MessageKind, StoredMessage, call_blocking};
+    use crate::storage::{MessageKind, SenderKind, StoredMessage, call_blocking};
 
     struct FakeProvider {
         response: String,
@@ -515,12 +511,11 @@ mod tests {
         let seed_message = StoredMessage {
             id: "seed-user".to_string(),
             chat_id,
-            sender_name: context.surface_user.clone(),
+            sender_id: context.surface_user.clone(),
             content: "hello".to_string(),
-            is_from_bot: false,
+            sender_kind: SenderKind::User,
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             message_kind: MessageKind::Message,
-            sender_agent_id: None,
             recipient_agent_id: None,
         };
         call_blocking(Arc::clone(&state.db), {
@@ -547,12 +542,11 @@ mod tests {
         let concurrent_message = StoredMessage {
             id: "seed-assistant".to_string(),
             chat_id,
-            sender_name: "egopulse".to_string(),
+            sender_id: "egopulse".to_string(),
             content: "hi".to_string(),
-            is_from_bot: true,
+            sender_kind: SenderKind::Assistant,
             timestamp: "2024-01-01T00:00:01Z".to_string(),
             message_kind: MessageKind::Message,
-            sender_agent_id: None,
             recipient_agent_id: None,
         };
         call_blocking(Arc::clone(&state.db), {
@@ -575,12 +569,11 @@ mod tests {
             StoredMessage {
                 id: "new-user".to_string(),
                 chat_id,
-                sender_name: context.surface_user.clone(),
+                sender_id: context.surface_user.clone(),
                 content: "next".to_string(),
-                is_from_bot: false,
+                sender_kind: SenderKind::User,
                 timestamp: "2024-01-01T00:00:02Z".to_string(),
                 message_kind: MessageKind::Message,
-                sender_agent_id: None,
                 recipient_agent_id: None,
             },
             Message::text("user", "next"),
@@ -631,12 +624,11 @@ mod tests {
             StoredMessage {
                 id: "tool-msg".to_string(),
                 chat_id,
-                sender_name: "egopulse".to_string(),
+                sender_id: "egopulse".to_string(),
                 content: "Read image file [image/png]".to_string(),
-                is_from_bot: true,
+                sender_kind: SenderKind::Assistant,
                 timestamp: "2024-01-01T00:00:00Z".to_string(),
                 message_kind: MessageKind::Message,
-                sender_agent_id: None,
                 recipient_agent_id: None,
             },
             messages[0].clone(),
@@ -843,12 +835,11 @@ mod tests {
         let concurrent_message = StoredMessage {
             id: "concurrent-assistant".to_string(),
             chat_id,
-            sender_name: "egopulse".to_string(),
+            sender_id: "egopulse".to_string(),
             content: "concurrent".to_string(),
-            is_from_bot: true,
+            sender_kind: SenderKind::Assistant,
             timestamp: "2024-01-01T00:00:52Z".to_string(),
             message_kind: MessageKind::Message,
-            sender_agent_id: None,
             recipient_agent_id: None,
         };
         let mut latest_messages = seed_messages.clone();
@@ -874,12 +865,11 @@ mod tests {
             StoredMessage {
                 id: "new-user-full".to_string(),
                 chat_id,
-                sender_name: context.surface_user.clone(),
+                sender_id: context.surface_user.clone(),
                 content: "next".to_string(),
-                is_from_bot: false,
+                sender_kind: SenderKind::User,
                 timestamp: "2024-01-01T00:00:53Z".to_string(),
                 message_kind: MessageKind::Message,
-                sender_agent_id: None,
                 recipient_agent_id: None,
             },
             Message::text("user", "next"),
@@ -1068,5 +1058,119 @@ mod tests {
         let second = super::resolve_chat_id(&state, &ctx).await.expect("second");
 
         assert_eq!(first, second, "reentry must preserve existing chat id");
+    }
+
+    // -- Step 4: SenderKind role mapping tests ----------------------------------
+
+    #[test]
+    fn load_session_maps_assistant_to_assistant() {
+        let message = StoredMessage::assistant(1, "lyre".to_string(), "hello".to_string());
+        assert_eq!(message.sender_kind, SenderKind::Assistant);
+        let role = match message.sender_kind {
+            SenderKind::Assistant | SenderKind::Tool => "assistant",
+            SenderKind::User => "user",
+            SenderKind::System => "system",
+        };
+        assert_eq!(role, "assistant");
+    }
+
+    #[test]
+    fn load_session_maps_user_to_user() {
+        let message = StoredMessage::user(1, "user:cli:default".to_string(), "hi".to_string());
+        assert_eq!(message.sender_kind, SenderKind::User);
+        let role = match message.sender_kind {
+            SenderKind::Assistant | SenderKind::Tool => "assistant",
+            SenderKind::User => "user",
+            SenderKind::System => "system",
+        };
+        assert_eq!(role, "user");
+    }
+
+    #[test]
+    fn load_session_maps_system_to_system() {
+        let message = StoredMessage::system(1, "boot complete".to_string());
+        assert_eq!(message.sender_kind, SenderKind::System);
+        let role = match message.sender_kind {
+            SenderKind::Assistant | SenderKind::Tool => "assistant",
+            SenderKind::User => "user",
+            SenderKind::System => "system",
+        };
+        assert_eq!(role, "system");
+    }
+
+    #[test]
+    fn load_session_maps_tool_to_assistant() {
+        let message = StoredMessage::tool(
+            1,
+            "lyre".to_string(),
+            "vega".to_string(),
+            "hello".to_string(),
+        );
+        assert_eq!(message.sender_kind, SenderKind::Tool);
+        let role = match message.sender_kind {
+            SenderKind::Assistant | SenderKind::Tool => "assistant",
+            SenderKind::User => "user",
+            SenderKind::System => "system",
+        };
+        assert_eq!(role, "assistant");
+    }
+
+    #[tokio::test]
+    async fn loaded_from_recent_preserves_sender_kind() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(FakeProvider {
+                response: "ok".to_string(),
+            }),
+        );
+        let context = cli_context("sender-kind");
+        let chat_id = super::resolve_chat_id(&state, &context)
+            .await
+            .expect("chat id");
+
+        call_blocking(Arc::clone(&state.db), {
+            move |db| {
+                db.store_message_only(&StoredMessage {
+                    id: "msg-user".to_string(),
+                    chat_id,
+                    sender_id: "user:cli:default".to_string(),
+                    content: "hello".to_string(),
+                    sender_kind: SenderKind::User,
+                    timestamp: "2024-01-01T00:00:00Z".to_string(),
+                    message_kind: MessageKind::Message,
+                    recipient_agent_id: None,
+                })
+            }
+        })
+        .await
+        .expect("store user message");
+
+        call_blocking(Arc::clone(&state.db), {
+            move |db| {
+                db.store_message_only(&StoredMessage {
+                    id: "msg-assistant".to_string(),
+                    chat_id,
+                    sender_id: "lyre".to_string(),
+                    content: "response".to_string(),
+                    sender_kind: SenderKind::Assistant,
+                    timestamp: "2024-01-01T00:00:01Z".to_string(),
+                    message_kind: MessageKind::Message,
+                    recipient_agent_id: None,
+                })
+            }
+        })
+        .await
+        .expect("store assistant message");
+
+        let loaded = load_messages_for_turn(&state, chat_id)
+            .await
+            .expect("load messages");
+
+        assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.messages[0].role, "user");
+        assert_eq!(loaded.messages[0].content.as_text_lossy(), "hello");
+        assert_eq!(loaded.messages[1].role, "assistant");
+        assert_eq!(loaded.messages[1].content.as_text_lossy(), "response");
     }
 }

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -19,7 +19,7 @@ use crate::channels::web::sse::AgentEvent;
 use crate::error::{EgoPulseError, StorageError};
 use crate::llm::{Message, ToolCall};
 use crate::runtime::{AppState, build_app_state};
-use crate::storage::{StoredMessage, ToolCall as StoredToolCall, call_blocking};
+use crate::storage::{SenderKind, StoredMessage, ToolCall as StoredToolCall, call_blocking};
 use crate::tools::ToolExecutionContext;
 use futures_util::future::join_all;
 use std::sync::Arc;
@@ -296,11 +296,11 @@ async fn process_turn_inner(
                         return persist_and_finalize(
                             state,
                             chat_id,
+                            &context.agent_id,
                             &mut messages,
                             session_updated_at.clone(),
                             &on_event,
-                            final_content,
-                            reasoning_content,
+                            (final_content, reasoning_content),
                         )
                         .await;
                     }
@@ -325,11 +325,11 @@ async fn process_turn_inner(
                         return persist_and_finalize(
                             state,
                             chat_id,
+                            &context.agent_id,
                             &mut messages,
                             session_updated_at.clone(),
                             &on_event,
-                            final_content,
-                            reasoning_content,
+                            (final_content, reasoning_content),
                         )
                         .await;
                     }
@@ -486,19 +486,20 @@ fn evaluate_malformed_response(
 async fn persist_and_finalize(
     state: &AppState,
     chat_id: i64,
+    agent_id: &str,
     messages: &mut Vec<Message>,
     session_updated_at: Option<String>,
     on_event: &EventEmitter,
-    final_content: String,
-    reasoning_content: Option<String>,
+    response: (String, Option<String>),
 ) -> Result<String, EgoPulseError> {
+    let (final_content, reasoning_content) = response;
     let mut assistant_message = Message::text("assistant", final_content.clone());
     assistant_message.reasoning_content = reasoning_content;
     messages.push(assistant_message.clone());
 
     let _persisted = persist_phase(
         state,
-        StoredMessage::bot(chat_id, final_content.clone()),
+        StoredMessage::assistant(chat_id, agent_id.to_string(), final_content.clone()),
         assistant_message,
         messages,
         session_updated_at,
@@ -524,6 +525,7 @@ async fn execute_and_persist_tools(
     let persisted = persist_tool_call_assistant_message(
         state,
         tool_context.chat_id,
+        &tool_context.agent_id,
         &assistant_message_id,
         &assistant_draft,
         messages,
@@ -544,6 +546,7 @@ async fn execute_and_persist_tools(
     let persisted = persist_tool_result_messages(
         state,
         tool_context.chat_id,
+        &tool_context.agent_id,
         messages,
         tool_messages,
         session_updated_at,
@@ -558,6 +561,7 @@ async fn execute_and_persist_tools(
 async fn persist_tool_call_assistant_message(
     state: &AppState,
     chat_id: i64,
+    agent_id: &str,
     assistant_message_id: &str,
     assistant_draft: &ToolAssistantDraft,
     mut messages: Vec<Message>,
@@ -580,7 +584,7 @@ async fn persist_tool_call_assistant_message(
         state,
         StoredMessage {
             id: assistant_message_id.to_string(),
-            ..StoredMessage::bot(chat_id, assistant_preview)
+            ..StoredMessage::assistant(chat_id, agent_id.to_string(), assistant_preview)
         },
         assistant_message,
         &messages,
@@ -592,6 +596,7 @@ async fn persist_tool_call_assistant_message(
 async fn persist_tool_result_messages(
     state: &AppState,
     chat_id: i64,
+    agent_id: &str,
     messages: Vec<Message>,
     tool_messages: Vec<Message>,
     session_updated_at: Option<String>,
@@ -608,7 +613,7 @@ async fn persist_tool_result_messages(
     let preview = summarize_tool_result_messages(&tool_messages);
     persist_phase_messages(
         state,
-        StoredMessage::bot(chat_id, preview),
+        StoredMessage::assistant(chat_id, agent_id.to_string(), preview),
         tool_messages,
         &messages_with_tools,
         session_updated_at,
@@ -873,12 +878,11 @@ async fn load_channel_context(state: &AppState, context: &SurfaceContext) -> Opt
 
     let formatted: String = messages
         .iter()
-        .map(|m| {
-            if m.is_from_bot {
-                format!("[Bot] {}", m.content)
-            } else {
-                format!("[{}] {}", m.sender_name, m.content)
-            }
+        .map(|m| match m.sender_kind {
+            SenderKind::User => format!("[{}] {}", m.sender_id, m.content),
+            SenderKind::Assistant => format!("[{}] {}", m.sender_id, m.content),
+            SenderKind::System => format!("[system] {}", m.content),
+            SenderKind::Tool => format!("[tool/{}] {}", m.sender_id, m.content),
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -1113,7 +1117,7 @@ mod tests {
     use crate::agent_loop::process_turn;
     use crate::error::EgoPulseError;
     use crate::llm::{MessagesResponse, ToolCall};
-    use crate::storage::call_blocking;
+    use crate::storage::{SenderKind, call_blocking};
 
     // -----------------------------------------------------------------------
     // Core turn execution
@@ -1725,16 +1729,16 @@ mod tests {
         db: &crate::storage::Database,
         chat_id: i64,
         id: &str,
-        sender: &str,
+        sender_id: &str,
         content: &str,
-        is_from_bot: bool,
+        sender_kind: SenderKind,
         ts: &str,
     ) {
         let conn = db.conn.lock().expect("lock");
         conn.execute(
-            "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind)
+            "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            rusqlite::params![id, chat_id, sender, content, is_from_bot as i32, ts, "message"],
+            rusqlite::params![id, chat_id, sender_id, content, sender_kind.to_string(), ts, "message"],
         )
         .expect("insert channel log message");
     }
@@ -1769,7 +1773,7 @@ mod tests {
             "cl-1",
             "alice",
             "hello from alice",
-            false,
+            SenderKind::User,
             "2025-01-01T00:00:00Z",
         );
         insert_channel_log_message(
@@ -1778,7 +1782,7 @@ mod tests {
             "cl-2",
             "Bot",
             "hi there",
-            true,
+            SenderKind::Assistant,
             "2025-01-01T00:00:01Z",
         );
 
@@ -1844,7 +1848,7 @@ mod tests {
                 &format!("cl-{i}"),
                 "alice",
                 &format!("msg {i}"),
-                false,
+                SenderKind::User,
                 &format!("2025-01-01T00:{i:02}:00Z"),
             );
         }
@@ -1905,7 +1909,7 @@ mod tests {
             "cl-di",
             "alice",
             "background",
-            false,
+            SenderKind::User,
             "2025-01-01T00:00:00Z",
         );
 
@@ -2032,7 +2036,7 @@ mod tests {
             "cl-persist",
             "alice",
             "should not persist",
-            false,
+            SenderKind::User,
             "2025-01-01T00:00:00Z",
         );
 
@@ -2122,7 +2126,7 @@ mod tests {
             "int-1",
             "alice",
             "previous message",
-            false,
+            SenderKind::User,
             "2025-01-01T00:00:00Z",
         );
 
@@ -2374,5 +2378,61 @@ mod tests {
             !trace_ids[0].is_empty(),
             "execute_scheduled_turn must generate a non-empty trace_id"
         );
+    }
+
+    // -- Step 5: SenderKind formatting tests for load_channel_context ------------
+
+    #[test]
+    fn build_channel_context_formats_user() {
+        let msg = crate::storage::StoredMessage::user(1, "Alice".to_string(), "hello".to_string());
+        let formatted = match msg.sender_kind {
+            SenderKind::User => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::Assistant => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::System => format!("[system] {}", msg.content),
+            SenderKind::Tool => format!("[tool/{}] {}", msg.sender_id, msg.content),
+        };
+        assert_eq!(formatted, "[Alice] hello");
+    }
+
+    #[test]
+    fn build_channel_context_formats_assistant() {
+        let msg =
+            crate::storage::StoredMessage::assistant(1, "lyre".to_string(), "response".to_string());
+        let formatted = match msg.sender_kind {
+            SenderKind::User => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::Assistant => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::System => format!("[system] {}", msg.content),
+            SenderKind::Tool => format!("[tool/{}] {}", msg.sender_id, msg.content),
+        };
+        assert_eq!(formatted, "[lyre] response");
+    }
+
+    #[test]
+    fn build_channel_context_formats_system() {
+        let msg = crate::storage::StoredMessage::system(1, "boot complete".to_string());
+        let formatted = match msg.sender_kind {
+            SenderKind::User => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::Assistant => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::System => format!("[system] {}", msg.content),
+            SenderKind::Tool => format!("[tool/{}] {}", msg.sender_id, msg.content),
+        };
+        assert_eq!(formatted, "[system] boot complete");
+    }
+
+    #[test]
+    fn build_channel_context_formats_tool() {
+        let msg = crate::storage::StoredMessage::tool(
+            1,
+            "lyre".to_string(),
+            "vega".to_string(),
+            "sent".to_string(),
+        );
+        let formatted = match msg.sender_kind {
+            SenderKind::User => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::Assistant => format!("[{}] {}", msg.sender_id, msg.content),
+            SenderKind::System => format!("[system] {}", msg.content),
+            SenderKind::Tool => format!("[tool/{}] {}", msg.sender_id, msg.content),
+        };
+        assert_eq!(formatted, "[tool/lyre] sent");
     }
 }

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -597,31 +597,32 @@ impl Handler {
         .await
         {
             Ok(chat_id) => {
+                let sender_id = format!("user:discord:{}", msg.author.id.get());
                 let stored = crate::storage::StoredMessage {
                     id: format!("cl-{}", msg.id.get()),
                     chat_id,
-                    sender_name: msg.author.name.clone(),
+                    sender_id,
                     content: text.to_string(),
-                    is_from_bot: false,
+                    sender_kind: crate::storage::SenderKind::User,
                     timestamp: msg.timestamp.to_string(),
                     message_kind: crate::storage::MessageKind::Message,
-                    sender_agent_id: None,
                     recipient_agent_id: None,
                 };
                 let db = std::sync::Arc::clone(&self.app_state.db);
                 if let Err(e) = crate::storage::call_blocking(db, move |db| {
                     let conn = db.lock_conn()?;
                     conn.execute(
-                        "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind, recipient_agent_id)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                         rusqlite::params![
                             stored.id,
                             stored.chat_id,
-                            stored.sender_name,
+                            stored.sender_id,
                             stored.content,
-                            stored.is_from_bot as i32,
+                            stored.sender_kind.to_string(),
                             stored.timestamp,
                             stored.message_kind.to_string(),
+                            stored.recipient_agent_id.as_deref(),
                         ],
                     )?;
                     Ok::<_, crate::error::StorageError>(())
@@ -2149,5 +2150,27 @@ mod tests {
 
         let result = route_responder_agent_id(&handler, 999, true, false);
         assert_eq!(result, Some("developer".to_string()));
+    }
+
+    // --- Sender ID / SenderKind tests (Step 6) ---
+
+    #[test]
+    fn discord_user_message_sender_id() {
+        let author_id: u64 = 123456789;
+        let sender_id = format!("user:discord:{author_id}");
+        assert!(sender_id.starts_with("user:discord:"));
+        assert!(sender_id.ends_with("123456789"));
+    }
+
+    #[test]
+    fn discord_stored_message_has_user_kind() {
+        let chat_id = 42;
+        let msg = crate::storage::StoredMessage::user(
+            chat_id,
+            "user:discord:123456789".to_string(),
+            "hello".to_string(),
+        );
+        assert_eq!(msg.sender_kind, crate::storage::SenderKind::User);
+        assert_eq!(msg.sender_id, "user:discord:123456789");
     }
 }

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -332,7 +332,7 @@ impl TelegramHandler {
     async fn store_human_channel_log_message(
         &self,
         raw_chat_id: i64,
-        sender_name: &str,
+        sender_id: &str,
         msg_id: i32,
         text: &str,
     ) -> Option<i64> {
@@ -346,28 +346,28 @@ impl TelegramHandler {
                 let stored = crate::storage::StoredMessage {
                     id: format!("cl-tg-{raw_chat_id}-{msg_id}"),
                     chat_id,
-                    sender_name: sender_name.to_string(),
+                    sender_id: sender_id.to_string(),
                     content: text.to_string(),
-                    is_from_bot: false,
+                    sender_kind: crate::storage::SenderKind::User,
                     timestamp: Utc::now().to_rfc3339(),
                     message_kind: crate::storage::MessageKind::Message,
-                    sender_agent_id: None,
                     recipient_agent_id: None,
                 };
                 let db = std::sync::Arc::clone(&self.app_state.db);
                 if let Err(e) = crate::storage::call_blocking(db, move |db| {
                     let conn = db.lock_conn()?;
                     conn.execute(
-                        "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind, recipient_agent_id)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                         rusqlite::params![
                             stored.id,
                             stored.chat_id,
-                            stored.sender_name,
+                            stored.sender_id,
                             stored.content,
-                            stored.is_from_bot as i32,
+                            stored.sender_kind.to_string(),
                             stored.timestamp,
                             stored.message_kind.to_string(),
+                            stored.recipient_agent_id.as_deref(),
                         ],
                     )?;
                     Ok::<_, crate::error::StorageError>(())
@@ -815,6 +815,12 @@ async fn handle_message(
         .map(|u| u.username.clone().unwrap_or_else(|| u.first_name.clone()))
         .unwrap_or_else(|| "unknown".to_string());
 
+    let storage_sender_id = msg
+        .from
+        .as_ref()
+        .map(|u| format!("user:telegram:{}", u.id.0))
+        .unwrap_or_else(|| "user:telegram:unknown".to_string());
+
     let thread = raw_chat_id.to_string();
     let context = handler.make_context(&sender_name, &thread, &route_agent_id);
 
@@ -915,7 +921,12 @@ async fn handle_message(
     // Channel Log: multi-agent room では combined_text（添付情報込み）を保存
     let channel_log_chat_id = if is_multi_agent && !is_dm {
         handler
-            .store_human_channel_log_message(raw_chat_id, &sender_name, msg.id.0, &combined_text)
+            .store_human_channel_log_message(
+                raw_chat_id,
+                &storage_sender_id,
+                msg.id.0,
+                &combined_text,
+            )
             .await
     } else {
         None
@@ -1655,5 +1666,27 @@ mod tests {
             handler.should_process_message(false, false, -100, false),
             ReceiveDecision::Accept { reset_chain: true }
         );
+    }
+
+    // --- Sender ID / SenderKind tests (Step 6) ---
+
+    #[test]
+    fn telegram_user_message_sender_id() {
+        let user_id: i64 = 987654321;
+        let sender_id = format!("user:telegram:{user_id}");
+        assert!(sender_id.starts_with("user:telegram:"));
+        assert!(sender_id.ends_with("987654321"));
+    }
+
+    #[test]
+    fn telegram_stored_message_has_user_kind() {
+        let chat_id = 42;
+        let msg = crate::storage::StoredMessage::user(
+            chat_id,
+            "user:telegram:987654321".to_string(),
+            "hello".to_string(),
+        );
+        assert_eq!(msg.sender_kind, crate::storage::SenderKind::User);
+        assert_eq!(msg.sender_id, "user:telegram:987654321");
     }
 }

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -816,9 +816,14 @@ async fn handle_message(
         .unwrap_or_else(|| "unknown".to_string());
 
     let storage_sender_id = msg
-        .from
+        .sender_chat
         .as_ref()
-        .map(|u| format!("user:telegram:{}", u.id.0))
+        .map(|chat| format!("chat:telegram:{}", chat.id.0))
+        .or_else(|| {
+            msg.from
+                .as_ref()
+                .map(|u| format!("user:telegram:{}", u.id.0))
+        })
         .unwrap_or_else(|| "user:telegram:unknown".to_string());
 
     let thread = raw_chat_id.to_string();

--- a/src/channels/web/sessions.rs
+++ b/src/channels/web/sessions.rs
@@ -137,9 +137,9 @@ pub(super) async fn get_history(
         "session_key": session_key,
         "messages": messages.into_iter().map(|message| serde_json::json!({
             "id": message.id,
-            "sender_name": message.sender_name,
+            "sender_id": message.sender_id,
+            "sender_kind": message.sender_kind.to_string(),
             "content": message.content,
-            "is_from_bot": message.is_from_bot,
             "timestamp": message.timestamp,
         })).collect::<Vec<_>>()
     })))
@@ -161,5 +161,73 @@ mod tests {
         assert_eq!(parse_chat_id_from_session_key("web:main"), None);
         assert_eq!(parse_chat_id_from_session_key("chat:"), None);
         assert_eq!(parse_chat_id_from_session_key("chat:abc"), None);
+    }
+
+    #[test]
+    fn api_messages_returns_sender_id() {
+        let message = crate::storage::StoredMessage::user(
+            1,
+            "user:discord:123".to_string(),
+            "hello".to_string(),
+        );
+        let json = serde_json::json!({
+            "id": message.id,
+            "sender_id": message.sender_id,
+            "sender_kind": message.sender_kind.to_string(),
+            "content": message.content,
+            "timestamp": message.timestamp,
+        });
+        assert_eq!(json["sender_id"], "user:discord:123");
+    }
+
+    #[test]
+    fn api_messages_returns_sender_kind() {
+        let message = crate::storage::StoredMessage::user(
+            1,
+            "user:discord:123".to_string(),
+            "hello".to_string(),
+        );
+        let json = serde_json::json!({
+            "id": message.id,
+            "sender_id": message.sender_id,
+            "sender_kind": message.sender_kind.to_string(),
+            "content": message.content,
+            "timestamp": message.timestamp,
+        });
+        assert_eq!(json["sender_kind"], "user");
+    }
+
+    #[test]
+    fn api_messages_excludes_sender_name() {
+        let message = crate::storage::StoredMessage::user(
+            1,
+            "user:discord:123".to_string(),
+            "hello".to_string(),
+        );
+        let json = serde_json::json!({
+            "id": message.id,
+            "sender_id": message.sender_id,
+            "sender_kind": message.sender_kind.to_string(),
+            "content": message.content,
+            "timestamp": message.timestamp,
+        });
+        assert!(json.get("sender_name").is_none());
+    }
+
+    #[test]
+    fn api_messages_excludes_is_from_bot() {
+        let message = crate::storage::StoredMessage::user(
+            1,
+            "user:discord:123".to_string(),
+            "hello".to_string(),
+        );
+        let json = serde_json::json!({
+            "id": message.id,
+            "sender_id": message.sender_id,
+            "sender_kind": message.sender_kind.to_string(),
+            "content": message.content,
+            "timestamp": message.timestamp,
+        });
+        assert!(json.get("is_from_bot").is_none());
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -430,9 +430,9 @@ mod tests {
     fn store_msg(db: &Database, id: &str, chat_id: i64, content: &str, ts: &str) {
         let conn = db.conn.lock().expect("lock");
         conn.execute(
-            "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind)
+            "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            rusqlite::params![id, chat_id, "alice", content, 0, ts, "message"],
+            rusqlite::params![id, chat_id, "alice", content, "user", ts, "message"],
         )
         .expect("store message");
     }

--- a/src/pulse/output.rs
+++ b/src/pulse/output.rs
@@ -20,7 +20,7 @@ use crate::pulse::capsule::HomeSurface;
 use crate::pulse::definition::{TemporalIntention, format_schedule};
 use crate::pulse::runner::ActivationResult;
 use crate::runtime::AppState;
-use crate::storage::{MessageKind, PulseOutputKind, StoredMessage};
+use crate::storage::{MessageKind, PulseOutputKind, SenderKind, StoredMessage};
 
 /// Result of output handling.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -241,12 +241,11 @@ async fn persist_notification_with_session(
     let synthetic_input = StoredMessage {
         id: format!("pulse-in-{}", uuid::Uuid::new_v4()),
         chat_id,
-        sender_name: "Pulse".to_string(),
+        sender_id: "pulse".to_string(),
         content: synthetic_content.clone(),
-        is_from_bot: false,
+        sender_kind: SenderKind::User,
         timestamp: now.clone(),
         message_kind: MessageKind::SystemEvent,
-        sender_agent_id: None,
         recipient_agent_id: None,
     };
 
@@ -276,12 +275,11 @@ async fn persist_notification_with_session(
             StoredMessage {
                 id: phase.assistant_message_id.clone(),
                 chat_id,
-                sender_name: agent_id.to_string(),
+                sender_id: agent_id.to_string(),
                 content: phase.assistant_preview.clone(),
-                is_from_bot: true,
+                sender_kind: SenderKind::Assistant,
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 message_kind: MessageKind::Message,
-                sender_agent_id: Some(agent_id.to_string()),
                 recipient_agent_id: None,
             },
             phase.assistant_message.clone(),
@@ -304,12 +302,11 @@ async fn persist_notification_with_session(
                 StoredMessage {
                     id: format!("pulse-tools-{}", uuid::Uuid::new_v4()),
                     chat_id,
-                    sender_name: agent_id.to_string(),
+                    sender_id: agent_id.to_string(),
                     content: preview_text(&phase.tool_result_preview, 160),
-                    is_from_bot: true,
+                    sender_kind: SenderKind::Assistant,
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     message_kind: MessageKind::Message,
-                    sender_agent_id: Some(agent_id.to_string()),
                     recipient_agent_id: None,
                 },
                 phase.tool_messages.clone(),
@@ -326,12 +323,11 @@ async fn persist_notification_with_session(
     let assistant_msg = StoredMessage {
         id: assistant_id.clone(),
         chat_id,
-        sender_name: agent_id.to_string(),
+        sender_id: agent_id.to_string(),
         content: output_text.to_string(),
-        is_from_bot: true,
+        sender_kind: SenderKind::Assistant,
         timestamp: now,
         message_kind: MessageKind::Message,
-        sender_agent_id: Some(agent_id.to_string()),
         recipient_agent_id: None,
     };
 
@@ -358,7 +354,7 @@ mod tests {
     use super::*;
     use crate::channels::adapter::{ChannelAdapter, ChannelRegistry, ConversationKind};
     use crate::pulse::runner::ToolPhase;
-    use crate::storage::Database;
+    use crate::storage::{Database, SenderKind};
     use std::sync::Arc;
 
     #[test]
@@ -571,15 +567,15 @@ mod tests {
                 .content
                 .contains("Check today's schedule and unresolved items.")
         );
-        assert!(!synthetic.is_from_bot);
+        assert_eq!(synthetic.sender_kind, SenderKind::User);
         assert_eq!(synthetic.message_kind, MessageKind::SystemEvent);
-        assert_eq!(synthetic.sender_name, "Pulse");
+        assert_eq!(synthetic.sender_id, "pulse");
 
         let assistant = &messages[1];
         assert_eq!(assistant.content, notification_text);
-        assert!(assistant.is_from_bot);
+        assert_eq!(assistant.sender_kind, SenderKind::Assistant);
         assert_eq!(assistant.message_kind, MessageKind::Message);
-        assert_eq!(assistant.sender_name, agent_id);
+        assert_eq!(assistant.sender_id, agent_id);
     }
 
     #[tokio::test]
@@ -915,5 +911,22 @@ mod tests {
             messages.is_empty(),
             "missing adapter should fail before session persistence"
         );
+    }
+
+    #[test]
+    fn pulse_synthetic_sets_user_kind() {
+        let msg = StoredMessage {
+            id: "test-pulse".to_string(),
+            chat_id: 1,
+            sender_id: "pulse".to_string(),
+            content: "[Pulse: test] content".to_string(),
+            sender_kind: SenderKind::User,
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            message_kind: MessageKind::SystemEvent,
+            recipient_agent_id: None,
+        };
+        assert_eq!(msg.sender_kind, SenderKind::User);
+        assert_eq!(msg.sender_id, "pulse");
+        assert_eq!(msg.message_kind, MessageKind::SystemEvent);
     }
 }

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -629,6 +629,7 @@ async fn handle_model_command(
             }
         }
     }
+
     config.save_config_with_secrets(path)?;
     let updated = Config::load_allow_missing_api_key(Some(path))?;
     let effective = resolved_for_scope(&updated, &scope)?;
@@ -740,7 +741,7 @@ mod tests {
     use crate::error::LlmError;
     use crate::llm::{LlmProvider, Message, MessagesResponse};
     use crate::runtime::AppState;
-    use crate::storage::{MessageKind, StoredMessage, call_blocking};
+    use crate::storage::{MessageKind, SenderKind, StoredMessage, call_blocking};
 
     use super::{
         SlashCommandOutcome, all_commands, handle_slash_command, is_slash_command,
@@ -878,12 +879,11 @@ mod tests {
                     &StoredMessage {
                         id: "msg-1".to_string(),
                         chat_id,
-                        sender_name: "user".to_string(),
+                        sender_id: "user:cli:default".to_string(),
                         content: "hello".to_string(),
-                        is_from_bot: false,
+                        sender_kind: SenderKind::User,
                         timestamp: "2024-01-01T00:00:00Z".to_string(),
                         message_kind: MessageKind::Message,
-                        sender_agent_id: None,
                         recipient_agent_id: None,
                     },
                     r#"[{"role":"user","content":"hello"}]"#,
@@ -1440,5 +1440,12 @@ agents:
             }
             other => panic!("expected Respond with unknown fallback, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn slash_command_cli_user_sets_user_kind() {
+        let msg = StoredMessage::user(1, "user:cli:default".to_string(), "/status".to_string());
+        assert_eq!(msg.sender_kind, SenderKind::User);
+        assert_eq!(msg.sender_id, "user:cli:default");
     }
 }

--- a/src/sleep/batch.rs
+++ b/src/sleep/batch.rs
@@ -1472,9 +1472,9 @@ mod tests {
     fn store_msg(db: &Database, id: &str, chat_id: i64, content: &str, ts: &str) {
         let conn = db.conn.lock().expect("lock");
         conn.execute(
-            "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind)
+            "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            rusqlite::params![id, chat_id, "alice", content, 0, ts, "message"],
+            rusqlite::params![id, chat_id, "alice", content, "user", ts, "message"],
         )
         .expect("store message");
     }

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -399,6 +399,13 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
                     let (sender_id, sender_kind) =
                         if row.is_from_bot != 0 && row.message_kind == "system_event" {
                             ("system".to_string(), "system")
+                        } else if row.is_from_bot != 0 && row.message_kind == "agent_send" {
+                            (
+                                row.sender_agent_id
+                                    .clone()
+                                    .unwrap_or_else(|| row.sender_name.clone()),
+                                "tool",
+                            )
                         } else if row.is_from_bot != 0 && row.sender_agent_id.is_some() {
                             (row.sender_agent_id.clone().unwrap(), "assistant")
                         } else if row.is_from_bot != 0 {
@@ -1014,5 +1021,29 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
             .expect("count");
         assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn migration_v4_to_v5_converts_agent_send_to_tool() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let (sender_id, sender_kind): (String, String) = conn
+            .query_row(
+                "SELECT sender_id, sender_kind FROM messages WHERE id = 'm5'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row");
+        assert_eq!(sender_id, "lyre");
+        assert_eq!(sender_kind, "tool");
     }
 }

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -8,7 +8,7 @@ use crate::error::StorageError;
 ///
 /// スキーマを変更する際はこの値をインクリメントし、
 /// `run_migrations` に対応する `if version < N` ブロックを追加する。
-pub(super) const SCHEMA_VERSION: i64 = 4;
+pub(super) const SCHEMA_VERSION: i64 = 5;
 
 /// `db_meta` に格納されたスキーマバージョンを読み取る。
 ///
@@ -335,6 +335,114 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
         version = 4;
     }
 
+    if version < 5 {
+        let tx = conn.unchecked_transaction()?;
+
+        let needs_migration: bool = tx
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('messages') WHERE name = 'is_from_bot'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+
+        if needs_migration {
+            tx.execute_batch(
+                "CREATE TABLE messages_v5 (
+                    id TEXT NOT NULL,
+                    chat_id INTEGER NOT NULL,
+                    sender_id TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    sender_kind TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    message_kind TEXT NOT NULL DEFAULT 'message',
+                    recipient_agent_id TEXT,
+                    PRIMARY KEY (id, chat_id)
+                );",
+            )?;
+
+            {
+                struct V4Row {
+                    id: String,
+                    chat_id: i64,
+                    sender_name: String,
+                    content: String,
+                    is_from_bot: i32,
+                    timestamp: String,
+                    message_kind: String,
+                    sender_agent_id: Option<String>,
+                    recipient_agent_id: Option<String>,
+                }
+
+                let mut stmt = tx.prepare(
+                    "SELECT id, chat_id, sender_name, content, is_from_bot,
+                            timestamp, message_kind, sender_agent_id, recipient_agent_id
+                     FROM messages",
+                )?;
+                let rows: Vec<V4Row> = stmt
+                    .query_map([], |row| {
+                        Ok(V4Row {
+                            id: row.get::<_, String>(0)?,
+                            chat_id: row.get::<_, i64>(1)?,
+                            sender_name: row.get::<_, String>(2)?,
+                            content: row.get::<_, String>(3)?,
+                            is_from_bot: row.get::<_, i32>(4)?,
+                            timestamp: row.get::<_, String>(5)?,
+                            message_kind: row.get::<_, String>(6)?,
+                            sender_agent_id: row.get::<_, Option<String>>(7)?,
+                            recipient_agent_id: row.get::<_, Option<String>>(8)?,
+                        })
+                    })?
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                for row in &rows {
+                    let (sender_id, sender_kind) =
+                        if row.is_from_bot != 0 && row.message_kind == "system_event" {
+                            ("system".to_string(), "system")
+                        } else if row.is_from_bot != 0 && row.sender_agent_id.is_some() {
+                            (row.sender_agent_id.clone().unwrap(), "assistant")
+                        } else if row.is_from_bot != 0 {
+                            (row.sender_name.clone(), "assistant")
+                        } else {
+                            (row.sender_name.clone(), "user")
+                        };
+
+                    tx.execute(
+                        "INSERT INTO messages_v5
+                            (id, chat_id, sender_id, content, sender_kind,
+                             timestamp, message_kind, recipient_agent_id)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                        params![
+                            row.id,
+                            row.chat_id,
+                            sender_id,
+                            row.content,
+                            sender_kind,
+                            row.timestamp,
+                            row.message_kind,
+                            row.recipient_agent_id,
+                        ],
+                    )?;
+                }
+            }
+
+            tx.execute_batch("DROP TABLE messages;")?;
+            tx.execute_batch("ALTER TABLE messages_v5 RENAME TO messages;")?;
+            tx.execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_messages_chat_timestamp
+                    ON messages(chat_id, timestamp);",
+            )?;
+        }
+
+        set_schema_version_in_tx(
+            &tx,
+            5,
+            "replace sender_name/is_from_bot/sender_agent_id with sender_id/sender_kind",
+        )?;
+        tx.commit()?;
+        version = 5;
+    }
+
     debug_assert_eq!(version, SCHEMA_VERSION, "all migrations applied");
     Ok(())
 }
@@ -625,5 +733,286 @@ mod tests {
         for name in &expected_indexes {
             assert!(indexes.iter().any(|i| i == *name), "missing index: {name}");
         }
+    }
+
+    // --- v5: messages sender_id / sender_kind ---------------------------------
+
+    fn seed_v4_messages(conn: &rusqlite::Connection) {
+        // Bot message (no agent id)
+        conn.execute(
+            "INSERT INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id)
+             VALUES ('m1', 1, 'egopulse', 'bot hello', 1, '2024-01-01T00:00:00Z', 'message', NULL, NULL)",
+            [],
+        ).unwrap();
+        // Agent message (has sender_agent_id)
+        conn.execute(
+            "INSERT INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id)
+             VALUES ('m2', 1, 'lyre', 'agent reply', 1, '2024-01-01T00:00:01Z', 'message', 'lyre', NULL)",
+            [],
+        ).unwrap();
+        // User message
+        conn.execute(
+            "INSERT INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id)
+             VALUES ('m3', 1, 'alice', 'user hello', 0, '2024-01-01T00:00:02Z', 'message', NULL, NULL)",
+            [],
+        ).unwrap();
+        // System event
+        conn.execute(
+            "INSERT INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id)
+             VALUES ('m4', 1, 'system', '{\"reason\":\"TurnCountExceeded\"}', 1, '2024-01-01T00:00:03Z', 'system_event', NULL, NULL)",
+            [],
+        ).unwrap();
+        // Agent message with recipient
+        conn.execute(
+            "INSERT INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id)
+             VALUES ('m5', 1, 'lyre', 'agent send', 1, '2024-01-01T00:00:04Z', 'agent_send', 'lyre', 'bob')",
+            [],
+        ).unwrap();
+    }
+
+    fn run_v5_migration(db: &super::super::Database) {
+        {
+            let conn = db.conn.lock().expect("lock");
+            super::run_migrations(&conn).expect("re-run migrations");
+        }
+    }
+
+    /// Creates a Database with v4 schema (old messages columns) for testing v5 migration.
+    fn create_v4_db(dir: &tempfile::TempDir) -> super::super::Database {
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+
+        // v1 schema — only the tables needed for v5 migration tests
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS chats (
+                chat_id INTEGER PRIMARY KEY,
+                chat_title TEXT,
+                chat_type TEXT NOT NULL DEFAULT 'private',
+                last_message_time TEXT NOT NULL,
+                channel TEXT,
+                external_chat_id TEXT,
+                agent_id TEXT NOT NULL DEFAULT 'default'
+            );
+
+            CREATE TABLE IF NOT EXISTS messages (
+                id TEXT NOT NULL,
+                chat_id INTEGER NOT NULL,
+                sender_name TEXT NOT NULL,
+                content TEXT NOT NULL,
+                is_from_bot INTEGER NOT NULL DEFAULT 0,
+                timestamp TEXT NOT NULL,
+                message_kind TEXT NOT NULL DEFAULT 'message',
+                sender_agent_id TEXT,
+                recipient_agent_id TEXT,
+                PRIMARY KEY (id, chat_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_messages_chat_timestamp
+                ON messages(chat_id, timestamp);",
+        )
+        .unwrap();
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS db_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+
+        super::set_schema_version(&conn, 4, "test v4 baseline").unwrap();
+
+        super::super::Database {
+            conn: std::sync::Mutex::new(conn),
+        }
+    }
+
+    #[test]
+    fn migration_v4_to_v5_adds_sender_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let has_sender_id: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('messages') WHERE name = 'sender_id'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check");
+        assert!(has_sender_id, "messages should have sender_id column");
+    }
+
+    #[test]
+    fn migration_v4_to_v5_removes_is_from_bot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let has_is_from_bot: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('messages') WHERE name = 'is_from_bot'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check");
+        assert!(
+            !has_is_from_bot,
+            "messages should not have is_from_bot column after migration"
+        );
+    }
+
+    #[test]
+    fn migration_v4_to_v5_converts_bot_message() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let (sender_id, sender_kind): (String, String) = conn
+            .query_row(
+                "SELECT sender_id, sender_kind FROM messages WHERE id = 'm1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row");
+        assert_eq!(sender_id, "egopulse");
+        assert_eq!(sender_kind, "assistant");
+    }
+
+    #[test]
+    fn migration_v4_to_v5_converts_agent_message() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let (sender_id, sender_kind): (String, String) = conn
+            .query_row(
+                "SELECT sender_id, sender_kind FROM messages WHERE id = 'm2'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row");
+        assert_eq!(sender_id, "lyre");
+        assert_eq!(sender_kind, "assistant");
+    }
+
+    #[test]
+    fn migration_v4_to_v5_converts_user_message() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let (sender_id, sender_kind): (String, String) = conn
+            .query_row(
+                "SELECT sender_id, sender_kind FROM messages WHERE id = 'm3'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row");
+        assert_eq!(sender_id, "alice");
+        assert_eq!(sender_kind, "user");
+    }
+
+    #[test]
+    fn migration_v4_to_v5_converts_system_event() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let (sender_id, sender_kind): (String, String) = conn
+            .query_row(
+                "SELECT sender_id, sender_kind FROM messages WHERE id = 'm4'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row");
+        assert_eq!(sender_id, "system");
+        assert_eq!(sender_kind, "system");
+    }
+
+    #[test]
+    fn migration_v4_to_v5_preserves_recipient_agent_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let recipient: Option<String> = conn
+            .query_row(
+                "SELECT recipient_agent_id FROM messages WHERE id = 'm5'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("row");
+        assert_eq!(recipient.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn migration_v4_to_v5_preserves_data_count() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = create_v4_db(&dir);
+
+        {
+            let conn = db.conn.lock().expect("lock");
+            seed_v4_messages(&conn);
+        }
+
+        run_v5_migration(&db);
+
+        let conn = db.conn.lock().expect("lock");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
+            .expect("count");
+        assert_eq!(count, 5);
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -20,43 +20,71 @@ pub struct Database {
 pub(crate) struct StoredMessage {
     pub id: String,
     pub chat_id: i64,
-    pub sender_name: String,
+    pub sender_id: String,
     pub content: String,
-    pub is_from_bot: bool,
+    pub sender_kind: SenderKind,
     pub timestamp: String,
     pub message_kind: MessageKind,
-    pub sender_agent_id: Option<String>,
     pub recipient_agent_id: Option<String>,
 }
 
 impl StoredMessage {
-    /// Creates a bot-originated message with auto-generated id and timestamp.
-    pub(crate) fn bot(chat_id: i64, content: String) -> Self {
+    /// Creates an assistant-originated message with auto-generated id and timestamp.
+    pub(crate) fn assistant(chat_id: i64, sender_id: String, content: String) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             chat_id,
-            sender_name: "egopulse".to_string(),
+            sender_id,
             content,
-            is_from_bot: true,
+            sender_kind: SenderKind::Assistant,
             timestamp: chrono::Utc::now().to_rfc3339(),
             message_kind: MessageKind::Message,
-            sender_agent_id: None,
             recipient_agent_id: None,
         }
     }
 
     /// Creates a user-originated message with auto-generated id and timestamp.
-    pub(crate) fn user(chat_id: i64, sender_name: String, content: String) -> Self {
+    pub(crate) fn user(chat_id: i64, sender_id: String, content: String) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             chat_id,
-            sender_name,
+            sender_id,
             content,
-            is_from_bot: false,
+            sender_kind: SenderKind::User,
             timestamp: chrono::Utc::now().to_rfc3339(),
             message_kind: MessageKind::Message,
-            sender_agent_id: None,
             recipient_agent_id: None,
+        }
+    }
+
+    pub(crate) fn system(chat_id: i64, content: String) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            chat_id,
+            sender_id: "system".to_string(),
+            content,
+            sender_kind: SenderKind::System,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            message_kind: MessageKind::Message,
+            recipient_agent_id: None,
+        }
+    }
+
+    pub(crate) fn tool(
+        chat_id: i64,
+        sender_id: String,
+        recipient_id: String,
+        content: String,
+    ) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            chat_id,
+            sender_id,
+            content,
+            sender_kind: SenderKind::Tool,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            message_kind: MessageKind::Message,
+            recipient_agent_id: Some(recipient_id),
         }
     }
 }
@@ -135,6 +163,39 @@ impl FromStr for MessageKind {
             "agent_send" => Ok(Self::AgentSend),
             "system_event" => Ok(Self::SystemEvent),
             other => Err(format!("invalid message kind: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SenderKind {
+    User,
+    Assistant,
+    System,
+    Tool,
+}
+
+impl fmt::Display for SenderKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::User => write!(f, "user"),
+            Self::Assistant => write!(f, "assistant"),
+            Self::System => write!(f, "system"),
+            Self::Tool => write!(f, "tool"),
+        }
+    }
+}
+
+impl FromStr for SenderKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "user" => Ok(Self::User),
+            "assistant" => Ok(Self::Assistant),
+            "system" => Ok(Self::System),
+            "tool" => Ok(Self::Tool),
+            other => Err(format!("invalid sender kind: {other}")),
         }
     }
 }
@@ -446,6 +507,8 @@ const _: () = {
     const fn assert_display<T: fmt::Display>() {}
     const fn assert_from_str<T: FromStr>() {}
 
+    assert_display::<SenderKind>();
+    assert_from_str::<SenderKind>();
     assert_display::<SleepRunStatus>();
     assert_display::<SleepRunTrigger>();
     assert_display::<MemoryFile>();
@@ -730,5 +793,60 @@ mod tests {
     #[test]
     fn episode_event_certainty_from_str_invalid() {
         assert!(EpisodeEventCertainty::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn sender_kind_display() {
+        assert_eq!(SenderKind::User.to_string(), "user");
+    }
+
+    #[test]
+    fn sender_kind_display_assistant() {
+        assert_eq!(SenderKind::Assistant.to_string(), "assistant");
+    }
+
+    #[test]
+    fn sender_kind_display_system() {
+        assert_eq!(SenderKind::System.to_string(), "system");
+    }
+
+    #[test]
+    fn sender_kind_display_tool() {
+        assert_eq!(SenderKind::Tool.to_string(), "tool");
+    }
+
+    #[test]
+    fn sender_kind_from_str() {
+        assert_eq!(
+            SenderKind::from_str("assistant").unwrap(),
+            SenderKind::Assistant
+        );
+        assert_eq!(SenderKind::from_str("user").unwrap(), SenderKind::User);
+        assert_eq!(SenderKind::from_str("system").unwrap(), SenderKind::System);
+        assert_eq!(SenderKind::from_str("tool").unwrap(), SenderKind::Tool);
+    }
+
+    #[test]
+    fn sender_kind_from_str_invalid() {
+        assert!(SenderKind::from_str("unknown").is_err());
+    }
+
+    #[test]
+    fn stored_message_assistant_factory() {
+        let msg = StoredMessage::assistant(42, "lyre".to_string(), "hello".to_string());
+        assert_eq!(msg.sender_id, "lyre");
+        assert_eq!(msg.sender_kind, SenderKind::Assistant);
+        assert_eq!(msg.content, "hello");
+        assert_eq!(msg.chat_id, 42);
+        assert!(msg.recipient_agent_id.is_none());
+    }
+
+    #[test]
+    fn stored_message_user_factory() {
+        let msg = StoredMessage::user(10, "user:cli:default".to_string(), "hi".to_string());
+        assert_eq!(msg.sender_id, "user:cli:default");
+        assert_eq!(msg.sender_kind, SenderKind::User);
+        assert_eq!(msg.content, "hi");
+        assert!(msg.recipient_agent_id.is_none());
     }
 }

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -7,11 +7,20 @@ use crate::error::StorageError;
 use super::{
     AgentSessionInfo, ChatInfo, Database, EpisodeEvent, EpisodeEventCertainty, EpisodeEventKind,
     LlmUsageLogEntry, MemoryFile, MemorySnapshot, MessageKind, PulseOutputKind, PulseRun,
-    PulseRunStatus, SessionSnapshot, SessionSummary, SleepRun, SleepRunStatus, SleepRunTrigger,
-    StoredMessage, ToolCall,
+    PulseRunStatus, SenderKind, SessionSnapshot, SessionSummary, SleepRun, SleepRunStatus,
+    SleepRunTrigger, StoredMessage, ToolCall,
 };
 
 fn row_to_stored_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredMessage> {
+    let sender_kind_str: String = row.get(4)?;
+    let sender_kind = SenderKind::from_str(&sender_kind_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
     let message_kind_str: String = row.get(6)?;
     let message_kind = MessageKind::from_str(&message_kind_str).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(
@@ -24,13 +33,12 @@ fn row_to_stored_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredMess
     Ok(StoredMessage {
         id: row.get(0)?,
         chat_id: row.get(1)?,
-        sender_name: row.get(2)?,
+        sender_id: row.get(2)?,
         content: row.get(3)?,
-        is_from_bot: row.get::<_, i32>(4)? != 0,
+        sender_kind,
         timestamp: row.get(5)?,
         message_kind,
-        sender_agent_id: row.get(7)?,
-        recipient_agent_id: row.get(8)?,
+        recipient_agent_id: row.get(7)?,
     })
 }
 
@@ -330,8 +338,8 @@ impl Database {
     ) -> Result<Vec<StoredMessage>, StorageError> {
         let conn = self.lock_conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id, chat_id, sender_name, content, is_from_bot, timestamp,
-                    message_kind, sender_agent_id, recipient_agent_id
+            "SELECT id, chat_id, sender_id, content, sender_kind, timestamp,
+                    message_kind, recipient_agent_id
              FROM messages
              WHERE chat_id = ?1
              ORDER BY timestamp DESC
@@ -351,8 +359,8 @@ impl Database {
     ) -> Result<Vec<StoredMessage>, StorageError> {
         let conn = self.lock_conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id, chat_id, sender_name, content, is_from_bot, timestamp,
-                    message_kind, sender_agent_id, recipient_agent_id
+            "SELECT id, chat_id, sender_id, content, sender_kind, timestamp,
+                    message_kind, recipient_agent_id
              FROM messages
              WHERE chat_id = ?1
              ORDER BY timestamp ASC",
@@ -418,17 +426,16 @@ impl Database {
         let mut conn = self.lock_conn()?;
         let tx = conn.transaction()?;
         tx.execute(
-            "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind, recipient_agent_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
                 message.id,
                 message.chat_id,
-                message.sender_name,
+                message.sender_id,
                 message.content,
-                message.is_from_bot as i32,
+                message.sender_kind.to_string(),
                 message.timestamp,
                 message.message_kind.to_string(),
-                message.sender_agent_id.as_deref(),
                 message.recipient_agent_id.as_deref(),
             ],
         )?;
@@ -480,8 +487,8 @@ impl Database {
 
         let recent_messages = {
             let mut stmt = tx.prepare(
-                "SELECT id, chat_id, sender_name, content, is_from_bot, timestamp,
-                        message_kind, sender_agent_id, recipient_agent_id
+                "SELECT id, chat_id, sender_id, content, sender_kind, timestamp,
+                        message_kind, recipient_agent_id
                  FROM messages
                  WHERE chat_id = ?1
                  ORDER BY timestamp DESC
@@ -548,17 +555,16 @@ impl Database {
     pub(crate) fn store_message_only(&self, message: &StoredMessage) -> Result<(), StorageError> {
         let conn = self.lock_conn()?;
         conn.execute(
-            "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind, sender_agent_id, recipient_agent_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind, recipient_agent_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
                 message.id,
                 message.chat_id,
-                message.sender_name,
+                message.sender_id,
                 message.content,
-                message.is_from_bot as i32,
+                message.sender_kind.to_string(),
                 message.timestamp,
                 message.message_kind.to_string(),
-                message.sender_agent_id.as_deref(),
                 message.recipient_agent_id.as_deref(),
             ],
         )?;
@@ -568,7 +574,7 @@ impl Database {
     /// Persists a stop-reason system event to the Channel Log.
     ///
     /// Content format: `{"reason": "StopReasonVariant"}`.
-    /// Sender: `"system"`, `is_from_bot: true`.
+    /// Sender: `sender_id = "system"`, `sender_kind = System`.
     pub(crate) fn store_system_event(
         &self,
         channel_log_chat_id: i64,
@@ -579,24 +585,15 @@ impl Database {
         })
         .to_string();
 
-        let message = StoredMessage {
-            id: uuid::Uuid::new_v4().to_string(),
-            chat_id: channel_log_chat_id,
-            sender_name: "system".to_string(),
-            content,
-            is_from_bot: true,
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            message_kind: MessageKind::SystemEvent,
-            sender_agent_id: None,
-            recipient_agent_id: None,
-        };
+        let mut message = StoredMessage::system(channel_log_chat_id, content);
+        message.message_kind = MessageKind::SystemEvent;
 
         self.store_message_only(&message)
     }
 
     /// Persists a bot response to the Channel Log.
     ///
-    /// Sender is the agent ID, `is_from_bot: true`, `MessageKind::Message`.
+    /// Sender is the agent ID, `sender_kind = Assistant`, `MessageKind::Message`.
     pub(crate) fn store_channel_log_bot_response(
         &self,
         channel_log_chat_id: i64,
@@ -606,12 +603,11 @@ impl Database {
         let message = StoredMessage {
             id: format!("cl-bot-{}", uuid::Uuid::new_v4()),
             chat_id: channel_log_chat_id,
-            sender_name: agent_id.to_string(),
+            sender_id: agent_id.to_string(),
             content: response.to_string(),
-            is_from_bot: true,
+            sender_kind: SenderKind::Assistant,
             timestamp: chrono::Utc::now().to_rfc3339(),
             message_kind: MessageKind::Message,
-            sender_agent_id: Some(agent_id.to_string()),
             recipient_agent_id: None,
         };
         self.store_message_only(&message)
@@ -1556,9 +1552,9 @@ mod tests {
     fn store_msg(db: &Database, id: &str, chat_id: i64, content: &str, ts: &str) {
         let conn = db.conn.lock().expect("lock");
         conn.execute(
-            "INSERT OR REPLACE INTO messages (id, chat_id, sender_name, content, is_from_bot, timestamp, message_kind)
+            "INSERT OR REPLACE INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            rusqlite::params![id, chat_id, "alice", content, 0, ts, "message"],
+            rusqlite::params![id, chat_id, "alice", content, "user", ts, "message"],
         )
         .expect("store message");
     }
@@ -1698,12 +1694,11 @@ mod tests {
         let message = StoredMessage {
             id: "msg-1".to_string(),
             chat_id: 100,
-            sender_name: "alice".to_string(),
+            sender_id: "user:cli:default".to_string(),
             content: "hello".to_string(),
-            is_from_bot: false,
+            sender_kind: SenderKind::User,
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             message_kind: MessageKind::Message,
-            sender_agent_id: None,
             recipient_agent_id: None,
         };
 
@@ -1714,12 +1709,11 @@ mod tests {
             &StoredMessage {
                 id: "msg-2".to_string(),
                 chat_id: 100,
-                sender_name: "alice".to_string(),
+                sender_id: "user:cli:default".to_string(),
                 content: "hello again".to_string(),
-                is_from_bot: false,
+                sender_kind: SenderKind::User,
                 timestamp: "2024-01-01T00:00:01Z".to_string(),
                 message_kind: MessageKind::Message,
-                sender_agent_id: None,
                 recipient_agent_id: None,
             },
             r#"[{"role":"user","content":"hello again"}]"#,
@@ -2769,11 +2763,12 @@ mod tests {
         .expect("store");
 
         let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
-        assert_eq!(msgs[0].sender_name, "system");
+        assert_eq!(msgs[0].sender_id, "system");
+        assert_eq!(msgs[0].sender_kind, SenderKind::System);
     }
 
     #[test]
-    fn store_system_event_is_from_bot_true() {
+    fn store_system_event_sender_kind_is_system() {
         let (db, _dir) = test_db();
 
         let chat_id = db.resolve_channel_log_chat_id(303).expect("create");
@@ -2784,7 +2779,188 @@ mod tests {
         .expect("store");
 
         let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
-        assert!(msgs[0].is_from_bot);
+        assert_eq!(msgs[0].sender_kind, SenderKind::System);
+    }
+
+    #[test]
+    fn store_message_with_sender_kind() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:sender-kind", None, "cli", "default")
+            .expect("create chat");
+        let message = StoredMessage {
+            id: "msg-assistant".to_string(),
+            chat_id,
+            sender_id: "lyre".to_string(),
+            content: "assistant says hi".to_string(),
+            sender_kind: SenderKind::Assistant,
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            message_kind: MessageKind::Message,
+            recipient_agent_id: None,
+        };
+
+        db.store_message_with_session(&message, r#"[]"#, None)
+            .expect("store");
+
+        let msgs = db.get_recent_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].sender_id, "lyre");
+        assert_eq!(msgs[0].sender_kind, SenderKind::Assistant);
+    }
+
+    #[test]
+    fn store_message_user_kind() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:user-kind", None, "cli", "default")
+            .expect("create chat");
+        let message =
+            StoredMessage::user(chat_id, "user:discord:123".to_string(), "hello".to_string());
+
+        db.store_message_with_session(&message, r#"[]"#, None)
+            .expect("store");
+
+        let msgs = db.get_recent_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].sender_kind, SenderKind::User);
+        assert_eq!(msgs[0].sender_id, "user:discord:123");
+    }
+
+    #[test]
+    fn store_message_system_kind() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:sys-kind", None, "cli", "default")
+            .expect("create chat");
+        let message = StoredMessage::system(chat_id, "boot complete".to_string());
+
+        db.store_message_with_session(&message, r#"[]"#, None)
+            .expect("store");
+
+        let msgs = db.get_recent_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].sender_kind, SenderKind::System);
+        assert_eq!(msgs[0].sender_id, "system");
+    }
+
+    #[test]
+    fn store_message_tool_kind() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:tool-kind", None, "cli", "default")
+            .expect("create chat");
+        let message = StoredMessage::tool(
+            chat_id,
+            "tool:web_fetch".to_string(),
+            "lyre".to_string(),
+            "fetched https://example.com".to_string(),
+        );
+
+        db.store_message_with_session(&message, r#"[]"#, None)
+            .expect("store");
+
+        let msgs = db.get_recent_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].sender_kind, SenderKind::Tool);
+        assert_eq!(msgs[0].sender_id, "tool:web_fetch");
+        assert_eq!(msgs[0].recipient_agent_id.as_deref(), Some("lyre"));
+    }
+
+    #[test]
+    fn get_recent_messages_returns_sender_id() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("web", "web:sender-id", None, "web", "default")
+            .expect("create chat");
+
+        let conn = db.conn.lock().expect("lock");
+        conn.execute(
+            "INSERT INTO messages (id, chat_id, sender_id, content, sender_kind, timestamp, message_kind)
+             VALUES ('m1', ?1, 'user:cli:alice', 'hello', 'user', '2024-01-01T00:00:00Z', 'message')",
+            rusqlite::params![chat_id],
+        )
+        .expect("insert");
+        drop(conn);
+
+        let msgs = db.get_recent_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs[0].sender_id, "user:cli:alice");
+        assert_eq!(msgs[0].sender_kind, SenderKind::User);
+    }
+
+    #[test]
+    fn find_message_by_content_finds_system_event() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db.resolve_channel_log_chat_id(500).expect("create");
+        db.store_system_event(
+            chat_id,
+            &crate::runtime::turn_scheduler::StopReason::LlmFailure,
+        )
+        .expect("store");
+
+        let msgs = db.get_all_messages(chat_id).expect("messages");
+        let found = msgs.iter().find(|m| m.content.contains("LlmFailure"));
+        assert!(found.is_some(), "should find system event by content");
+        assert_eq!(found.unwrap().sender_kind, SenderKind::System);
+    }
+
+    #[test]
+    fn store_system_event_sets_system_kind() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db.resolve_channel_log_chat_id(600).expect("create");
+        db.store_system_event(
+            chat_id,
+            &crate::runtime::turn_scheduler::StopReason::ChainDepthExceeded,
+        )
+        .expect("store");
+
+        let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs[0].sender_id, "system");
+        assert_eq!(msgs[0].sender_kind, SenderKind::System);
+        assert_eq!(msgs[0].message_kind, MessageKind::SystemEvent);
+    }
+
+    #[test]
+    fn store_agent_response_sets_assistant_kind() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db.resolve_channel_log_chat_id(700).expect("create");
+        db.store_channel_log_bot_response(chat_id, "lyre", "Hello from agent")
+            .expect("store");
+
+        let msgs = db.get_channel_log_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs[0].sender_id, "lyre");
+        assert_eq!(msgs[0].sender_kind, SenderKind::Assistant);
+        assert_eq!(msgs[0].content, "Hello from agent");
+    }
+
+    #[test]
+    fn roundtrip_recipient_agent_id() {
+        let (db, _dir) = test_db();
+
+        let chat_id = db
+            .resolve_or_create_chat_id("cli", "cli:recipient", None, "cli", "default")
+            .expect("create chat");
+        let message = StoredMessage::tool(
+            chat_id,
+            "tool:read".to_string(),
+            "bob".to_string(),
+            "file contents".to_string(),
+        );
+
+        db.store_message_with_session(&message, r#"[]"#, None)
+            .expect("store");
+
+        let msgs = db.get_recent_messages(chat_id, 10).expect("messages");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].recipient_agent_id.as_deref(), Some("bob"));
+        assert_eq!(msgs[0].sender_kind, SenderKind::Tool);
     }
 
     #[test]

--- a/src/tools/agent_send.rs
+++ b/src/tools/agent_send.rs
@@ -141,17 +141,14 @@ impl Tool for AgentSendTool {
         // 1. Save to Channel Log
         let message_id = uuid::Uuid::new_v4().to_string();
         let chat_id = context.chat_id;
-        let stored = StoredMessage {
-            id: message_id,
-            chat_id: context.channel_log_chat_id.unwrap_or(chat_id),
-            sender_name: "egopulse".to_string(),
-            content: display_text.clone(),
-            is_from_bot: true,
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            message_kind: MessageKind::AgentSend,
-            sender_agent_id: Some(context.agent_id.clone()),
-            recipient_agent_id: Some(target_id.clone()),
-        };
+        let mut stored = StoredMessage::tool(
+            context.channel_log_chat_id.unwrap_or(chat_id),
+            context.agent_id.clone(),
+            target_id.clone(),
+            display_text.clone(),
+        );
+        stored.id = message_id;
+        stored.message_kind = MessageKind::AgentSend;
 
         if let Err(error) = call_blocking(Arc::clone(&self.db), move |db| {
             db.store_message_only(&stored)
@@ -219,7 +216,7 @@ impl Tool for AgentSendTool {
 mod tests {
     use super::*;
     use crate::config::{AgentConfig, AgentId};
-    use crate::storage::MessageKind;
+    use crate::storage::{MessageKind, SenderKind};
     use crate::test_util::test_config;
     use crate::tools::ToolExecutionContext;
     use serde_json::json;
@@ -550,7 +547,8 @@ mod tests {
         .await
         .expect("messages");
 
-        assert_eq!(messages[0].sender_agent_id.as_deref(), Some("lyre"));
+        assert_eq!(messages[0].sender_id, "lyre");
+        assert_eq!(messages[0].sender_kind, SenderKind::Tool);
         assert_eq!(messages[0].recipient_agent_id.as_deref(), Some("vega"));
     }
 }
@@ -559,7 +557,7 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::config::{AgentConfig, AgentId};
-    use crate::storage::{MessageKind, call_blocking};
+    use crate::storage::{MessageKind, SenderKind, call_blocking};
     use crate::test_util::test_config;
     use serde_json::json;
     use std::collections::HashMap;
@@ -703,7 +701,8 @@ mod integration_tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].message_kind, MessageKind::AgentSend);
-        assert_eq!(messages[0].sender_agent_id.as_deref(), Some("lyre"));
+        assert_eq!(messages[0].sender_id, "lyre");
+        assert_eq!(messages[0].sender_kind, SenderKind::Tool);
         assert_eq!(messages[0].recipient_agent_id.as_deref(), Some("vega"));
         assert!(messages[0].content.contains("[Lyre → Vega]"));
         assert!(messages[0].content.contains("check this design"));

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -196,8 +196,23 @@
   background: rgba(192, 132, 252, 0.06);
 }
 
-.bubble-bot {
+.bubble-assistant {
   align-self: flex-start;
+}
+
+.bubble-tool {
+  align-self: flex-start;
+  border-color: rgba(0, 212, 255, 0.15);
+  background: rgba(0, 212, 255, 0.03);
+}
+
+.bubble-system {
+  align-self: center;
+  max-width: min(760px, 90%);
+  font-size: 0.82rem;
+  color: var(--color-muted);
+  background: rgba(8, 16, 32, 0.5);
+  border-style: dashed;
 }
 
 .bubble-meta {

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -34,16 +34,16 @@ const markdownComponents: Components = {
 
 export function MessageBubble({ message }: MessageBubbleProps) {
   const isStreaming = message.id.startsWith("draft:");
+  const isRenderable =
+    message.sender_kind === "assistant" || message.sender_kind === "tool";
 
   return (
-    <article
-      className={`bubble ${message.is_from_bot ? "bubble-bot" : "bubble-user"}`}
-    >
+    <article className={`bubble bubble-${message.sender_kind}`}>
       <div className="bubble-meta">
-        <span>{message.sender_name}</span>
+        <span>{message.sender_id}</span>
         <time>{new Date(message.timestamp).toLocaleTimeString()}</time>
       </div>
-      {message.is_from_bot ? (
+      {isRenderable ? (
         <div className={isStreaming ? "streaming-cursor" : ""}>
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}

--- a/web/src/hooks/useStream.ts
+++ b/web/src/hooks/useStream.ts
@@ -58,9 +58,9 @@ export function useStream({
 
     const userMessage: MessageItem = {
       id: makeId("message"),
-      sender_name: "web-user",
+      sender_id: "user:web:default",
+      sender_kind: "user",
       content: text,
-      is_from_bot: false,
       timestamp: nowIso(),
     };
 
@@ -138,9 +138,9 @@ export function useStream({
               ...prev,
               {
                 id: draftId,
-                sender_name: "egopulse",
+                sender_id: "egopulse",
+                sender_kind: "assistant",
                 content: delta,
-                is_from_bot: true,
                 timestamp: nowIso(),
               },
             ];
@@ -169,9 +169,9 @@ export function useStream({
                 ...prev,
                 {
                   id: `${draftId}:done`,
-                  sender_name: "egopulse",
+                  sender_id: "egopulse",
+                  sender_kind: "assistant",
                   content: responseText,
-                  is_from_bot: true,
                   timestamp: nowIso(),
                 },
               ];

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -11,9 +11,9 @@ export type SessionItem = {
 /** メッセージアイテム */
 export type MessageItem = {
   id: string;
-  sender_name: string;
+  sender_id: string;
+  sender_kind: "user" | "assistant" | "system" | "tool";
   content: string;
-  is_from_bot: boolean;
   timestamp: string;
 };
 


### PR DESCRIPTION
## 概要

messages テーブルの送信者表現を整理し、3カラム（`sender_name`, `is_from_bot`, `sender_agent_id`）を2カラム（`sender_id`, `sender_kind`）に統合する。エージェントファースト設計により、表示名のDB保持を廃止し識別子を技術IDで統一。

## 設計方針

- **エージェントファースト**: 表示名はDBに持たず、識別子は常に技術ID（`"lyre"`, `"user:discord:123"` 等）で統一
- **単一ID空間**: `sender_id` はエージェント・人間・システムを同じString列に格納し、`sender_kind` で区別
- **SenderKind enum**: `User` / `Assistant` / `System` / `Tool` の4種別

## 変更内容

| 変更 | 詳細 |
|---|---|
| DBスキーマ v4→v5 | `sender_name`/`is_from_bot`/`sender_agent_id` → `sender_id`/`sender_kind` |
| `SenderKind` enum 追加 | `Display` / `FromStr` 実装（`MessageKind` と同じパターン） |
| `StoredMessage` 再定義 | 旧3フィールド削除、新2フィールド追加 |
| マイグレーション | テーブル再構築パターン（SQLite DROP COLUMN 非対応） |
| 全チャンネル対応 | Discord / Telegram / Web / CLI の送信者ID生成を統一 |
| WebUI API レスポンス変更 | `sender_id` / `sender_kind` を返すように変更 |
| WebUI フロントエンド更新 | `MessageBubble` / `useStream` / `types.ts` / `app.css` |

## sender_id 形式

| 送信者 | sender_id 例 | sender_kind |
|---|---|---|
| エージェント | `"lyre"` | `assistant` |
| Discord ユーザー | `"user:discord:123456789"` | `user` |
| Telegram ユーザー | `"user:telegram:12345"` | `user` |
| CLI ユーザー | `"user:cli:default"` | `user` |
| Web ユーザー | `"user:web:default"` | `user` |
| Pulse synthetic | `"pulse"` | `user` |
| システム | `"system"` | `system` |
| agent_send ツール | `"lyre"` | `tool` |

## マイグレーション変換ルール

| 旧データ | 変換後 |
|---|---|
| `is_from_bot=1` + `message_kind=system_event` | `sender_id="system"`, `sender_kind=system` |
| `is_from_bot=1` + `sender_agent_id IS NOT NULL` | `sender_id=sender_agent_id`, `sender_kind=assistant` |
| `is_from_bot=1` + `sender_agent_id IS NULL` | `sender_id=sender_name`, `sender_kind=assistant` |
| `is_from_bot=0` | `sender_id=sender_name`, `sender_kind=user` |

## 検証

- `cargo test -p egopulse`: 1175 tests passed
- `cargo clippy --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: clean
- `npm run build --prefix web`: 成功

## コミット構成（10 commits）

1. `feat(storage): add SenderKind enum and refactor StoredMessage fields`
2. `feat(storage): add v4→v5 migration for sender_id/sender_kind`
3. `feat(storage): update queries for sender_id/sender_kind schema`
4. `feat(agent_loop): adapt session loading to SenderKind`
5. `feat(agent_loop): update turn prompt formatting for SenderKind`
6. `feat(channels): update Discord/Telegram to use sender_id/sender_kind`
7. `feat(channels/web): update API response to use sender_id/sender_kind`
8. `feat: update agent_send, pulse, slash_commands, memory, sleep for new schema`
9. `feat(web): update MessageItem type and MessageBubble for sender_id/sender_kind`
10. `docs: update db.md for sender_id/sender_kind schema`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 送信者が user/assistant/system/tool の4種で扱われ、送信元識別が一貫化しました。

* **Style**
  * Webのメッセージ表示が送信者種別に応じた新しいスタイル（assistant/tool/system）に更新され、表示やレンダリングが改善されました。

* **Documentation**
  * DBスキーマドキュメントが sender_id/sender_kind 準拠に更新されました。

* **Chores**
  * データベースのスキーマが自動で新バージョンへ移行されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->