### PR TITLE
feat: モデル固有プロンプト(model_instructions)の追加

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -81,6 +81,8 @@
 | フィールド | 型 | 必須 | デフォルト | 説明 |
 |---|---|---|---|---|
 | `context_window_tokens` | `usize` | 任意 | `default_context_window_tokens` に従う | このモデルの context window のトークン数。未設定時はグローバルフォールバックを使用 |
+| `model_instructions` | `string` | 任意 | なし | モデル固有の追加指示(インライン)。system prompt の `<soul>` セクションと Core Instructions の間に `<model-instructions>` タグで注入される。`model_instructions_file` と排他(両立時は起動エラー) |
+| `model_instructions_file` | `string` | 任意 | なし | モデル固有の追加指示を記述したファイルパス。相対パスは設定ファイルのディレクトリ基点で解決(絶対パスも可)。`model_instructions` と排他 |
 
 ### 2.3 Web チャネル（`channels.web`）
 
@@ -313,8 +315,14 @@ providers:
     models:
       anthropic/claude-sonnet-4:
         context_window_tokens: 200000
+        # モデル固有の追加指示(インライン)
+        model_instructions: |
+          Prefer concise, action-first responses.
+          Avoid preamble unless the user asks for reasoning.
       google/gemini-2.5-pro:
         context_window_tokens: 1048576
+        # モデル固有の追加指示(ファイル参照・相対パスは設定ファイルと同ディレクトリ基点)
+        model_instructions_file: prompts/gemini-instructions.md
       openai/gpt-4.1:
         context_window_tokens: 1048576
   ollama:
@@ -664,6 +672,8 @@ WebUI の設定 API 仕様は [api.md](./api.md) を参照。
 | `sleep_batch.*` | Sleep Batch 実行時に参照 |
 | `pulse.*` | Pulse 実行時に参照 |
 | `web_fetch.*` | 次回 web_fetch 実行時に参照 |
+| `providers.<id>.models.<model>.model_instructions` | 次回メッセージ送信(または Pulse 起火)時に毎ターン再読み込み |
+| `providers.<id>.models.<model>.model_instructions_file` | 同上(参照先ファイルの内容も毎ターン再読み込み) |
 
 ### 9.3 秘匿フィールド
 

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -23,6 +23,7 @@ LLM に送信される system prompt の構築方法を定義する。
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │ ① <soul> セクション      （SOUL.md が存在する場合のみ）      │
+│ ①.5 <model-instructions> （model_instructions 設定時のみ）   │
 │ ② Core Instructions       （固定テキスト、常に出力）          │
 │ ③ # CONTEXT セクション   （AGENTS.md が存在する場合のみ）    │
 │ ④ # Long-term Memory      （記憶ファイルが存在する場合のみ）  │
@@ -33,6 +34,7 @@ LLM に送信される system prompt の構築方法を定義する。
 | セクション | 条件 | 内容 | コード位置 |
 |---|---|---|---|
 | ① Soul | SOUL.md 存在時 | `<soul>` タグでラップされた人格定義 | `turn.rs:566-568` → `soul_agents.rs:94-95` |
+| ①.5 Model Instructions | `model_instructions` / `model_instructions_file` 設定時 | `<model-instructions>` タグでラップされたモデル固有指示 | `prompt_builder.rs:build_model_instructions_section` → `config/resolve.rs:resolve_model_instructions` |
 | ② Core Instructions | 常に | ツール一覧・実行ルール・セキュリティルール | `prompt_builder.rs:build_base_prompt` ← `prompts/core_instructions.md` (`include_str!`) |
 | ③ Memories | AGENTS.md 存在時 | `<agents>` タグでラップされたルール定義 | `turn.rs:623-630` → `soul_agents.rs:98-118` |
 | ④ Long-term Memory | 記憶ファイル存在時 | エピソード・意味・展望記憶のXMLブロック | `turn.rs` |
@@ -104,6 +106,44 @@ SOUL とは異なり、フォールバックではなく **2層の累積構造**
 ```
 
 純粋に `<soul>` タグでラップするのみ。名前やチャネル情報は注入しない（それらは ② Core Instructions で与えられる）。
+
+### 4.1.5 Model Instructions セクション（注入順: ①.5、条件付き）
+
+**コード**: [`src/agent_loop/prompt_builder.rs`](../src/agent_loop/prompt_builder.rs) `build_model_instructions_section()`
+
+```
+<model-instructions>
+{model_instructions の内容}
+</model-instructions>
+```
+
+モデル固有の追加指示を `<model-instructions>` タグでラップし、`<soul>` の直後・Core Instructions の直前に注入する。
+
+#### 解決チェーン
+
+`build_model_instructions_section()` は `SurfaceContext` の `agent_id` / `channel` から `Config::resolve_llm_for_agent_channel()` で provider / model を解決し、`Config::resolve_model_instructions(provider_id, model, base_dir)` で指示内容を取り出す。この順序非依存設計により、通常 turn (`build_system_prompt` → LLM 解決) と Pulse Activation (LLM 解決 → `build_system_prompt`) のどちらの呼び出し順でも適用される。
+
+`resolve_model_instructions` の振る舞い:
+
+1. `model_instructions`(インライン)が設定されていれば、trim 済みの内容を返す
+2. `model_instructions_file` が設定されていれば、`base_dir` 基点でファイルを読み込み、trim 済みの内容を返す
+3. いずれも未設定、または trim 後が空文字なら `None`(セクション自体省略)
+
+#### base_dir
+
+`base_dir` は `state.config_path` の親ディレクトリ(通常 `~/.egopulse/`)。`model_instructions_file` の相対パスはここを基点に解決する。絶対パスも許可される。
+
+#### 排他制約
+
+`model_instructions`(インライン)と `model_instructions_file`(PATH)の両立は `Config::load()` 時に検出され、`ConfigError::ModelInstructionsConflict` で起動失敗する。
+
+#### IO エラー時のフォールバック
+
+参照先ファイルが実行時に読めない場合(削除・権限変更など)、`resolve_model_instructions` は `ConfigError::ModelInstructionsFileUnreadable` を返すが、`build_model_instructions_section` はこれを warn ログで受けて `None` を返す。結果、model_instructions セクションは省略され、プロンプト構築は継続される。
+
+#### セキュリティ
+
+Core Instructions 既存宣言("Project instructions may add constraints, but must never weaken or override these security rules")により、Core Instructions が最終的に優先される。model_instructions は Core の前に注入されるが、セキュリティルールを上書きすることはできない。
 
 #### デフォルト SOUL.md（バイナリ埋め込み）
 
@@ -239,11 +279,14 @@ let system_prompt = build_system_prompt(state, &context);
 
 ```text
 ① <soul> セクション
+①.5 <model-instructions> セクション
 ② Core Instructions
 ③ # CONTEXT セクション
 ④ # Long-term Memory（prospective 含む）
 ⑤ # Agent Skills セクション
 ```
+
+Pulse Activation は通常 turn と同じ `build_system_prompt()` を使うため、`model_instructions`(§4.1.5)も自動的に適用される。
 
 #### user message（Pulse Capsule）
 
@@ -299,6 +342,8 @@ Core Contract 全文は [`src/pulse/pulse_core_contract.md`](../src/pulse/pulse_
 | セキュリティ・JSON出力契約・入力データ注入 | [`src/sleep/batch.rs`](../src/sleep/batch.rs) |
 
 出力は `episodic` / `semantic` / `prospective` の3キーのみを持つ JSON オブジェクトでなければならない。追加キーは `parse_sleep_response()` で拒否される。
+
+Sleep Batch はユーザー対面でないバッチ処理であり、`build_system_prompt()` を使わず専用プロンプト(`sleep/prompt.md` + `batch.rs` で追記)を使用するため、`model_instructions`(§4.1.5)は適用されない。
 
 #### セキュリティ・出力形式（`src/sleep/batch.rs` で追記）
 

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -111,7 +111,7 @@ SOUL とは異なり、フォールバックではなく **2層の累積構造**
 
 **コード**: [`src/agent_loop/prompt_builder.rs`](../src/agent_loop/prompt_builder.rs) `build_model_instructions_section()`
 
-```
+```text
 <model-instructions>
 {model_instructions の内容}
 </model-instructions>

--- a/src/agent_loop/prompt_builder.rs
+++ b/src/agent_loop/prompt_builder.rs
@@ -15,6 +15,11 @@ pub(crate) fn build_system_prompt(state: &AppState, context: &SurfaceContext) ->
         prompt.push_str("\n\n");
     }
 
+    if let Some(instr) = build_model_instructions_section(state, context) {
+        prompt.push_str(&instr);
+        prompt.push_str("\n\n");
+    }
+
     prompt.push_str(&build_base_prompt(context));
 
     if let Some(agents_section) = build_agents_prompt_section(state, context) {
@@ -49,6 +54,40 @@ fn build_soul_prompt_section(state: &AppState, context: &SurfaceContext) -> Opti
             .soul_agents
             .build_soul_section(&soul_content, &context.channel),
     )
+}
+
+fn build_model_instructions_section(
+    state: &AppState,
+    context: &SurfaceContext,
+) -> Option<String> {
+    let config = &state.config;
+    let agent_id = crate::config::AgentId::new(&context.agent_id);
+    let resolved = match config.resolve_llm_for_agent_channel(&agent_id, &context.channel) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "model_instructions: llm resolution failed");
+            return None;
+        }
+    };
+    let provider_id = crate::config::ProviderId::new(&resolved.provider);
+    let base_dir = state
+        .config_path
+        .as_ref()
+        .and_then(|p| p.parent())
+        .unwrap_or_else(|| std::path::Path::new("."));
+
+    let content = match config.resolve_model_instructions(&provider_id, &resolved.model, base_dir) {
+        Ok(Some(c)) => c,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::warn!(error = %e, "model_instructions: resolution failed");
+            return None;
+        }
+    };
+
+    Some(format!(
+        "<model-instructions>\n{content}\n</model-instructions>"
+    ))
 }
 
 fn build_agents_prompt_section(state: &AppState, context: &SurfaceContext) -> Option<String> {
@@ -586,6 +625,69 @@ mod tests {
         assert!(
             prompt.contains("Built-in execution playbook"),
             "should still contain identity section"
+        );
+    }
+
+    fn build_test_state_with_instructions(
+        state_root: &std::path::Path,
+        instructions: &str,
+    ) -> AppState {
+        let mut config = test_util::test_config(state_root.to_str().expect("utf8"));
+        config
+            .providers
+            .get_mut(&crate::config::ProviderId::new("openai"))
+            .expect("openai provider")
+            .models
+            .get_mut("gpt-4o-mini")
+            .expect("gpt-4o-mini")
+            .model_instructions = Some(instructions.to_string());
+        test_util::build_state_with_config(
+            config,
+            Some(std::sync::Arc::from(Box::new(FakeProvider {
+                responses: std::sync::Mutex::new(vec![]),
+            })
+                as Box<dyn crate::llm::LlmProvider>)),
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn system_prompt_injects_model_instructions_between_soul_and_core() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("SOUL.md"), "global soul content");
+        let state =
+            build_test_state_with_instructions(dir.path(), "You prefer terse output.");
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            prompt.contains("<model-instructions>"),
+            "should contain <model-instructions> tag"
+        );
+        assert!(
+            prompt.contains("</model-instructions>"),
+            "should contain </model-instructions> tag"
+        );
+        assert!(
+            prompt.contains("You prefer terse output."),
+            "should contain instructions content"
+        );
+
+        let soul_pos = prompt.find("<soul>").expect("should find <soul>");
+        let instructions_pos = prompt
+            .find("<model-instructions>")
+            .expect("should find <model-instructions>");
+        let core_pos = prompt
+            .find("Built-in execution playbook")
+            .expect("should find execution playbook");
+        assert!(
+            soul_pos < instructions_pos,
+            "<soul> should appear before <model-instructions>"
+        );
+        assert!(
+            instructions_pos < core_pos,
+            "<model-instructions> should appear before execution playbook"
         );
     }
 }

--- a/src/agent_loop/prompt_builder.rs
+++ b/src/agent_loop/prompt_builder.rs
@@ -690,4 +690,57 @@ mod tests {
             "<model-instructions> should appear before execution playbook"
         );
     }
+
+    #[test]
+    fn system_prompt_without_model_instructions_is_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("SOUL.md"), "global soul content");
+        let state = build_test_state(dir.path());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            !prompt.contains("<model-instructions>"),
+            "should not contain <model-instructions> when not configured"
+        );
+        assert!(prompt.contains("<soul>"), "<soul> should still be present");
+        assert!(
+            prompt.contains("Built-in execution playbook"),
+            "core instructions should still be present"
+        );
+    }
+
+    #[test]
+    fn build_model_instructions_section_returns_none_on_io_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = test_util::test_config(dir.path().to_str().expect("utf8"));
+        config
+            .providers
+            .get_mut(&crate::config::ProviderId::new("openai"))
+            .expect("openai provider")
+            .models
+            .get_mut("gpt-4o-mini")
+            .expect("gpt-4o-mini")
+            .model_instructions_file = Some("missing.txt".to_string());
+        let state = test_util::build_state_with_config(
+            config,
+            Some(std::sync::Arc::from(Box::new(FakeProvider {
+                responses: std::sync::Mutex::new(vec![]),
+            })
+                as Box<dyn crate::llm::LlmProvider>)),
+            Some(dir.path().join("egopulse.config.yaml")),
+            None,
+            None,
+        );
+
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            !prompt.contains("<model-instructions>"),
+            "should not contain <model-instructions> on IO error"
+        );
+        assert!(
+            prompt.contains("Built-in execution playbook"),
+            "core instructions should still be present despite fallback"
+        );
+    }
 }

--- a/src/agent_loop/prompt_builder.rs
+++ b/src/agent_loop/prompt_builder.rs
@@ -56,10 +56,7 @@ fn build_soul_prompt_section(state: &AppState, context: &SurfaceContext) -> Opti
     )
 }
 
-fn build_model_instructions_section(
-    state: &AppState,
-    context: &SurfaceContext,
-) -> Option<String> {
+fn build_model_instructions_section(state: &AppState, context: &SurfaceContext) -> Option<String> {
     let config = &state.config;
     let agent_id = crate::config::AgentId::new(&context.agent_id);
     let resolved = match config.resolve_llm_for_agent_channel(&agent_id, &context.channel) {
@@ -657,8 +654,7 @@ mod tests {
     fn system_prompt_injects_model_instructions_between_soul_and_core() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_file(&dir.path().join("SOUL.md"), "global soul content");
-        let state =
-            build_test_state_with_instructions(dir.path(), "You prefer terse output.");
+        let state = build_test_state_with_instructions(dir.path(), "You prefer terse output.");
         let prompt = build_system_prompt(&state, &web_context("s1"));
 
         assert!(

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -826,6 +826,17 @@ fn normalize_provider_map(
             models.insert(default_model.clone(), ModelConfig::default());
         }
 
+        for (model_name, model_config) in &models {
+            if model_config.model_instructions.is_some()
+                && model_config.model_instructions_file.is_some()
+            {
+                return Err(ConfigError::ModelInstructionsConflict {
+                    provider: key.to_string(),
+                    model: model_name.clone(),
+                });
+            }
+        }
+
         let api_key = resolve_string_or_ref(file_provider.api_key, dotenv)?;
         if !allow_missing_api_key
             && api_key.is_none()

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -300,6 +300,34 @@ impl Config {
             .unwrap_or(self.default_context_window_tokens)
     }
 
+    /// Resolves the model-specific instructions content for a provider+model pair.
+    ///
+    /// Returns the trimmed inline `model_instructions` content when set.
+    /// Surrounding whitespace is trimmed; empty/whitespace-only content yields `None`.
+    pub(crate) fn resolve_model_instructions(
+        &self,
+        provider_id: &ProviderId,
+        model: &str,
+        base_dir: &std::path::Path,
+    ) -> Result<Option<String>, ConfigError> {
+        let _ = base_dir;
+        let Some(provider) = self.providers.get(provider_id) else {
+            return Ok(None);
+        };
+        let Some(model_config) = provider.models.get(model) else {
+            return Ok(None);
+        };
+        if let Some(inline) = &model_config.model_instructions {
+            let trimmed = inline.trim();
+            return Ok(if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            });
+        }
+        Ok(None)
+    }
+
     /// Saves config with SecretRef-aware YAML and .env file.
     pub(crate) fn save_config_with_secrets(
         &self,

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -303,14 +303,21 @@ impl Config {
     /// Resolves the model-specific instructions content for a provider+model pair.
     ///
     /// Returns the trimmed inline `model_instructions` content when set.
-    /// Surrounding whitespace is trimmed; empty/whitespace-only content yields `None`.
+    /// When only `model_instructions_file` is set, the referenced file is read
+    /// (relative paths resolve against `base_dir`) and its trimmed contents are
+    /// returned. Surrounding whitespace is trimmed; empty/whitespace-only content
+    /// yields `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::ModelInstructionsFileUnreadable`] when the
+    /// referenced file cannot be read.
     pub(crate) fn resolve_model_instructions(
         &self,
         provider_id: &ProviderId,
         model: &str,
         base_dir: &std::path::Path,
     ) -> Result<Option<String>, ConfigError> {
-        let _ = base_dir;
         let Some(provider) = self.providers.get(provider_id) else {
             return Ok(None);
         };
@@ -319,6 +326,27 @@ impl Config {
         };
         if let Some(inline) = &model_config.model_instructions {
             let trimmed = inline.trim();
+            return Ok(if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            });
+        }
+        if let Some(relative) = &model_config.model_instructions_file {
+            let path = if std::path::Path::new(relative).is_absolute() {
+                std::path::PathBuf::from(relative)
+            } else {
+                base_dir.join(relative)
+            };
+            let content = std::fs::read_to_string(&path).map_err(|e| {
+                ConfigError::ModelInstructionsFileUnreadable {
+                    provider: provider_id.to_string(),
+                    model: model.to_string(),
+                    path: path.to_string_lossy().into_owned(),
+                    detail: e.to_string(),
+                }
+            })?;
+            let trimmed = content.trim();
             return Ok(if trimmed.is_empty() {
                 None
             } else {

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -311,7 +311,8 @@ impl Config {
     /// # Errors
     ///
     /// Returns [`ConfigError::ModelInstructionsFileUnreadable`] when the
-    /// referenced file cannot be read.
+    /// referenced file cannot be read or exceeds
+    /// [`MAX_MODEL_INSTRUCTIONS_FILE_BYTES`].
     pub(crate) fn resolve_model_instructions(
         &self,
         provider_id: &ProviderId,
@@ -332,28 +333,15 @@ impl Config {
                 Some(trimmed.to_string())
             });
         }
-        if let Some(relative) = &model_config.model_instructions_file {
-            let path = if std::path::Path::new(relative).is_absolute() {
-                std::path::PathBuf::from(relative)
-            } else {
-                base_dir.join(relative)
-            };
-            let content = std::fs::read_to_string(&path).map_err(|e| {
-                ConfigError::ModelInstructionsFileUnreadable {
-                    provider: provider_id.to_string(),
-                    model: model.to_string(),
-                    path: path.to_string_lossy().into_owned(),
-                    detail: e.to_string(),
-                }
-            })?;
-            let trimmed = content.trim();
-            return Ok(if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            });
-        }
-        Ok(None)
+        let Some(relative) = &model_config.model_instructions_file else {
+            return Ok(None);
+        };
+        let path = if std::path::Path::new(relative).is_absolute() {
+            std::path::PathBuf::from(relative)
+        } else {
+            base_dir.join(relative)
+        };
+        read_model_instructions_file(provider_id, model, &path)
     }
 
     /// Saves config with SecretRef-aware YAML and .env file.
@@ -506,4 +494,45 @@ pub(super) fn default_compaction_target_ratio() -> f64 {
 
 pub(super) fn default_compact_keep_recent() -> usize {
     20
+}
+
+// 64KB ceiling: `model_instructions_file` is re-read on every turn and every
+// Pulse activation, so an unbounded file would degrade latency and memory.
+// Roughly 16k tokens, ample for any system-prompt-level directive.
+const MAX_MODEL_INSTRUCTIONS_FILE_BYTES: u64 = 64 * 1024;
+
+fn read_model_instructions_file(
+    provider_id: &ProviderId,
+    model: &str,
+    path: &std::path::Path,
+) -> Result<Option<String>, ConfigError> {
+    let file_size = std::fs::metadata(path)
+        .map_err(|e| model_instructions_io_err(provider_id, model, path, e.to_string()))?
+        .len();
+    if file_size > MAX_MODEL_INSTRUCTIONS_FILE_BYTES {
+        return Err(model_instructions_io_err(
+            provider_id,
+            model,
+            path,
+            format!("file too large: {file_size} bytes (max {MAX_MODEL_INSTRUCTIONS_FILE_BYTES})"),
+        ));
+    }
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| model_instructions_io_err(provider_id, model, path, e.to_string()))?;
+    let trimmed = content.trim();
+    Ok((!trimmed.is_empty()).then(|| trimmed.to_string()))
+}
+
+fn model_instructions_io_err(
+    provider_id: &ProviderId,
+    model: &str,
+    path: &std::path::Path,
+    detail: String,
+) -> ConfigError {
+    ConfigError::ModelInstructionsFileUnreadable {
+        provider: provider_id.to_string(),
+        model: model.to_string(),
+        path: path.to_string_lossy().into_owned(),
+        detail,
+    }
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3961,3 +3961,73 @@ channels:
 
     assert_eq!(result.as_deref(), Some("Be concise."));
 }
+
+#[test]
+#[serial]
+fn resolve_model_instructions_reads_file_relative_to_base_dir() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let _home = EnvVarGuard::set("HOME", temp_dir.path());
+    std::fs::write(temp_dir.path().join("instructions.txt"), "Be concise.\n")
+        .expect("write file");
+    let body = r#"default_provider: openai
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+    models:
+      gpt-4o-mini:
+        model_instructions_file: instructions.txt
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret"#;
+    let file_path = write_config(&temp_dir, body);
+    let config = Config::load(Some(&file_path)).expect("load config");
+
+    let result = config
+        .resolve_model_instructions(
+            &super::ProviderId::new("openai"),
+            "gpt-4o-mini",
+            temp_dir.path(),
+        )
+        .expect("resolve");
+
+    assert_eq!(result.as_deref(), Some("Be concise."));
+}
+
+#[test]
+#[serial]
+fn resolve_model_instructions_returns_none_for_blank_content() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let _home = EnvVarGuard::set("HOME", temp_dir.path());
+    std::fs::write(temp_dir.path().join("blank.txt"), "   \n\t\n  ")
+        .expect("write file");
+    let body = r#"default_provider: openai
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+    models:
+      gpt-4o-mini:
+        model_instructions_file: blank.txt
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret"#;
+    let file_path = write_config(&temp_dir, body);
+    let config = Config::load(Some(&file_path)).expect("load config");
+
+    let result = config
+        .resolve_model_instructions(
+            &super::ProviderId::new("openai"),
+            "gpt-4o-mini",
+            temp_dir.path(),
+        )
+        .expect("resolve");
+
+    assert_eq!(result, None);
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4029,3 +4029,46 @@ channels:
 
     assert_eq!(result, None);
 }
+
+#[test]
+#[serial]
+fn resolve_model_instructions_rejects_file_exceeding_size_limit() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let _home = EnvVarGuard::set("HOME", temp_dir.path());
+    let oversized = "a".repeat(64 * 1024 + 1);
+    std::fs::write(temp_dir.path().join("oversize.txt"), &oversized).expect("write file");
+    let body = r#"default_provider: openai
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+    models:
+      gpt-4o-mini:
+        model_instructions_file: oversize.txt
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret"#;
+    let file_path = write_config(&temp_dir, body);
+    let config = Config::load(Some(&file_path)).expect("load config");
+
+    let error = config
+        .resolve_model_instructions(
+            &super::ProviderId::new("openai"),
+            "gpt-4o-mini",
+            temp_dir.path(),
+        )
+        .expect_err("should fail");
+
+    match error {
+        ConfigError::ModelInstructionsFileUnreadable { detail, .. } => {
+            assert!(
+                detail.contains("file too large"),
+                "expected size-limit detail, got: {detail}"
+            );
+        }
+        _ => panic!("expected ModelInstructionsFileUnreadable, got {error:?}"),
+    }
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3967,8 +3967,7 @@ channels:
 fn resolve_model_instructions_reads_file_relative_to_base_dir() {
     let temp_dir = tempfile::tempdir().expect("tempdir");
     let _home = EnvVarGuard::set("HOME", temp_dir.path());
-    std::fs::write(temp_dir.path().join("instructions.txt"), "Be concise.\n")
-        .expect("write file");
+    std::fs::write(temp_dir.path().join("instructions.txt"), "Be concise.\n").expect("write file");
     let body = r#"default_provider: openai
 providers:
   openai:
@@ -4002,8 +4001,7 @@ channels:
 fn resolve_model_instructions_returns_none_for_blank_content() {
     let temp_dir = tempfile::tempdir().expect("tempdir");
     let _home = EnvVarGuard::set("HOME", temp_dir.path());
-    std::fs::write(temp_dir.path().join("blank.txt"), "   \n\t\n  ")
-        .expect("write file");
+    std::fs::write(temp_dir.path().join("blank.txt"), "   \n\t\n  ").expect("write file");
     let body = r#"default_provider: openai
 providers:
   openai:

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3928,3 +3928,36 @@ channels:
         _ => panic!("expected ModelInstructionsConflict, got {error:?}"),
     }
 }
+
+#[test]
+#[serial]
+fn resolve_model_instructions_returns_inline() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let _home = EnvVarGuard::set("HOME", temp_dir.path());
+    let body = r#"default_provider: openai
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+    models:
+      gpt-4o-mini:
+        model_instructions: "  Be concise.  "
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret"#;
+    let file_path = write_config(&temp_dir, body);
+    let config = Config::load(Some(&file_path)).expect("load config");
+
+    let result = config
+        .resolve_model_instructions(
+            &super::ProviderId::new("openai"),
+            "gpt-4o-mini",
+            temp_dir.path(),
+        )
+        .expect("resolve");
+
+    assert_eq!(result.as_deref(), Some("Be concise."));
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2370,6 +2370,7 @@ fn persists_provider_model_contexts_without_secret_leak() {
                         "gpt-5".to_string(),
                         ModelConfig {
                             context_window_tokens: Some(200000),
+                            ..Default::default()
                         },
                     ),
                     ("gpt-4o-mini".to_string(), ModelConfig::default()),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3894,3 +3894,37 @@ fn validate_agent_profile_provider_references() {
         "expected InvalidProviderReference, got {error:?}"
     );
 }
+
+#[test]
+#[serial]
+fn model_instructions_conflict_when_both_specified() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let _home = EnvVarGuard::set("HOME", temp_dir.path());
+    let body = r#"default_provider: openai
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+    models:
+      gpt-4o-mini:
+        model_instructions: |
+          Be concise.
+        model_instructions_file: instructions.txt
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret"#;
+    let file_path = write_config(&temp_dir, body);
+
+    let error = Config::load(Some(&file_path)).expect_err("conflict should fail");
+
+    match error {
+        ConfigError::ModelInstructionsConflict { provider, model } => {
+            assert_eq!(provider, "openai");
+            assert_eq!(model, "gpt-4o-mini");
+        }
+        _ => panic!("expected ModelInstructionsConflict, got {error:?}"),
+    }
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -177,6 +177,12 @@ pub(crate) struct ModelConfig {
     /// When `None`, falls back to `Config.default_context_window_tokens`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_window_tokens: Option<usize>,
+
+    /// Optional inline model-specific instructions injected into the system
+    /// prompt between SOUL and Core Instructions (wrapped in
+    /// `<model-instructions>`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_instructions: Option<String>,
 }
 
 #[derive(Clone)]
@@ -506,5 +512,22 @@ mod tests {
     #[test]
     fn parse_duration_rejects_bare_number() {
         assert!(parse_duration("60").is_err());
+    }
+
+    #[test]
+    fn model_config_deserializes_inline_instructions() {
+        let yaml = "context_window_tokens: 200000
+model_instructions: |
+  Be concise.
+  Avoid preamble.
+";
+
+        let config: ModelConfig = yaml_serde::from_str(yaml).expect("deserialize ModelConfig");
+
+        assert_eq!(config.context_window_tokens, Some(200000));
+        assert_eq!(
+            config.model_instructions.as_deref(),
+            Some("Be concise.\nAvoid preamble.\n")
+        );
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -183,6 +183,12 @@ pub(crate) struct ModelConfig {
     /// `<model-instructions>`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_instructions: Option<String>,
+
+    /// Optional path to a file whose contents are used as model-specific
+    /// instructions. Relative paths resolve against the config file directory.
+    /// Mutually exclusive with [`ModelConfig::model_instructions`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_instructions_file: Option<String>,
 }
 
 #[derive(Clone)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -235,6 +235,10 @@ pub enum ConfigError {
     PulseInvalidTickInterval { reason: String },
     #[error("invalid_timezone: {timezone}")]
     InvalidTimezone { timezone: String },
+    #[error(
+        "model_instructions_conflict: provider={provider} model={model}: specify either 'model_instructions' or 'model_instructions_file', not both"
+    )]
+    ModelInstructionsConflict { provider: String, model: String },
 }
 
 /// TUI (Terminal User Interface) rendering and event errors.

--- a/src/error.rs
+++ b/src/error.rs
@@ -239,6 +239,15 @@ pub enum ConfigError {
         "model_instructions_conflict: provider={provider} model={model}: specify either 'model_instructions' or 'model_instructions_file', not both"
     )]
     ModelInstructionsConflict { provider: String, model: String },
+    #[error(
+        "model_instructions_file_unreadable: provider={provider} model={model} path={path}: {detail}"
+    )]
+    ModelInstructionsFileUnreadable {
+        provider: String,
+        model: String,
+        path: String,
+        detail: String,
+    },
 }
 
 /// TUI (Terminal User Interface) rendering and event errors.


### PR DESCRIPTION
## 概要

`providers.<id>.models.<model>` 配下に `model_instructions`(インライン)と `model_instructions_file`(ファイルPATH)を追加し、設定した内容を `<model-instructions>` タグでラップして system prompt の SOUL と Core Instructions の間に注入する機能を追加する。

### 主な変更

- **設定**: `ModelConfig` に `model_instructions` / `model_instructions_file` を追加。両立は起動エラー(排他)。
- **resolve**: `Config::resolve_model_instructions(provider_id, model, base_dir)` を新設。インライン優先、ファイルは `base_dir`(設定ファイルのディレクトリ)基点で相対解決。空文字/空白のみは `None`。
- **プロンプト注入**: `build_model_instructions_section` を新設し、`build_system_prompt` で `<soul>` の直後・Core Instructions の直前に注入。内部で `resolve_llm_for_agent_channel` を呼ぶことで、通常 turn と Pulse Activation のどちらの呼び出し順でも自動適用される。
- **適用範囲**: 通常 turn ○、Pulse 活性化 ○(自動)。Compaction・Sleep Batch は専用プロンプトのため対象外。
- **フォールバック**: 参照先ファイルが実行時に読めない場合は warn ログ + `None` でプロンプト構築を継続。
- **セキュリティ**: Core Instructions の既存宣言(セキュリティルールは上書き不可)により、model_instructions が Core の前に注入されてもセキュリティルールは最終優先される。

## 設計判断

| 論点 | 判断 |
|---|---|
| インライン/PATH 両立(Q1) | 起動エラー(排他) |
| 相対パス基点(Q2) | 設定ファイルのディレクトリ |
| 読み込みタイミング(Q3) | 毎ターン |
| Sleep Batch(Q4) | 対象外(専用プロンプトのため) |
| ラップタグ(Q5) | `<model-instructions>` |
| provider_instructions(Q6) | 作らない(YAGNI) |

詳細は [Plan](docs/plan/plan-model-instructions.md) 参照。

## テスト

自動テスト8件(`cargo test` すべて通過):

| ID | テスト名 |
|---|---|
| T1 | `model_config_deserializes_inline_instructions` |
| T2 | `model_instructions_conflict_when_both_specified` |
| T3 | `resolve_model_instructions_returns_inline` |
| T4 | `resolve_model_instructions_reads_file_relative_to_base_dir` |
| T5 | `resolve_model_instructions_returns_none_for_blank_content` |
| T6 | `system_prompt_injects_model_instructions_between_soul_and_core` |
| T7 | `system_prompt_without_model_instructions_is_unchanged` |
| T8 | `build_model_instructions_section_returns_none_on_io_error` |

品質ゲート(`Step 8`): `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` すべて通過。

## 補足

ベースブランチ作成後に `Pulse Stuck Running Recovery`(PR #106)が取り込まれたため、本ブランチは最新 origin/main に rebase 済み。差分は Plan の変更ファイル一覧(8ファイル)に一致する。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for model-specific instructions that can be configured per model. Instructions can be provided inline or via external files and are automatically injected into the system prompt between the soul section and core instructions.

* **Documentation**
  * Updated configuration and system prompt documentation to explain the new model-specific instructions feature and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->