### PR TITLE
feat(pulse): PULSE.md に配送先（delivery）を指定

### DIFF
--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -122,23 +122,21 @@ agent_id
 
 ### 解決順序
 
-Phase 1 の Home Surface 解決順序は以下とする。
+Home Surface 解決順序は以下とする。
 
 ```text
-1. agent が最後に会話した chat
-2. 見つからなければ skipped
+1. intention.delivery（明示指定）
+2. default_delivery（agent レベルのデフォルト）
+3. agent が最後に会話した chat（自動解決）
+4. 見つからなければ skipped
 ```
 
 将来的には、以下を追加できる。
 
 ```text
-- intention 単位の delivery override
-- agent 単位の home_surface 明示設定
 - Pulse Inbox
 - Lyre Router
 ```
-
-ただし Phase 1 では、まず **最後に会話した場所** を優先する。
 
 ---
 
@@ -265,6 +263,9 @@ Pulse は agent 配下の `PULSE.md` を使う。
 ```md
 ---
 version: 1
+default_delivery:
+  channel: discord
+  external_chat_id: "1234567890123456789"
 intentions:
   - id: morning_review
     schedule:
@@ -272,6 +273,16 @@ intentions:
       at: "09:00"
     attention: |
       今日の予定、未解決事項、昨日から持ち越している設計論点を確認する。
+    delivery:
+      channel: telegram
+      external_chat_id: "987654321"
+  - id: weekly_reflection
+    schedule:
+      kind: weekly
+      day: sun
+      at: "21:00"
+    attention: |
+      週の振り返り。
 ---
 
 # PULSE
@@ -339,15 +350,21 @@ schedule:
 
 ## validation
 
-| 項目              | 仕様                          |
-| --------------- | --------------------------- |
-| `id`            | agent 内で一意                  |
-| `enabled`       | `true` / `false`。省略時 `true`。`false` のときその intention の due 判定・実行をスキップする |
-| `schedule.kind` | `daily` / `weekly` |
-| `daily.at`      | `HH:MM`                     |
-| `weekly.day`    | `mon`〜`sun`                 |
-| `weekly.at`     | `HH:MM`                     |
-| `attention`     | LLM に渡す注意対象。実行命令ではない        |
+| 項目                          | 仕様                          |
+| --------------------------- | --------------------------- |
+| `id`                        | agent 内で一意                  |
+| `enabled`                   | `true` / `false`。省略時 `true`。`false` のときその intention の due 判定・実行をスキップする |
+| `schedule.kind`             | `daily` / `weekly` |
+| `daily.at`                  | `HH:MM`                     |
+| `weekly.day`                | `mon`〜`sun`                 |
+| `weekly.at`                 | `HH:MM`                     |
+| `attention`                 | LLM に渡す注意対象。実行命令ではない        |
+| `default_delivery`          | 省略可能。agent レベルのデフォルト配送先     |
+| `default_delivery.channel`  | `discord` / `telegram` のみ   |
+| `default_delivery.external_chat_id` | 空不可                    |
+| `delivery`（intention 内）     | 省略可能。`default_delivery` をオーバーライド |
+| `delivery.channel`          | `discord` / `telegram` のみ   |
+| `delivery.external_chat_id` | 空不可                         |
 
 `attention` は `task` ではない。
 「この時間に、この対象へ注意を向ける」という意味を持つ。
@@ -465,14 +482,16 @@ Pulse は agent 単位で発火するが、結果はユーザーが普段その 
 
 そのため、Pulse は Home Surface を解決してから通知する。
 
-## 8.2 Phase 1 の解決ルール
+## 8.2 解決ルール
 
 ```text
-resolve_home_surface(agent_id):
+resolve_home_surface(agent_id, delivery):
 
-1. chats から agent_id に一致する最新 chat を探す
-2. channel adapter が存在し、送信可能なら採用
-3. それも無ければ skipped
+1. delivery が明示指定されていれば、その channel:external_chat_id を DB から検索
+2. 見つからなければ、default_delivery を同様に検索
+3. どちらも指定されていなければ、chats から agent_id に一致する最新 chat を探す
+4. channel adapter が存在し、送信可能なら採用
+5. すべて見つからなければ skipped
 ```
 
 ## 8.3 注意点
@@ -686,22 +705,23 @@ src/
 | Pulse Inbox           | 通知が増えてから                      |
 | Lyre Router           | multi-agent 通知設計の後            |
 | 自律探索                  | 最終段階                          |
-| 複雑な delivery override | Home Surface 優先で開始            |
+| 複雑な delivery override | —                             |
 
 ## Phase 1 Implementation Decisions
 
 実装判断による元仕様との差分。実装者が迷わないよう明示する。
 
-### `default_delivery` 未実装
-- Phase 1 では `default_delivery` は実装しない
-- Home Surface が見つからない場合は `skipped` になる
-- 将来フェーズで実装予定
+### Home Surface の解決順序
+- `intention.delivery` → `default_delivery` → 自動解決（最新 chat）→ skipped
+- 明示指定時は `get_chat_by_channel_external()` で DB ルックアップ
+- channel adapter が存在するか `state.channels` で確認
+- 指定先が見つからない場合はその intention のみ skipped + 警告ログ
 
 ### Home Surface の送信可能 chat 探索
 - `resolve_home_surface()` は Discord/Telegram チャネルのみ対応
-- agent_id に紐づく最新の chat を `get_agent_chats_by_recent()` で取得
+- 自動解決時は agent_id に紐づく最新の chat を `get_agent_chats_by_recent()` で取得
 - channel adapter が存在するか `state.channels` で確認
-- Web/CLI は Phase 1 では対象外
+- Web/CLI は対象外
 
 ### Tools 使用可能
 - Pulse Activation は通常 turn と同じく built-in tools + MCP tools を使用可能
@@ -881,7 +901,7 @@ User
 | ユーザー自由記述      | `PULSE.md` body                |
 | 内部契約          | バイナリ埋め込み                       |
 | Config        | runtime 設定のみ                   |
-| 出力先           | agent が最後に会話した Home Surface    |
+| 出力先           | delivery → default_delivery → 最新 Home Surface → skipped |
 | 実行文脈          | Pulse Capsule                  |
 | 通常 session 保存 | 通知本文だけ assistant message として保存 |
 | `PULSE_OK`    | 通知せず、通常 session にも保存しない        |

--- a/src/pulse/capsule.rs
+++ b/src/pulse/capsule.rs
@@ -74,14 +74,56 @@ pub(crate) struct HomeSurface {
 
 const SENDABLE_CHANNELS: &[&str] = &["discord", "telegram"];
 
+use crate::pulse::definition::DeliverySpec;
+
 /// Resolve the home surface for an agent.
 ///
-/// Queries the database for the agent's chats ordered by recency,
-/// then returns the first chat on a sendable channel (Discord or Telegram).
+/// Resolution order:
+/// 1. `explicit_delivery` — if provided, look up the exact chat from DB
+/// 2. Auto-resolve — find the agent's most recent chat on a sendable channel
+/// 3. `None` — no sendable surface found
 ///
 /// # Errors
 /// Returns `StorageError` when the database query fails.
 pub(crate) async fn resolve_home_surface(
+    db: &Arc<Database>,
+    agent_id: &str,
+    available_channels: &[&str],
+    explicit_delivery: Option<&DeliverySpec>,
+) -> Result<Option<HomeSurface>, crate::error::StorageError> {
+    if let Some(spec) = explicit_delivery {
+        return resolve_explicit(db, spec, available_channels).await;
+    }
+
+    resolve_auto(db, agent_id, available_channels).await
+}
+
+async fn resolve_explicit(
+    db: &Arc<Database>,
+    spec: &DeliverySpec,
+    available_channels: &[&str],
+) -> Result<Option<HomeSurface>, crate::error::StorageError> {
+    if !available_channels.contains(&spec.channel.as_str()) {
+        return Ok(None);
+    }
+
+    let channel = spec.channel.clone();
+    let external_chat_id = spec.external_chat_id.clone();
+
+    let chat = crate::storage::call_blocking(db.clone(), move |db| {
+        db.get_chat_by_channel_external(&channel, &external_chat_id)
+    })
+    .await?;
+
+    Ok(chat.map(|c| HomeSurface {
+        chat_id: c.chat_id,
+        channel: c.channel,
+        external_chat_id: c.external_chat_id,
+        chat_type: c.chat_type,
+    }))
+}
+
+async fn resolve_auto(
     db: &Arc<Database>,
     agent_id: &str,
     available_channels: &[&str],
@@ -297,7 +339,7 @@ mod tests {
             "2024-06-01T00:00:00Z",
         );
 
-        let surface = resolve_home_surface(&db, "agent-a", &["discord", "telegram"])
+        let surface = resolve_home_surface(&db, "agent-a", &["discord", "telegram"], None)
             .await
             .expect("resolve")
             .expect("should find surface");
@@ -328,7 +370,7 @@ mod tests {
             "2024-06-01T00:00:00Z",
         );
 
-        let surface = resolve_home_surface(&db, "agent-a", &["discord"])
+        let surface = resolve_home_surface(&db, "agent-a", &["discord"], None)
             .await
             .expect("resolve")
             .expect("should find surface");
@@ -350,7 +392,7 @@ mod tests {
             "2024-06-01T00:00:00Z",
         );
 
-        let surface = resolve_home_surface(&db, "agent-a", &["discord", "telegram"])
+        let surface = resolve_home_surface(&db, "agent-a", &["discord", "telegram"], None)
             .await
             .expect("resolve");
 
@@ -378,7 +420,7 @@ mod tests {
             "2024-06-01T00:00:00Z",
         );
 
-        let surface = resolve_home_surface(&db, "agent-a", &["discord", "telegram"])
+        let surface = resolve_home_surface(&db, "agent-a", &["discord", "telegram"], None)
             .await
             .expect("resolve");
 
@@ -397,11 +439,104 @@ mod tests {
             "2024-06-01T00:00:00Z",
         );
 
-        let surface = resolve_home_surface(&db, "agent-a", &["telegram"])
+        let surface = resolve_home_surface(&db, "agent-a", &["telegram"], None)
             .await
             .expect("resolve");
 
         assert!(surface.is_none());
+    }
+
+    // --- explicit delivery tests ---
+
+    #[tokio::test]
+    async fn explicit_delivery_resolves_from_db() {
+        let (db, _dir) = test_db();
+
+        let chat_id = insert_chat(
+            &db,
+            "discord",
+            "discord:999",
+            "dm",
+            "agent-a",
+            "2024-01-01T00:00:00Z",
+        );
+
+        let spec = DeliverySpec {
+            channel: "discord".to_string(),
+            external_chat_id: "discord:999".to_string(),
+        };
+
+        let surface = resolve_home_surface(&db, "agent-a", &["discord"], Some(&spec))
+            .await
+            .expect("resolve")
+            .expect("should find surface");
+
+        assert_eq!(surface.chat_id, chat_id);
+        assert_eq!(surface.channel, "discord");
+        assert_eq!(surface.external_chat_id, "discord:999");
+    }
+
+    #[tokio::test]
+    async fn explicit_delivery_returns_none_when_chat_not_found() {
+        let (db, _dir) = test_db();
+
+        let spec = DeliverySpec {
+            channel: "discord".to_string(),
+            external_chat_id: "discord:nonexistent".to_string(),
+        };
+
+        let surface = resolve_home_surface(&db, "agent-a", &["discord"], Some(&spec))
+            .await
+            .expect("resolve");
+
+        assert!(surface.is_none());
+    }
+
+    #[tokio::test]
+    async fn explicit_delivery_returns_none_when_adapter_missing() {
+        let (db, _dir) = test_db();
+
+        let _chat_id = insert_chat(
+            &db,
+            "discord",
+            "discord:111",
+            "dm",
+            "agent-a",
+            "2024-01-01T00:00:00Z",
+        );
+
+        let spec = DeliverySpec {
+            channel: "discord".to_string(),
+            external_chat_id: "discord:111".to_string(),
+        };
+
+        let surface = resolve_home_surface(&db, "agent-a", &["telegram"], Some(&spec))
+            .await
+            .expect("resolve");
+
+        assert!(surface.is_none());
+    }
+
+    #[tokio::test]
+    async fn no_delivery_falls_back_to_auto_resolve() {
+        let (db, _dir) = test_db();
+
+        let chat_id = insert_chat(
+            &db,
+            "discord",
+            "discord:auto",
+            "dm",
+            "agent-a",
+            "2024-06-01T00:00:00Z",
+        );
+
+        let surface = resolve_home_surface(&db, "agent-a", &["discord"], None)
+            .await
+            .expect("resolve")
+            .expect("should find surface");
+
+        assert_eq!(surface.chat_id, chat_id);
+        assert_eq!(surface.channel, "discord");
     }
 
     // --- Capsule tests ---

--- a/src/pulse/capsule.rs
+++ b/src/pulse/capsule.rs
@@ -414,6 +414,7 @@ mod tests {
                 at: "09:00".to_string(),
             },
             attention: "Check today's schedule and unresolved items.".to_string(),
+            delivery: None,
         }
     }
 

--- a/src/pulse/capsule.rs
+++ b/src/pulse/capsule.rs
@@ -92,7 +92,14 @@ pub(crate) async fn resolve_home_surface(
     explicit_delivery: Option<&DeliverySpec>,
 ) -> Result<Option<HomeSurface>, crate::error::StorageError> {
     if let Some(spec) = explicit_delivery {
-        return resolve_explicit(db, spec, available_channels).await;
+        if let Some(surface) = resolve_explicit(db, agent_id, spec, available_channels).await? {
+            return Ok(Some(surface));
+        }
+        tracing::warn!(
+            channel = %spec.channel,
+            external_chat_id = %spec.external_chat_id,
+            "explicit delivery not found, falling back to auto resolve"
+        );
     }
 
     resolve_auto(db, agent_id, available_channels).await
@@ -100,6 +107,7 @@ pub(crate) async fn resolve_home_surface(
 
 async fn resolve_explicit(
     db: &Arc<Database>,
+    agent_id: &str,
     spec: &DeliverySpec,
     available_channels: &[&str],
 ) -> Result<Option<HomeSurface>, crate::error::StorageError> {
@@ -109,9 +117,10 @@ async fn resolve_explicit(
 
     let channel = spec.channel.clone();
     let external_chat_id = spec.external_chat_id.clone();
+    let agent_id = agent_id.to_string();
 
     let chat = crate::storage::call_blocking(db.clone(), move |db| {
-        db.get_chat_by_channel_external(&channel, &external_chat_id)
+        db.get_chat_by_channel_external_and_agent(&channel, &external_chat_id, &agent_id)
     })
     .await?;
 
@@ -477,8 +486,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_delivery_returns_none_when_chat_not_found() {
+    async fn explicit_delivery_falls_back_to_auto_when_chat_not_found() {
         let (db, _dir) = test_db();
+
+        let auto_chat_id = insert_chat(
+            &db,
+            "discord",
+            "discord:auto",
+            "dm",
+            "agent-a",
+            "2024-06-01T00:00:00Z",
+        );
 
         let spec = DeliverySpec {
             channel: "discord".to_string(),
@@ -487,13 +505,14 @@ mod tests {
 
         let surface = resolve_home_surface(&db, "agent-a", &["discord"], Some(&spec))
             .await
-            .expect("resolve");
+            .expect("resolve")
+            .expect("should fall back to auto");
 
-        assert!(surface.is_none());
+        assert_eq!(surface.chat_id, auto_chat_id);
     }
 
     #[tokio::test]
-    async fn explicit_delivery_returns_none_when_adapter_missing() {
+    async fn explicit_delivery_falls_back_to_auto_when_adapter_missing() {
         let (db, _dir) = test_db();
 
         let _chat_id = insert_chat(
@@ -505,6 +524,15 @@ mod tests {
             "2024-01-01T00:00:00Z",
         );
 
+        let telegram_chat_id = insert_chat(
+            &db,
+            "telegram",
+            "telegram:auto",
+            "dm",
+            "agent-a",
+            "2024-06-01T00:00:00Z",
+        );
+
         let spec = DeliverySpec {
             channel: "discord".to_string(),
             external_chat_id: "discord:111".to_string(),
@@ -512,9 +540,48 @@ mod tests {
 
         let surface = resolve_home_surface(&db, "agent-a", &["telegram"], Some(&spec))
             .await
-            .expect("resolve");
+            .expect("resolve")
+            .expect("should fall back to auto");
 
-        assert!(surface.is_none());
+        assert_eq!(surface.chat_id, telegram_chat_id);
+    }
+
+    #[tokio::test]
+    async fn explicit_delivery_scoped_to_agent() {
+        let (db, _dir) = test_db();
+
+        let _other_agent_chat = insert_chat(
+            &db,
+            "discord",
+            "discord:999",
+            "dm",
+            "agent-b",
+            "2024-01-01T00:00:00Z",
+        );
+
+        let auto_chat_id = insert_chat(
+            &db,
+            "discord",
+            "discord:auto",
+            "dm",
+            "agent-a",
+            "2024-06-01T00:00:00Z",
+        );
+
+        let spec = DeliverySpec {
+            channel: "discord".to_string(),
+            external_chat_id: "discord:999".to_string(),
+        };
+
+        let surface = resolve_home_surface(&db, "agent-a", &["discord"], Some(&spec))
+            .await
+            .expect("resolve")
+            .expect("should fall back to auto");
+
+        assert_eq!(
+            surface.chat_id, auto_chat_id,
+            "should not resolve to another agent's chat"
+        );
     }
 
     #[tokio::test]

--- a/src/pulse/definition.rs
+++ b/src/pulse/definition.rs
@@ -4,9 +4,17 @@ use std::path::Path;
 use serde::Deserialize;
 use thiserror::Error;
 
+/// Explicit delivery destination for pulse notifications.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DeliverySpec {
+    pub channel: String,
+    pub external_chat_id: String,
+}
+
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub(crate) struct PulseDefinition {
+    pub default_delivery: Option<DeliverySpec>,
     pub intentions: Vec<TemporalIntention>,
     pub body: String,
 }
@@ -18,6 +26,7 @@ pub(crate) struct TemporalIntention {
     pub enabled: bool,
     pub schedule: TemporalSchedule,
     pub attention: String,
+    pub delivery: Option<DeliverySpec>,
 }
 
 #[derive(Clone, Debug)]
@@ -42,6 +51,8 @@ pub(crate) enum PulseParseError {
         intention_id: String,
         detail: String,
     },
+    #[error("pulse_invalid_delivery: {agent_id}: {detail}")]
+    InvalidDelivery { agent_id: String, detail: String },
 }
 
 #[derive(Deserialize)]
@@ -50,6 +61,7 @@ struct PulseFrontMatter {
     version: u32,
     #[serde(default)]
     intentions: Vec<IntentionRaw>,
+    default_delivery: Option<DeliveryRaw>,
 }
 
 #[derive(Deserialize)]
@@ -59,6 +71,7 @@ struct IntentionRaw {
     enabled: bool,
     schedule: ScheduleRaw,
     attention: String,
+    delivery: Option<DeliveryRaw>,
 }
 
 fn default_true() -> bool {
@@ -70,6 +83,41 @@ struct ScheduleRaw {
     kind: String,
     at: String,
     day: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DeliveryRaw {
+    channel: String,
+    external_chat_id: String,
+}
+
+const VALID_DELIVERY_CHANNELS: &[&str] = &["discord", "telegram"];
+
+fn validate_delivery_raw(
+    agent_id: &str,
+    raw: &DeliveryRaw,
+) -> Result<DeliverySpec, PulseParseError> {
+    let channel = raw.channel.trim().to_ascii_lowercase();
+    if !VALID_DELIVERY_CHANNELS.contains(&channel.as_str()) {
+        return Err(PulseParseError::InvalidDelivery {
+            agent_id: agent_id.to_string(),
+            detail: format!(
+                "invalid delivery channel: {channel}, expected one of {}",
+                VALID_DELIVERY_CHANNELS.join(", ")
+            ),
+        });
+    }
+    let external_chat_id = raw.external_chat_id.trim().to_string();
+    if external_chat_id.is_empty() {
+        return Err(PulseParseError::InvalidDelivery {
+            agent_id: agent_id.to_string(),
+            detail: "delivery external_chat_id must not be empty".to_string(),
+        });
+    }
+    Ok(DeliverySpec {
+        channel,
+        external_chat_id,
+    })
 }
 
 #[cfg(test)]
@@ -86,6 +134,7 @@ fn parse_pulse_definition_inner(
 
     if trimmed.is_empty() {
         return Ok(PulseDefinition {
+            default_delivery: None,
             intentions: Vec::new(),
             body: String::new(),
         });
@@ -93,6 +142,7 @@ fn parse_pulse_definition_inner(
 
     let Some(rest) = trimmed.strip_prefix("---") else {
         return Ok(PulseDefinition {
+            default_delivery: None,
             intentions: Vec::new(),
             body: trimmed.to_string(),
         });
@@ -100,6 +150,7 @@ fn parse_pulse_definition_inner(
 
     let Some(rest) = rest.strip_prefix('\n') else {
         return Ok(PulseDefinition {
+            default_delivery: None,
             intentions: Vec::new(),
             body: trimmed.to_string(),
         });
@@ -107,6 +158,7 @@ fn parse_pulse_definition_inner(
 
     let Some(end) = rest.find("\n---") else {
         return Ok(PulseDefinition {
+            default_delivery: None,
             intentions: Vec::new(),
             body: trimmed.to_string(),
         });
@@ -121,6 +173,12 @@ fn parse_pulse_definition_inner(
             detail: e.to_string(),
         })?;
 
+    let default_delivery = fm
+        .default_delivery
+        .as_ref()
+        .map(|raw| validate_delivery_raw(agent_id, raw))
+        .transpose()?;
+
     let mut intentions = Vec::with_capacity(fm.intentions.len());
     let mut seen_ids = HashSet::new();
 
@@ -134,15 +192,25 @@ fn parse_pulse_definition_inner(
         seen_ids.insert(raw.id.clone());
 
         let schedule = validate_and_build_schedule(agent_id, &raw)?;
+        let delivery = raw
+            .delivery
+            .as_ref()
+            .map(|d| validate_delivery_raw(agent_id, d))
+            .transpose()?;
         intentions.push(TemporalIntention {
             id: raw.id,
             enabled: raw.enabled,
             schedule,
             attention: raw.attention,
+            delivery,
         });
     }
 
-    Ok(PulseDefinition { intentions, body })
+    Ok(PulseDefinition {
+        default_delivery,
+        intentions,
+        body,
+    })
 }
 
 fn validate_and_build_schedule(
@@ -252,6 +320,7 @@ pub(crate) fn load_pulse_definition(
 
     if !path.exists() {
         return Ok(PulseDefinition {
+            default_delivery: None,
             intentions: Vec::new(),
             body: String::new(),
         });
@@ -675,6 +744,7 @@ body
             enabled: true,
             schedule: TemporalSchedule::Daily { at: at.to_string() },
             attention: String::new(),
+            delivery: None,
         }
     }
 
@@ -687,6 +757,7 @@ body
                 at: at.to_string(),
             },
             attention: String::new(),
+            delivery: None,
         }
     }
 
@@ -728,6 +799,7 @@ body
                 at: "09:00".to_string(),
             },
             attention: String::new(),
+            delivery: None,
         };
         let now = utc(2026, 5, 10, 0, 0, 0);
         let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo");
@@ -744,6 +816,7 @@ body
                 at: "21:00".to_string(),
             },
             attention: String::new(),
+            delivery: None,
         };
         let now = utc(2026, 5, 10, 12, 0, 0);
         let key = generate_due_key("kitara", &intention, now, "Asia/Tokyo");
@@ -873,5 +946,179 @@ body
         let result = parse_pulse_definition(content).expect("should parse");
         assert_eq!(result.intentions.len(), 1);
         assert!(result.intentions[0].enabled);
+    }
+
+    // --- delivery tests ---
+
+    #[test]
+    fn parse_intention_delivery() {
+        let content = "\
+---
+version: 1
+intentions:
+  - id: morning_review
+    schedule:
+      kind: daily
+      at: \"09:00\"
+    attention: test
+    delivery:
+      channel: discord
+      external_chat_id: \"123456789\"
+---
+
+body
+";
+        let result = parse_pulse_definition(content).expect("should parse");
+        assert_eq!(result.intentions.len(), 1);
+        let delivery = result.intentions[0].delivery.as_ref().expect("delivery");
+        assert_eq!(delivery.channel, "discord");
+        assert_eq!(delivery.external_chat_id, "123456789");
+    }
+
+    #[test]
+    fn parse_default_delivery() {
+        let content = "\
+---
+version: 1
+default_delivery:
+  channel: telegram
+  external_chat_id: \"987654321\"
+intentions:
+  - id: morning_review
+    schedule:
+      kind: daily
+      at: \"09:00\"
+    attention: test
+---
+
+body
+";
+        let result = parse_pulse_definition(content).expect("should parse");
+        let dd = result.default_delivery.as_ref().expect("default_delivery");
+        assert_eq!(dd.channel, "telegram");
+        assert_eq!(dd.external_chat_id, "987654321");
+        assert!(result.intentions[0].delivery.is_none());
+    }
+
+    #[test]
+    fn parse_delivery_optional_on_intention() {
+        let content = "\
+---
+version: 1
+intentions:
+  - id: morning_review
+    schedule:
+      kind: daily
+      at: \"09:00\"
+    attention: test
+---
+
+body
+";
+        let result = parse_pulse_definition(content).expect("should parse");
+        assert!(result.intentions[0].delivery.is_none());
+    }
+
+    #[test]
+    fn parse_default_delivery_optional() {
+        let content = valid_pulse_md();
+        let result = parse_pulse_definition(&content).expect("should parse");
+        assert!(result.default_delivery.is_none());
+    }
+
+    #[test]
+    fn parse_rejects_invalid_channel() {
+        let content = "\
+---
+version: 1
+intentions:
+  - id: morning_review
+    schedule:
+      kind: daily
+      at: \"09:00\"
+    attention: test
+    delivery:
+      channel: web
+      external_chat_id: \"abc\"
+---
+
+body
+";
+        let err = parse_pulse_definition(content).unwrap_err();
+        assert!(
+            matches!(err, PulseParseError::InvalidDelivery { .. }),
+            "expected InvalidDelivery, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_empty_external_chat_id() {
+        let content = "\
+---
+version: 1
+default_delivery:
+  channel: discord
+  external_chat_id: \"\"
+intentions:
+  - id: morning_review
+    schedule:
+      kind: daily
+      at: \"09:00\"
+    attention: test
+---
+
+body
+";
+        let err = parse_pulse_definition(content).unwrap_err();
+        assert!(
+            matches!(err, PulseParseError::InvalidDelivery { .. }),
+            "expected InvalidDelivery, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_both_delivery_sources() {
+        let content = "\
+---
+version: 1
+default_delivery:
+  channel: discord
+  external_chat_id: \"111\"
+intentions:
+  - id: morning_review
+    schedule:
+      kind: daily
+      at: \"09:00\"
+    attention: test
+    delivery:
+      channel: telegram
+      external_chat_id: \"222\"
+  - id: evening_review
+    schedule:
+      kind: daily
+      at: \"21:00\"
+    attention: test
+---
+
+body
+";
+        let result = parse_pulse_definition(content).expect("should parse");
+        let dd = result.default_delivery.as_ref().expect("default_delivery");
+        assert_eq!(dd.channel, "discord");
+
+        let first = &result.intentions[0];
+        let d = first.delivery.as_ref().expect("intention delivery");
+        assert_eq!(d.channel, "telegram");
+        assert_eq!(d.external_chat_id, "222");
+
+        assert!(result.intentions[1].delivery.is_none());
+    }
+
+    #[test]
+    fn parse_delivery_without_front_matter_backward_compat() {
+        let content = "# Just a heading\nSome text without front matter";
+        let result = parse_pulse_definition(content).expect("should parse");
+        assert!(result.default_delivery.is_none());
+        assert!(result.intentions.is_empty());
     }
 }

--- a/src/pulse/definition.rs
+++ b/src/pulse/definition.rs
@@ -96,13 +96,14 @@ const VALID_DELIVERY_CHANNELS: &[&str] = &["discord", "telegram"];
 fn validate_delivery_raw(
     agent_id: &str,
     raw: &DeliveryRaw,
+    source: &str,
 ) -> Result<DeliverySpec, PulseParseError> {
     let channel = raw.channel.trim().to_ascii_lowercase();
     if !VALID_DELIVERY_CHANNELS.contains(&channel.as_str()) {
         return Err(PulseParseError::InvalidDelivery {
             agent_id: agent_id.to_string(),
             detail: format!(
-                "invalid delivery channel: {channel}, expected one of {}",
+                "{source}: invalid delivery channel: {channel}, expected one of {}",
                 VALID_DELIVERY_CHANNELS.join(", ")
             ),
         });
@@ -111,7 +112,7 @@ fn validate_delivery_raw(
     if external_chat_id.is_empty() {
         return Err(PulseParseError::InvalidDelivery {
             agent_id: agent_id.to_string(),
-            detail: "delivery external_chat_id must not be empty".to_string(),
+            detail: format!("{source}: delivery external_chat_id must not be empty"),
         });
     }
     Ok(DeliverySpec {
@@ -176,7 +177,7 @@ fn parse_pulse_definition_inner(
     let default_delivery = fm
         .default_delivery
         .as_ref()
-        .map(|raw| validate_delivery_raw(agent_id, raw))
+        .map(|raw| validate_delivery_raw(agent_id, raw, "default_delivery"))
         .transpose()?;
 
     let mut intentions = Vec::with_capacity(fm.intentions.len());
@@ -195,7 +196,7 @@ fn parse_pulse_definition_inner(
         let delivery = raw
             .delivery
             .as_ref()
-            .map(|d| validate_delivery_raw(agent_id, d))
+            .map(|d| validate_delivery_raw(agent_id, d, &format!("intention '{}'", raw.id)))
             .transpose()?;
         intentions.push(TemporalIntention {
             id: raw.id,

--- a/src/pulse/output.rs
+++ b/src/pulse/output.rs
@@ -366,6 +366,7 @@ mod tests {
                 at: "08:00".to_string(),
             },
             attention: "Check today's schedule.\n".to_string(),
+            delivery: None,
         };
         let content = format_synthetic_content(&intention);
         assert_eq!(
@@ -384,6 +385,7 @@ mod tests {
                 at: "21:00".to_string(),
             },
             attention: "Reflect on the week.".to_string(),
+            delivery: None,
         };
         let content = format_synthetic_content(&intention);
         assert!(content.starts_with("[Pulse: weekly_reflection]"));
@@ -400,6 +402,7 @@ mod tests {
                 at: "09:00".to_string(),
             },
             attention: "  hello world  \n\n".to_string(),
+            delivery: None,
         };
         let content = format_synthetic_content(&intention);
         assert!(content.contains("Attention:\nhello world"));
@@ -445,6 +448,7 @@ mod tests {
                 at: "09:00".to_string(),
             },
             attention: "Check today's schedule and unresolved items.".to_string(),
+            delivery: None,
         }
     }
 

--- a/src/pulse/runner.rs
+++ b/src/pulse/runner.rs
@@ -308,6 +308,7 @@ mod tests {
                 at: "09:00".to_string(),
             },
             attention: "Check today's schedule.".to_string(),
+            delivery: None,
         }
     }
 

--- a/src/pulse/scheduler.rs
+++ b/src/pulse/scheduler.rs
@@ -149,42 +149,45 @@ async fn process_intention(
     // 5. Resolve home surface
     let available_channels = state.channels.names();
     let explicit_delivery = intention.delivery.as_ref().or(default_delivery);
-    let home_surface =
-        match super::capsule::resolve_home_surface(&state.db, agent_id_str, &available_channels, explicit_delivery)
-            .await
-        {
-            Ok(Some(surface)) => surface,
-            Ok(None) => {
-                if let Err(e) =
-                    update_run_skipped(&state.db, &pulse_run_id, "no sendable home surface").await
-                {
-                    warn!(
-                        pulse_run_id = %pulse_run_id,
-                        error = %e,
-                        "pulse scan: failed to mark pulse_run as skipped"
-                    );
-                }
-                return;
-            }
-            Err(e) => {
+    let home_surface = match super::capsule::resolve_home_surface(
+        &state.db,
+        agent_id_str,
+        &available_channels,
+        explicit_delivery,
+    )
+    .await
+    {
+        Ok(Some(surface)) => surface,
+        Ok(None) => {
+            if let Err(e) =
+                update_run_skipped(&state.db, &pulse_run_id, "no sendable home surface").await
+            {
                 warn!(
-                    agent_id = agent_id_str,
+                    pulse_run_id = %pulse_run_id,
                     error = %e,
-                    "pulse scan: failed to resolve home surface"
+                    "pulse scan: failed to mark pulse_run as skipped"
                 );
-                if let Err(e) =
-                    update_run_skipped(&state.db, &pulse_run_id, "home surface resolution failed")
-                        .await
-                {
-                    warn!(
-                        pulse_run_id = %pulse_run_id,
-                        error = %e,
-                        "pulse scan: failed to mark pulse_run as skipped"
-                    );
-                }
-                return;
             }
-        };
+            return;
+        }
+        Err(e) => {
+            warn!(
+                agent_id = agent_id_str,
+                error = %e,
+                "pulse scan: failed to resolve home surface"
+            );
+            if let Err(e) =
+                update_run_skipped(&state.db, &pulse_run_id, "home surface resolution failed").await
+            {
+                warn!(
+                    pulse_run_id = %pulse_run_id,
+                    error = %e,
+                    "pulse scan: failed to mark pulse_run as skipped"
+                );
+            }
+            return;
+        }
+    };
 
     // 6. Build capsule
     // Prospective memory is already injected via build_system_prompt() in the

--- a/src/pulse/scheduler.rs
+++ b/src/pulse/scheduler.rs
@@ -59,7 +59,16 @@ async fn scan_agent(
     }
 
     for intention in &definition.intentions {
-        process_intention(state, agent_id, intention, &definition.body, timezone, now).await;
+        process_intention(
+            state,
+            agent_id,
+            intention,
+            definition.default_delivery.as_ref(),
+            &definition.body,
+            timezone,
+            now,
+        )
+        .await;
     }
 }
 
@@ -69,6 +78,7 @@ async fn process_intention(
     state: &AppState,
     agent_id: &AgentId,
     intention: &super::definition::TemporalIntention,
+    default_delivery: Option<&super::definition::DeliverySpec>,
     pulse_body: &str,
     timezone: &str,
     now: chrono::DateTime<Utc>,
@@ -138,8 +148,9 @@ async fn process_intention(
 
     // 5. Resolve home surface
     let available_channels = state.channels.names();
+    let explicit_delivery = intention.delivery.as_ref().or(default_delivery);
     let home_surface =
-        match super::capsule::resolve_home_surface(&state.db, agent_id_str, &available_channels)
+        match super::capsule::resolve_home_surface(&state.db, agent_id_str, &available_channels, explicit_delivery)
             .await
         {
             Ok(Some(surface)) => surface,

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -213,6 +213,31 @@ impl Database {
         }
     }
 
+    pub(crate) fn get_chat_by_channel_external(
+        &self,
+        channel: &str,
+        external_chat_id: &str,
+    ) -> Result<Option<ChatInfo>, StorageError> {
+        let conn = self.get_conn()?;
+        match conn.query_row(
+            "SELECT chat_id, chat_type, agent_id FROM chats WHERE channel = ?1 AND external_chat_id = ?2 LIMIT 1",
+            params![channel, external_chat_id],
+            |row| {
+                Ok(ChatInfo {
+                    chat_id: row.get(0)?,
+                    channel: channel.to_string(),
+                    external_chat_id: external_chat_id.to_string(),
+                    chat_type: row.get(1)?,
+                    agent_id: row.get(2)?,
+                })
+            },
+        ) {
+            Ok(info) => Ok(Some(info)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     pub(crate) fn resolve_or_create_chat_id(
         &self,
         channel: &str,

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -213,15 +213,16 @@ impl Database {
         }
     }
 
-    pub(crate) fn get_chat_by_channel_external(
+    pub(crate) fn get_chat_by_channel_external_and_agent(
         &self,
         channel: &str,
         external_chat_id: &str,
+        agent_id: &str,
     ) -> Result<Option<ChatInfo>, StorageError> {
         let conn = self.get_conn()?;
         match conn.query_row(
-            "SELECT chat_id, chat_type, agent_id FROM chats WHERE channel = ?1 AND external_chat_id = ?2 LIMIT 1",
-            params![channel, external_chat_id],
+            "SELECT chat_id, chat_type, agent_id FROM chats WHERE channel = ?1 AND external_chat_id = ?2 AND agent_id = ?3 LIMIT 1",
+            params![channel, external_chat_id, agent_id],
             |row| {
                 Ok(ChatInfo {
                     chat_id: row.get(0)?,


### PR DESCRIPTION
## 概要

PULSE.md front matter に `default_delivery` と intention 単位の `delivery` を追加し、Pulse の通知先を明示的に指定できるようにする。

## 変更内容

### PULSE.md 仕様追加

```yaml
---
version: 1
default_delivery:
  channel: discord
  external_chat_id: "1234567890123456789"
intentions:
  - id: morning_review
    schedule:
      kind: daily
      at: "09:00"
    attention: |
      今日の予定を確認。
    delivery:
      channel: telegram
      external_chat_id: "987654321"
  - id: weekly_reflection
    schedule:
      kind: weekly
      day: sun
      at: "21:00"
    attention: |
      週の振り返り。
    # delivery なし → default_delivery を使用
---
```

### 解決順序

1. `intention.delivery`（明示指定）
2. `default_delivery`（agent レベル）
3. 従来の自動解決（最新チャット）
4. `skipped`（見つからない場合）

### 変更ファイル

| ファイル | 変更種別 |
|---|---|
| `src/pulse/definition.rs` | 変更 — `DeliverySpec` struct、パーサー拡張、バリデーション |
| `src/pulse/capsule.rs` | 変更 — `resolve_home_surface` シグネチャ変更、明示配送ルート追加 |
| `src/pulse/scheduler.rs` | 変更 — delivery 解決チェーン統合 |
| `src/storage/queries.rs` | 変更 — `get_chat_by_channel_external` 追加 |
| `docs/pulse.md` | 変更 — 仕様書に delivery 機能追記 |

### コミット

1. `feat(pulse): add DeliverySpec and extend PULSE.md parser`
2. `feat(pulse): resolve explicit delivery in Home Surface resolution`
3. `docs(pulse): document delivery override in PULSE.md spec`

### テスト

- 全 86 pulse テスト通過（新規 12 テスト追加）
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅

### 後方互換性

- `default_delivery` / `delivery` ともに省略可能
- 省略時は従来の自動解決が動作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Pulse送信先の明示指定機能を追加。チャネルと外部IDを指定して送信先を固定できるように対応しました。

* **Documentation**
  * Pulse仕様書を更新。Home Surface解決の優先順位と送信先決定ロジックを明確化しました。

* **Tests**
  * 送信先指定機能に関する包括的なテストを追加。各パターンの動作確認が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->