### PR TITLE
LLM送信用型と保存用会話型を分離

### DIFF
--- a/src/agent_loop/formatting.rs
+++ b/src/agent_loop/formatting.rs
@@ -68,8 +68,7 @@ pub(crate) fn tool_message_content(
                 text: payload.to_string(),
             });
             content.extend(parts.iter().filter_map(|part| match part {
-                crate::llm::MessageContentPart::InputText { .. }
-                | crate::llm::MessageContentPart::InputImageRef { .. } => None,
+                crate::llm::MessageContentPart::InputText { .. } => None,
                 crate::llm::MessageContentPart::InputImage { image_url, detail } => {
                     Some(crate::llm::MessageContentPart::InputImage {
                         image_url: image_url.clone(),
@@ -230,7 +229,6 @@ fn format_message_part(
                 (true, None) => format!("[image: {image_url}]"),
             })
         }
-        MessageContentPart::InputImageRef { .. } => Some("[image]".to_string()),
     }
 }
 
@@ -247,8 +245,7 @@ pub(crate) fn tool_result_payload(message: &Message) -> Option<&str> {
         crate::llm::MessageContent::Text(text) => Some(text.as_str()),
         crate::llm::MessageContent::Parts(parts) => parts.iter().find_map(|part| match part {
             crate::llm::MessageContentPart::InputText { text } => Some(text.as_str()),
-            crate::llm::MessageContentPart::InputImage { .. }
-            | crate::llm::MessageContentPart::InputImageRef { .. } => None,
+            crate::llm::MessageContentPart::InputImage { .. } => None,
         }),
     }
 }

--- a/src/agent_loop/mod.rs
+++ b/src/agent_loop/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod formatting;
 pub(crate) mod guards;
 pub(crate) mod prompt_builder;
 pub(crate) mod session;
+pub(crate) mod session_snapshot;
 pub(crate) mod soul_agents;
 pub(crate) mod tool_phase;
 pub(crate) mod turn;

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -5,10 +5,13 @@
 
 use std::sync::Arc;
 
+use crate::agent_loop::session_snapshot::{
+    SnapshotMessage, messages_from_snapshot, messages_to_snapshot,
+};
 use crate::agent_loop::{ConversationScope, SurfaceContext};
 use crate::assets::AssetStore;
 use crate::error::{EgoPulseError, StorageError};
-use crate::llm::{Message, MessageContent, MessageContentPart};
+use crate::llm::{Message, MessageContent};
 use crate::runtime::AppState;
 use crate::storage::{SenderKind, SessionSnapshot, SessionSummary, StoredMessage, call_blocking};
 
@@ -284,7 +287,7 @@ async fn serialize_snapshot(
     messages: Vec<Message>,
 ) -> Result<String, EgoPulseError> {
     tokio::task::spawn_blocking(move || {
-        let persisted = persist_messages(&assets, &messages)?;
+        let persisted = messages_to_snapshot(&assets, &messages)?;
         serde_json::to_string(&persisted).map_err(StorageError::SessionSerialize)
     })
     .await
@@ -292,141 +295,15 @@ async fn serialize_snapshot(
     .map_err(EgoPulseError::Storage)
 }
 
-/// Convert `InputImage` parts to `InputImageRef` for disk serialization.
-fn persist_messages(
-    assets: &AssetStore,
-    messages: &[Message],
-) -> Result<Vec<Message>, StorageError> {
-    messages
-        .iter()
-        .map(|message| {
-            Ok(Message {
-                role: message.role.clone(),
-                content: persist_content(assets, &message.content)?,
-                reasoning_content: message.reasoning_content.clone(),
-                tool_calls: message.tool_calls.clone(),
-                tool_call_id: message.tool_call_id.clone(),
-            })
-        })
-        .collect()
-}
-
-fn persist_content(
-    assets: &AssetStore,
-    content: &MessageContent,
-) -> Result<MessageContent, StorageError> {
-    match content {
-        MessageContent::Text(text) => Ok(MessageContent::Text(text.clone())),
-        MessageContent::Parts(parts) => Ok(MessageContent::Parts(
-            parts
-                .iter()
-                .map(|part| persist_part(assets, part))
-                .collect::<Result<Vec<_>, _>>()?,
-        )),
-    }
-}
-
-fn persist_part(
-    assets: &AssetStore,
-    part: &MessageContentPart,
-) -> Result<MessageContentPart, StorageError> {
-    match part {
-        MessageContentPart::InputText { text } => {
-            Ok(MessageContentPart::InputText { text: text.clone() })
-        }
-        MessageContentPart::InputImage { image_url, detail } => {
-            let stored = assets.persist_image_data_url(image_url)?;
-            Ok(MessageContentPart::InputImageRef {
-                image_ref: stored.image_ref,
-                mime_type: stored.mime_type,
-                detail: detail.clone(),
-            })
-        }
-        MessageContentPart::InputImageRef { .. } => Ok(part.clone()),
-    }
-}
-
-/// Deserialize snapshot JSON as `Vec<Message>` and hydrate `InputImageRef` → `InputImage`.
-///
-/// For text-only sessions (the common case), the JSON string is scanned for
-/// `"input_image_ref"` before any per-message work. When absent the hydration
-/// pass is skipped entirely, eliminating the second iteration.
+/// Deserialize snapshot JSON and hydrate image references for LLM input.
 fn restore_snapshot_messages(
     assets: &AssetStore,
     json: &str,
 ) -> Result<Vec<Message>, StorageError> {
-    let messages: Vec<Message> =
+    let messages: Vec<SnapshotMessage> =
         serde_json::from_str(json).map_err(StorageError::SessionSerialize)?;
 
-    // Fast path: no image references in the serialized form → nothing to hydrate.
-    if !json.contains("\"input_image_ref\"") {
-        return Ok(messages);
-    }
-
-    // Selective hydration: only transform messages that actually contain refs.
-    Ok(messages
-        .into_iter()
-        .map(|message| {
-            if message_contains_image_ref(&message) {
-                hydrate_message(assets, message)
-            } else {
-                message
-            }
-        })
-        .collect())
-}
-
-fn message_contains_image_ref(message: &Message) -> bool {
-    match &message.content {
-        MessageContent::Text(_) => false,
-        MessageContent::Parts(parts) => parts
-            .iter()
-            .any(|part| matches!(part, MessageContentPart::InputImageRef { .. })),
-    }
-}
-
-fn hydrate_message(assets: &AssetStore, message: Message) -> Message {
-    Message {
-        content: hydrate_content(assets, message.content),
-        ..message
-    }
-}
-
-fn hydrate_content(assets: &AssetStore, content: MessageContent) -> MessageContent {
-    match content {
-        MessageContent::Text(text) => MessageContent::Text(text),
-        MessageContent::Parts(parts) => MessageContent::Parts(
-            parts
-                .into_iter()
-                .map(|part| hydrate_part(assets, part))
-                .collect(),
-        ),
-    }
-}
-
-fn hydrate_part(assets: &AssetStore, part: MessageContentPart) -> MessageContentPart {
-    match part {
-        MessageContentPart::InputText { text } => MessageContentPart::InputText { text },
-        MessageContentPart::InputImage { .. } => part,
-        MessageContentPart::InputImageRef {
-            image_ref,
-            mime_type,
-            detail,
-        } => assets
-            .load_image_data_url(&image_ref, &mime_type)
-            .map(|image_url| MessageContentPart::InputImage { image_url, detail })
-            .unwrap_or_else(|error| missing_image_text_part(&image_ref, error)),
-    }
-}
-
-fn missing_image_text_part(image_ref: &str, error: StorageError) -> MessageContentPart {
-    let reason = match error {
-        StorageError::NotFound(_) => format!("missing image_ref {image_ref}"),
-        other => other.to_string(),
-    };
-    MessageContentPart::InputText {
-        text: format!("Previously attached image could not be restored: {reason}"),
-    }
+    Ok(messages_from_snapshot(assets, messages))
 }
 
 async fn store_phase_snapshot(
@@ -460,7 +337,6 @@ mod tests {
 
     use super::{load_messages_for_turn, persist_phase};
     use crate::agent_loop::{ConversationScope, SurfaceContext};
-    use crate::assets::AssetStore;
     use crate::config::Config;
     use crate::error::LlmError;
     use crate::llm::{
@@ -721,7 +597,7 @@ mod tests {
         call_blocking(Arc::clone(&state.db), move |db| {
             db.save_session(
                 chat_id,
-                r#"[{"role":"tool","content":[{"type":"input_text","text":"Read image file [image/png]"},{"type":"input_image_ref","image_ref":"missing-ref","mime_type":"image/png","detail":"auto"}],"tool_call_id":"call_1"}]"#,
+                r#"[{"role":"tool","content":[{"type":"input_text","text":"Read image file [image/png]"},{"type":"input_image_ref","image_ref":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mime_type":"image/png","detail":"auto"}],"tool_call_id":"call_1"}]"#,
             )
         })
         .await
@@ -735,7 +611,7 @@ mod tests {
                 assert!(matches!(
                     parts[1],
                     MessageContentPart::InputText { ref text }
-                    if text.contains("missing image_ref missing-ref")
+                    if text.contains("missing image_ref aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                 ));
             }
             other => panic!("expected restored parts, got {other:?}"),
@@ -1219,165 +1095,6 @@ mod tests {
         assert_eq!(loaded.messages[0].content.as_text_lossy(), "hello");
         assert_eq!(loaded.messages[1].role, "assistant");
         assert_eq!(loaded.messages[1].content.as_text_lossy(), "response");
-    }
-
-    // -- Restore snapshot hydration optimization tests -------------------------
-
-    #[test]
-    fn text_only_snapshot_skips_hydration() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let assets = AssetStore::new(dir.path()).expect("store");
-        let json = serde_json::to_string(&vec![
-            Message::text("user", "hello"),
-            Message::text("assistant", "world"),
-        ])
-        .expect("json");
-
-        let messages = super::restore_snapshot_messages(&assets, &json).expect("restore");
-        assert_eq!(messages.len(), 2);
-        assert_eq!(messages[0].role, "user");
-        assert_eq!(messages[0].content.as_text_lossy(), "hello");
-        assert_eq!(messages[1].role, "assistant");
-        assert_eq!(messages[1].content.as_text_lossy(), "world");
-    }
-
-    #[test]
-    fn image_snapshot_hydrates_refs() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let assets = AssetStore::new(dir.path()).expect("store");
-        let data_url = "data:image/png;base64,AAAA";
-        let stored = assets.persist_image_data_url(data_url).expect("persist");
-
-        let snapshot = vec![Message {
-            role: "tool".to_string(),
-            content: MessageContent::parts(vec![
-                MessageContentPart::InputText {
-                    text: "screenshot".to_string(),
-                },
-                MessageContentPart::InputImageRef {
-                    image_ref: stored.image_ref.clone(),
-                    mime_type: stored.mime_type.clone(),
-                    detail: Some("auto".to_string()),
-                },
-            ]),
-            reasoning_content: None,
-            tool_calls: Vec::new(),
-            tool_call_id: Some("call_1".to_string()),
-        }];
-        let json = serde_json::to_string(&snapshot).expect("json");
-
-        let messages = super::restore_snapshot_messages(&assets, &json).expect("restore");
-        assert_eq!(messages.len(), 1);
-        match &messages[0].content {
-            MessageContent::Parts(parts) => {
-                assert!(matches!(
-                    &parts[1],
-                    MessageContentPart::InputImage { image_url, detail }
-                    if image_url == data_url && detail.as_deref() == Some("auto")
-                ));
-            }
-            other => panic!("expected parts, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn identical_output_to_two_pass() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let assets = AssetStore::new(dir.path()).expect("store");
-        let data_url = "data:image/png;base64,iVBORw==";
-        let stored = assets.persist_image_data_url(data_url).expect("persist");
-
-        let snapshot = vec![
-            Message::text("user", "look at this"),
-            Message {
-                role: "tool".to_string(),
-                content: MessageContent::parts(vec![
-                    MessageContentPart::InputText {
-                        text: "file read".to_string(),
-                    },
-                    MessageContentPart::InputImageRef {
-                        image_ref: stored.image_ref.clone(),
-                        mime_type: stored.mime_type.clone(),
-                        detail: None,
-                    },
-                ]),
-                reasoning_content: None,
-                tool_calls: Vec::new(),
-                tool_call_id: Some("call_img".to_string()),
-            },
-            Message::text("assistant", "I see the image"),
-        ];
-        let json = serde_json::to_string(&snapshot).expect("json");
-
-        let single_pass = super::restore_snapshot_messages(&assets, &json).expect("single");
-
-        // Simulate old two-pass: deserialize then hydrate every message unconditionally.
-        let raw: Vec<Message> = serde_json::from_str(&json).expect("deserialize");
-        let two_pass: Vec<Message> = raw
-            .into_iter()
-            .map(|message| {
-                let content = match message.content {
-                    MessageContent::Text(text) => MessageContent::Text(text),
-                    MessageContent::Parts(parts) => MessageContent::Parts(
-                        parts
-                            .into_iter()
-                            .map(|part| match part {
-                                MessageContentPart::InputText { text } => {
-                                    MessageContentPart::InputText { text }
-                                }
-                                MessageContentPart::InputImage { image_url, detail } => {
-                                    MessageContentPart::InputImage { image_url, detail }
-                                }
-                                MessageContentPart::InputImageRef {
-                                    image_ref,
-                                    mime_type,
-                                    detail,
-                                } => assets
-                                    .load_image_data_url(&image_ref, &mime_type)
-                                    .map(|image_url| MessageContentPart::InputImage {
-                                        image_url,
-                                        detail,
-                                    })
-                                    .unwrap_or_else(|error| {
-                                        MessageContentPart::InputText {
-                                            text: format!(
-                                                "Previously attached image could not be restored: {error}"
-                                            ),
-                                        }
-                                    }),
-                            })
-                            .collect(),
-                    ),
-                };
-                Message {
-                    content,
-                    ..message
-                }
-            })
-            .collect();
-
-        assert_eq!(single_pass, two_pass);
-    }
-
-    #[test]
-    fn large_session_load_performance() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let assets = AssetStore::new(dir.path()).expect("store");
-        let messages: Vec<Message> = (0..1000)
-            .map(|index| {
-                Message::text(
-                    if index % 2 == 0 { "user" } else { "assistant" },
-                    format!("message-{index}"),
-                )
-            })
-            .collect();
-        let json = serde_json::to_string(&messages).expect("json");
-
-        let start = std::time::Instant::now();
-        let restored = super::restore_snapshot_messages(&assets, &json).expect("restore");
-        let _elapsed = start.elapsed();
-
-        assert_eq!(restored.len(), 1000);
     }
 
     /// Verifies that `persist_phase` borrows `&[Message]` for serialization,

--- a/src/agent_loop/session_snapshot.rs
+++ b/src/agent_loop/session_snapshot.rs
@@ -1,0 +1,394 @@
+//! Persisted session snapshot types.
+//!
+//! LLM request messages are hydrated runtime values. Session snapshots are a
+//! separate disk format that can point at images stored in the asset store.
+
+use serde::{Deserialize, Serialize};
+
+use crate::assets::AssetStore;
+use crate::error::StorageError;
+use crate::llm::{Message, MessageContent, MessageContentPart, ToolCall};
+
+/// A message in the persisted session snapshot format.
+///
+/// This mirrors the fields needed to resume a conversation while keeping
+/// storage-only content, such as asset references, out of LLM request types.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SnapshotMessage {
+    /// Role name preserved from the LLM message stream.
+    pub(crate) role: String,
+    /// Stored content for the message.
+    pub(crate) content: SnapshotContent,
+    /// Provider-specific reasoning text preserved across turns when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reasoning_content: Option<String>,
+    /// Tool calls requested by this message.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) tool_calls: Vec<ToolCall>,
+    /// Tool call ID this message responds to when the role is `tool`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) tool_call_id: Option<String>,
+}
+
+/// Stored message content in a session snapshot.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub(crate) enum SnapshotContent {
+    /// Plain text content.
+    Text(String),
+    /// Multimodal content parts.
+    Parts(Vec<SnapshotContentPart>),
+}
+
+/// One stored multimodal content part in a session snapshot.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub(crate) enum SnapshotContentPart {
+    /// Text content included inline in the snapshot.
+    #[serde(rename = "input_text")]
+    Text { text: String },
+    /// Hydrated image content, accepted for snapshot imports and tests.
+    #[serde(rename = "input_image")]
+    Image {
+        image_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+    /// Asset-store image reference used by normal persisted snapshots.
+    #[serde(rename = "input_image_ref")]
+    ImageRef {
+        image_ref: String,
+        mime_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+}
+
+/// Converts hydrated LLM messages into persisted session snapshot messages.
+///
+/// Image data URLs are stored in the asset store and replaced with
+/// `SnapshotContentPart::ImageRef`.
+///
+/// # Errors
+///
+/// Returns `StorageError` when an image data URL cannot be persisted in the
+/// asset store.
+pub(crate) fn messages_to_snapshot(
+    assets: &AssetStore,
+    messages: &[Message],
+) -> Result<Vec<SnapshotMessage>, StorageError> {
+    messages
+        .iter()
+        .map(|message| message_to_snapshot(assets, message))
+        .collect()
+}
+
+/// Converts persisted session snapshot messages into hydrated LLM messages.
+///
+/// Valid image references are loaded from the asset store. Missing or malformed
+/// references become explicit text notes so the LLM sees why an image is absent.
+pub(crate) fn messages_from_snapshot(
+    assets: &AssetStore,
+    messages: Vec<SnapshotMessage>,
+) -> Vec<Message> {
+    messages
+        .into_iter()
+        .map(|message| message_from_snapshot(assets, message))
+        .collect()
+}
+
+fn message_to_snapshot(
+    assets: &AssetStore,
+    message: &Message,
+) -> Result<SnapshotMessage, StorageError> {
+    Ok(SnapshotMessage {
+        role: message.role.clone(),
+        content: content_to_snapshot(assets, &message.content)?,
+        reasoning_content: message.reasoning_content.clone(),
+        tool_calls: message.tool_calls.clone(),
+        tool_call_id: message.tool_call_id.clone(),
+    })
+}
+
+fn content_to_snapshot(
+    assets: &AssetStore,
+    content: &MessageContent,
+) -> Result<SnapshotContent, StorageError> {
+    match content {
+        MessageContent::Text(text) => Ok(SnapshotContent::Text(text.clone())),
+        MessageContent::Parts(parts) => Ok(SnapshotContent::Parts(
+            parts
+                .iter()
+                .map(|part| part_to_snapshot(assets, part))
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+    }
+}
+
+fn part_to_snapshot(
+    assets: &AssetStore,
+    part: &MessageContentPart,
+) -> Result<SnapshotContentPart, StorageError> {
+    match part {
+        MessageContentPart::InputText { text } => {
+            Ok(SnapshotContentPart::Text { text: text.clone() })
+        }
+        MessageContentPart::InputImage { image_url, detail } => {
+            let stored = assets.persist_image_data_url(image_url)?;
+            Ok(SnapshotContentPart::ImageRef {
+                image_ref: stored.image_ref,
+                mime_type: stored.mime_type,
+                detail: detail.clone(),
+            })
+        }
+    }
+}
+
+fn message_from_snapshot(assets: &AssetStore, message: SnapshotMessage) -> Message {
+    Message {
+        role: message.role,
+        content: content_from_snapshot(assets, message.content),
+        reasoning_content: message.reasoning_content,
+        tool_calls: message.tool_calls,
+        tool_call_id: message.tool_call_id,
+    }
+}
+
+fn content_from_snapshot(assets: &AssetStore, content: SnapshotContent) -> MessageContent {
+    match content {
+        SnapshotContent::Text(text) => MessageContent::Text(text),
+        SnapshotContent::Parts(parts) => MessageContent::Parts(
+            parts
+                .into_iter()
+                .map(|part| part_from_snapshot(assets, part))
+                .collect(),
+        ),
+    }
+}
+
+fn part_from_snapshot(assets: &AssetStore, part: SnapshotContentPart) -> MessageContentPart {
+    match part {
+        SnapshotContentPart::Text { text } => MessageContentPart::InputText { text },
+        SnapshotContentPart::Image { image_url, detail } => {
+            MessageContentPart::InputImage { image_url, detail }
+        }
+        SnapshotContentPart::ImageRef {
+            image_ref,
+            mime_type,
+            detail,
+        } => {
+            if !is_sha256_hex(&image_ref) {
+                return missing_image_text_part(
+                    &image_ref,
+                    StorageError::InvalidAsset(format!("malformed image_ref {image_ref}")),
+                );
+            }
+            assets
+                .load_image_data_url(&image_ref, &mime_type)
+                .map(|image_url| MessageContentPart::InputImage { image_url, detail })
+                .unwrap_or_else(|error| missing_image_text_part(&image_ref, error))
+        }
+    }
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn missing_image_text_part(image_ref: &str, error: StorageError) -> MessageContentPart {
+    let reason = match error {
+        StorageError::NotFound(_) => format!("missing image_ref {image_ref}"),
+        other => other.to_string(),
+    };
+    MessageContentPart::InputText {
+        text: format!("Previously attached image could not be restored: {reason}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SnapshotContent, SnapshotContentPart, SnapshotMessage, messages_from_snapshot};
+    use crate::assets::AssetStore;
+    use crate::llm::{MessageContent, MessageContentPart};
+
+    #[test]
+    fn text_only_snapshot_restores_to_llm_messages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let assets = AssetStore::new(dir.path()).expect("store");
+        let snapshot = vec![
+            SnapshotMessage {
+                role: "user".to_string(),
+                content: SnapshotContent::Text("hello".to_string()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            },
+            SnapshotMessage {
+                role: "assistant".to_string(),
+                content: SnapshotContent::Text("world".to_string()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            },
+        ];
+
+        let messages = messages_from_snapshot(&assets, snapshot);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content.as_text_lossy(), "hello");
+        assert_eq!(messages[1].role, "assistant");
+        assert_eq!(messages[1].content.as_text_lossy(), "world");
+    }
+
+    #[test]
+    fn image_snapshot_hydrates_refs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let assets = AssetStore::new(dir.path()).expect("store");
+        let data_url = "data:image/png;base64,AAAA";
+        let stored = assets.persist_image_data_url(data_url).expect("persist");
+
+        let snapshot = vec![SnapshotMessage {
+            role: "tool".to_string(),
+            content: SnapshotContent::Parts(vec![
+                SnapshotContentPart::Text {
+                    text: "screenshot".to_string(),
+                },
+                SnapshotContentPart::ImageRef {
+                    image_ref: stored.image_ref.clone(),
+                    mime_type: stored.mime_type.clone(),
+                    detail: Some("auto".to_string()),
+                },
+            ]),
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            tool_call_id: Some("call_1".to_string()),
+        }];
+
+        let messages = messages_from_snapshot(&assets, snapshot);
+
+        assert_eq!(messages.len(), 1);
+        match &messages[0].content {
+            MessageContent::Parts(parts) => {
+                assert!(matches!(
+                    &parts[1],
+                    MessageContentPart::InputImage { image_url, detail }
+                    if image_url == data_url && detail.as_deref() == Some("auto")
+                ));
+            }
+            other => panic!("expected parts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_snapshot_restores_to_llm_messages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let assets = AssetStore::new(dir.path()).expect("store");
+        let data_url = "data:image/png;base64,iVBORw==";
+        let stored = assets.persist_image_data_url(data_url).expect("persist");
+
+        let snapshot = vec![
+            SnapshotMessage {
+                role: "user".to_string(),
+                content: SnapshotContent::Text("look at this".to_string()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            },
+            SnapshotMessage {
+                role: "tool".to_string(),
+                content: SnapshotContent::Parts(vec![
+                    SnapshotContentPart::Text {
+                        text: "file read".to_string(),
+                    },
+                    SnapshotContentPart::ImageRef {
+                        image_ref: stored.image_ref.clone(),
+                        mime_type: stored.mime_type.clone(),
+                        detail: None,
+                    },
+                ]),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                tool_call_id: Some("call_img".to_string()),
+            },
+            SnapshotMessage {
+                role: "assistant".to_string(),
+                content: SnapshotContent::Text("I see the image".to_string()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            },
+        ];
+
+        let restored = messages_from_snapshot(&assets, snapshot);
+
+        assert_eq!(restored.len(), 3);
+        assert_eq!(restored[0].role, "user");
+        assert_eq!(restored[0].content.as_text_lossy(), "look at this");
+        assert_eq!(restored[1].role, "tool");
+        assert_eq!(restored[1].tool_call_id.as_deref(), Some("call_img"));
+        match &restored[1].content {
+            MessageContent::Parts(parts) => {
+                assert!(matches!(
+                    &parts[1],
+                    MessageContentPart::InputImage { image_url, detail }
+                    if image_url == data_url && detail.is_none()
+                ));
+            }
+            other => panic!("expected hydrated tool parts, got {other:?}"),
+        }
+        assert_eq!(restored[2].role, "assistant");
+        assert_eq!(restored[2].content.as_text_lossy(), "I see the image");
+    }
+
+    #[test]
+    fn malformed_image_ref_restores_to_text_note() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let assets = AssetStore::new(dir.path()).expect("store");
+        let snapshot = vec![SnapshotMessage {
+            role: "tool".to_string(),
+            content: SnapshotContent::Parts(vec![SnapshotContentPart::ImageRef {
+                image_ref: "../not-a-sha".to_string(),
+                mime_type: "image/png".to_string(),
+                detail: None,
+            }]),
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            tool_call_id: Some("call_bad_ref".to_string()),
+        }];
+
+        let restored = messages_from_snapshot(&assets, snapshot);
+
+        assert_eq!(restored[0].role, "tool");
+        assert_eq!(restored[0].tool_call_id.as_deref(), Some("call_bad_ref"));
+        match &restored[0].content {
+            MessageContent::Parts(parts) => {
+                assert!(matches!(
+                    &parts[0],
+                    MessageContentPart::InputText { text }
+                    if text.contains("malformed image_ref ../not-a-sha")
+                ));
+            }
+            other => panic!("expected restored parts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn large_snapshot_restores_all_messages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let assets = AssetStore::new(dir.path()).expect("store");
+        let messages: Vec<SnapshotMessage> = (0..1000)
+            .map(|index| SnapshotMessage {
+                role: if index % 2 == 0 { "user" } else { "assistant" }.to_string(),
+                content: SnapshotContent::Text(format!("message-{index}")),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            })
+            .collect();
+
+        let restored = messages_from_snapshot(&assets, messages);
+
+        assert_eq!(restored.len(), 1000);
+    }
+}

--- a/src/llm/messages.rs
+++ b/src/llm/messages.rs
@@ -224,7 +224,7 @@ pub(crate) fn synthetic_tool_attachment_parts(content: &MessageContent) -> Vec<s
     })];
     if let MessageContent::Parts(items) = content {
         parts.extend(items.iter().filter_map(|part| match part {
-            MessageContentPart::InputText { .. } | MessageContentPart::InputImageRef { .. } => None,
+            MessageContentPart::InputText { .. } => None,
             MessageContentPart::InputImage { image_url, detail } => Some(serde_json::json!({
                 "type": "input_image",
                 "image_url": image_url,
@@ -295,10 +295,6 @@ fn chat_content_part(part: &MessageContentPart) -> serde_json::Value {
                 "detail": default_detail(detail),
             }
         }),
-        MessageContentPart::InputImageRef { .. } => serde_json::json!({
-            "type": "text",
-            "text": "[image reference - not hydrated]",
-        }),
     }
 }
 
@@ -312,10 +308,6 @@ fn responses_content_part(part: &MessageContentPart) -> serde_json::Value {
             "type": "input_image",
             "image_url": image_url,
             "detail": default_detail(detail),
-        }),
-        MessageContentPart::InputImageRef { .. } => serde_json::json!({
-            "type": "input_text",
-            "text": "[image reference - not hydrated]",
         }),
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -74,19 +74,6 @@ pub(crate) enum MessageContentPart {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         detail: Option<String>,
     },
-    /// Asset-store reference used in session persistence.
-    ///
-    /// When a session snapshot is serialized to disk, `InputImage` parts are
-    /// converted to `InputImageRef` so the actual image bytes are stored in
-    /// the content-addressable asset store rather than inline as data URLs.
-    /// On restore, `InputImageRef` parts are hydrated back to `InputImage`.
-    #[serde(rename = "input_image_ref")]
-    InputImageRef {
-        image_ref: String,
-        mime_type: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        detail: Option<String>,
-    },
 }
 
 impl Default for MessageContent {
@@ -108,7 +95,7 @@ impl MessageContent {
 
     /// Returns `true` if the content includes at least one image part.
     pub(crate) fn is_multimodal(&self) -> bool {
-        matches!(self, Self::Parts(parts) if parts.iter().any(|part| matches!(part, MessageContentPart::InputImage { .. } | MessageContentPart::InputImageRef { .. })))
+        matches!(self, Self::Parts(parts) if parts.iter().any(|part| matches!(part, MessageContentPart::InputImage { .. })))
     }
 
     /// Extract all text, discarding images (lossy conversion).
@@ -119,8 +106,7 @@ impl MessageContent {
                 .iter()
                 .filter_map(|part| match part {
                     MessageContentPart::InputText { text } => Some(text.clone()),
-                    MessageContentPart::InputImage { .. }
-                    | MessageContentPart::InputImageRef { .. } => None,
+                    MessageContentPart::InputImage { .. } => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),

--- a/src/tools/sanitizer.rs
+++ b/src/tools/sanitizer.rs
@@ -119,15 +119,6 @@ pub(crate) fn sanitize_message_content(
                             detail: detail.map(|value| sanitize_output_string(&value, secrets)),
                         }
                     }
-                    MessageContentPart::InputImageRef {
-                        image_ref,
-                        mime_type,
-                        detail,
-                    } => MessageContentPart::InputImageRef {
-                        image_ref: sanitize_output_string(&image_ref, secrets),
-                        mime_type: sanitize_output_string(&mime_type, secrets),
-                        detail: detail.map(|value| sanitize_output_string(&value, secrets)),
-                    },
                 })
                 .collect(),
         ),


### PR DESCRIPTION
## 概要
- 保存用の `ConversationMessage` / `ConversationContent` / `ConversationContentPart` を追加
- `llm::MessageContentPart` から保存専用の `InputImageRef` を削除
- セッション保存時は保存用型へ変換し、復元時にLLM送信用 `Message` へ戻すよう整理

## 検証
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 会話履歴の保存・復元が改善され、画像を含むメッセージをより安定して扱えるようになりました。
* **Bug Fixes**
  * 画像参照があるメッセージで、表示や送信時の内容欠落・不整合が起きにくくなりました。
  * 参照先の画像が利用できない場合でも、内容が分かる形で復元されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->