### PR TITLE
feat: calibrate token estimation with observed usage

### DIFF
--- a/docs/plan/plan-accurate-token-estimation.md
+++ b/docs/plan/plan-accurate-token-estimation.md
@@ -1,0 +1,389 @@
+# Plan: Safety Compaction のトークン推定を実測 usage フィードバックで校正する
+
+Safety Compaction の発火判定が依存するトークン推定を、文字数ベースの概算（`bytes/3`）単体から、**実測 usage で継続的に校正するハイブリッド方式**へ置き換える。プロバイダが返す `usage.input_tokens` で補正係数を学習し、chars/3 の日本語過小評価を吸収する。ローカル tokenizer のダウンロードや新規 DB API の追加は行わない。
+
+> **Note**: 振る舞い（What）は「推定トークンが閾値に達したら compaction 発火」。これは不変。変更するのは推定の精度（HOW）のみ。
+
+## 目次
+
+1. [動機](#1-動機)
+2. [設計方針](#2-設計方針)
+3. [アーキテクチャ概要](#3-アーキテクチャ概要)
+4. [コンポーネント設計](#4-コンポーネント設計)
+5. [設定スキーマ](#5-設定スキーマ)
+6. [データフロー](#6-データフロー)
+7. [対象一覧](#7-対象一覧)
+8. [TDD テストリスト](#8-tdd-テストリスト)
+9. [実装スコープと限界](#9-実装スコープと限界)
+10. [セキュリティと運用](#10-セキュリティと運用)
+11. [未解決 / 保留](#11-未解決--保留)
+12. [動作確認](#12-動作確認)
+13. [Plan・仕様書との自己チェック](#13-plan仕様書との自己チェック)
+14. [PR 作成](#14-pr-作成)
+15. [初回レビューバック](#15-初回レビューバック)
+16. [レビュー対応後の再レビューバック](#16-レビュー対応後の再レビューバック)
+
+---
+
+## 1. 動機
+
+### 現状の問題
+
+`estimate_prompt_tokens`（`src/agent_loop/compaction.rs`）は次の概算式を採っている。
+
+```rust
+(total_chars / 3).max(1)   // total_chars は String::len() = バイト長
+```
+
+コメント上は「chars-based 近似で実際より多めに見積もる」ことを意図しているが、`String::len()` は**バイト長**であるため、UTF-8 で3バイト表現の日本語テキストでは `bytes/3 = 文字数` となり、BPE 実トークン（日本語1文字 ≈ 1.3〜2 token）に対して**過小評価**になる。
+
+### 実被害
+
+`chat_id=18`（Discord / agent=lyre / model=glm-5.2）で発生した Context7 MCP 無限ループ事故：
+
+- ループ中の実 `input_tokens` が 74K → 100K へ単調増加
+- 一方 `llm_usage_logs` の `request_kind='compaction'` は **0件**（summary LLM 呼び出しが一度も発火していない）
+- つまり推定値が閾値 `usable × 0.80` に一度も到達せず、安全装置が作動しなかった
+- 結果、コンテキスト肥大で推論品質が劣化し、EgoGraph/Context7 のツール誤選択ループに陥った
+
+### 決定的な点
+
+egopulse は**すでにプロバイダから実測 `usage.input_tokens` を受け取り、`llm_usage_logs` に記録している**。この実測値を推定の校正に使えば、chars/3 の過小評価を吸収できる。外部リソースのダウンロード（ローカル tokenizer 等）は不要。`usage` を返すプロバイダでは実測で収束し、返さないプロバイダでも未計測時の保守的な既定係数で過小評価リスクを下げる。
+
+### 目標
+
+実測 usage で校正された補正係数を推定に掛け合わせ、Safety Compaction の発火判定を信頼させる。日本語中心の会話でも閾値到達しやすい保守的な推定にする。
+
+---
+
+## 2. 設計方針
+
+1. **実測 usage フィードバックが主軸**: プロバイダが返す `usage.input_tokens` で補正係数を学習し、chars/3 推定に掛ける。外部ダウンロード不要。
+2. **chars/3 は推定のベース**: `estimate_prompt_tokens` の中身（bytes/3）は維持。過小評価のズレは補正係数で吸収する。
+3. **学習は送信 payload 基準**: 補正係数の学習は、compaction 判定時の推定ではなく、**LLM へ実際に送信した payload** の推定と、その response の `usage.input_tokens` を対応付けて行う（compaction 前後で payload が変わるため）。
+4. **未計測時も保守側に倒す**: 起動直後（実測蓄積なし）は factor=1.0 ではなく、固定の `DEFAULT_FACTOR` を返して過小評価を抑える。
+5. **新仕様へ一直線**: `maybe_compact_messages` の推定フローを差し替え。旧仕様維持のための分岐は作らない。
+6. **公開範囲は最小**: 新 API は `pub(crate)` から始める。
+
+---
+
+## 3. アーキテクチャ概要
+
+### Before（現状）
+
+```
+maybe_compact_messages
+  ├─ resolve_context_window_tokens(provider, model)   // 設定値
+  ├─ estimate_prompt_tokens(system, messages, tools)   // bytes/3
+  └─ should_compact(estimated, usable, 0.80)?
+        └─ safety_compact → summarize_old_messages (LLM) → build_compaction_result
+```
+
+### After（本プラン）
+
+```
+maybe_compact_messages
+  ├─ raw_est  = estimate_prompt_tokens(system, messages, tools)  // bytes/3（維持）
+  ├─ key      = CalibrationKey { provider, model, "agent_loop", has_tools }
+  ├─ factor   = state.calibrator.factor(&key)        // 実測で校正された補正係数（未計測時 DEFAULT_FACTOR）
+  ├─ estimated = calibrated_estimate(raw_est, factor)
+  ├─ usable   = resolve_context_window_tokens(provider, model) - 8192
+  └─ should_compact(estimated, usable, 0.80)?
+        └─ safety_compact → ... (内部の target 判定も同じ calibrated_estimate を使用)
+
+LLM 送信経路ごと（送信前 keep → response 後 record）:
+  ├─ agent_loop:       record(CalibrationKey{.., "agent_loop", has_tools}, raw_est, usage)
+  └─ compaction sum.:  record(CalibrationKey{.., "compaction", false}, raw_est, usage)
+```
+
+コンポーネント構成：
+
+```
+src/agent_loop/
+├── compaction.rs         (変更) maybe_compact_messages で factor 適用
+└── tool_phase.rs         (変更) 学習パス（送信前 estimate 保持 → response 後 record）
+
+src/runtime/
+└── mod.rs                (変更) AppState に UsageCalibrator
+
+src/llm/
+└── calibration.rs        (新規) UsageCalibrator + CalibrationKey
+```
+
+---
+
+## 4. コンポーネント設計
+
+### 4.1 `UsageCalibrator`（`src/llm/calibration.rs` 新規）
+
+`(provider, model, request_kind, has_tools)` 単位の補正係数をメモリ内で保持する。非永続化（プロセス再起動で未計測状態に戻る）。
+
+```rust
+#[derive(Hash, Eq, PartialEq, Clone)]
+pub(crate) struct CalibrationKey {
+    pub provider: String,
+    pub model: String,
+    pub request_kind: String,   // "agent_loop" / "compaction"
+    pub has_tools: bool,         // tool schema を含む payload か
+}
+
+pub(crate) struct UsageCalibrator {
+    factors: tokio::sync::RwLock<HashMap<CalibrationKey, f64>>,
+    // EMA の重み（例: α=0.3）
+}
+
+impl UsageCalibrator {
+    /// 補正係数を取得。未計測時は DEFAULT_FACTOR。
+    pub(crate) async fn factor(&self, key: &CalibrationKey) -> f64;
+
+    /// estimated に対する actual の比で係数を EMA 更新。
+    /// estimated が 0 以下、actual が異常値（0 以下）は無視。
+    /// 係数は [0.5, 3.0] にクリップ（異常スパイク防止）。
+    pub(crate) async fn record(
+        &self, key: CalibrationKey, estimated: usize, actual: i64,
+    );
+}
+```
+
+設計判断：
+
+- **キー粒度**: `(provider, model, request_kind, has_tools)`。tool-heavy な agent_loop と tool 無しの compaction summarizer は overhead 構造が異なるため別係数。これより細かい（tool schema hash 等）とサンプルが足りず収束しない。`has_tools` の大区分が実用的妥協点。
+- **EMA（指数移動平均）**: 単発のスパイク（ツール結果が異常に大きい等）で係数が振れるのを防ぐ。
+- **クリップ [0.5, 3.0]**: 係数が極端になると推定が暴走する。下限 0.5（過大評価時の修正）、上限 3.0（過小評価時の修正、今回の日本語ケース相当）。
+- **estimated == 0 を除外**: 推定が 0 の場合は記録しない（ゼロ除算・異常係数防止）。
+- **非永続化**: プロセス再起動で未計測状態に戻る。未計測時は `DEFAULT_FACTOR` を使うため、DB 永続化や起動時 warm start は追加しない。
+
+### 4.2 `estimate_prompt_tokens`（既存、維持）
+
+`src/agent_loop/compaction.rs` の既存関数。`bytes/3` 推定の中身は変更しない。過小評価のズレは `UsageCalibrator` の factor で吸収するため、推定関数自体の改良は不要。
+
+呼び出し元の `maybe_compact_messages` と compaction 後の target 判定で、推定結果に同じ factor を掛ける。
+
+### 4.3 `DEFAULT_FACTOR`
+
+起動直後（実測蓄積なし）の過小評価をカバーするため、未計測 key では 1.0 ではなく固定の既定係数を返す。
+
+```rust
+/// chars/3 の日本語過小評価を未計測時から補う保守係数。
+const DEFAULT_FACTOR: f64 = 1.6;
+
+fn calibrated_estimate(raw_estimate: usize, factor: f64) -> usize {
+    ((raw_estimate as f64) * factor).ceil().max(1.0) as usize
+}
+```
+
+新しい設定は追加しない。既存の `compaction_threshold_ratio` は維持し、発火ロジックの調整は補正係数に閉じる。
+
+### 4.4 学習パス（送信 payload 基準・2経路）
+
+学習は LLM 送信を行う2経路で実施。いずれも**送信前に estimate と key を計算してローカル変数に保持**する（payload は `send_message` に move されるため、response 後には再計算できない）。response の `usage` 受信後に record する。
+
+#### 経路1: agent_loop（`send_tool_phase_request`）
+
+```text
+send_tool_phase_request (src/agent_loop/tool_phase.rs:116)
+  │  ※ 送信前（move 前）に ToolPhaseRequest から以下を計算して保持:
+  │    raw_est = estimate_prompt_tokens(request.system_prompt, &request.messages, tools_json)
+  │    key     = CalibrationKey { provider, model, request_kind: "agent_loop",
+  │                               has_tools: request.tools.as_ref().map_or(false, |t| !t.is_empty()) }
+  ├─ response = llm.send_message(request.system_prompt, request.messages, request.tools).await  // move 発生
+  └─ response.usage が存在すれば:
+       state.calibrator.record(key, raw_est, usage.input_tokens)
+```
+
+#### 経路2: compaction summarizer（`send_summary_request`）
+
+```text
+send_summary_request (src/agent_loop/compaction.rs)
+  │  ※ 送信前に summary_input から以下を計算して保持:
+  │    raw_est = estimate_prompt_tokens(SUMMARIZER_SYSTEM_PROMPT,
+  │                                    &[Message::text("user", &summary_input)], None)
+  │    key     = CalibrationKey { provider, model, request_kind: "compaction", has_tools: false }
+  ├─ response = llm.send_message(...).await  // move 発生
+  └─ summarize_old_messages 側で response.usage が存在すれば:
+       state.calibrator.record(key, raw_est, usage.input_tokens)
+```
+
+`TurnLoopState` には推定値を持たせない。agent_loop は `send_tool_phase_request` のローカル変数で完結させる。compaction summarizer は `send_summary_request` の戻り値に `raw_est` と `key` を添えるか、呼び出し元 `summarize_old_messages` で送信前に保持して response 後に record する。`usage` が `None` のプロバイダでは record しない。
+
+compaction 判定（§6）の estimate は record に使わない。判定は「推定 × factor（agent_loop 係数）」のみで行い、学習は上記2経路のみ。
+
+---
+
+## 5. 設定スキーマ
+
+**設定追加なし。**
+
+- `UsageCalibrator` の factor は実測から自動学習するため、ユーザー設定不要。
+- `DEFAULT_FACTOR` はコード内定数。
+- 既存の `compaction_threshold_ratio`（デフォルト 0.80）は維持する。
+
+---
+
+## 6. データフロー
+
+### compaction 判定
+
+```text
+persist_user_turn_with_compaction / tool 後 maybe_compact_messages
+  │
+  ├─ raw_est = estimate_prompt_tokens(system, messages, tools)   // bytes/3（維持）
+  ├─ next_tools が存在するか確認（has_tools 判定）
+  ├─ key     = CalibrationKey { provider, model, "agent_loop", has_tools }
+  │            ※ 判定は「次に送る agent_loop payload」を予測するため agent_loop 係数を使用
+  ├─ factor  = state.calibrator.factor(&key).await                // 未計測時 DEFAULT_FACTOR
+  ├─ estimated = calibrated_estimate(raw_est, factor)
+  ├─ usable  = resolve_context_window_tokens(provider, model) - 8192
+  └─ should_compact(estimated, usable, 0.80)?
+        └─ YES → safety_compact（target 判定も同じ calibrated_estimate を使用）
+```
+
+### 補正係数学習
+
+§4.4 の2経路（agent_loop / compaction summarizer）を参照。
+
+---
+
+## 7. 対象一覧
+
+| 対象 | 種別 | 既存パターン / 参照元 | 備考 |
+| -- | -- | -- | -- |
+| `src/llm/calibration.rs` | **新規** | — | `UsageCalibrator`, `CalibrationKey` |
+| `src/llm/mod.rs` | 変更 | 既存モジュール公開 | `pub(crate) mod calibration;` |
+| `src/runtime/mod.rs` | 変更 | `AppState` | `UsageCalibrator` フィールド、`build_app_state` での初期化 |
+| `src/agent_loop/compaction.rs` | 変更 | `maybe_compact_messages` | 推定に factor を適用。compaction 後 target 判定にも同じ補正式を使用。summary 送信の学習パス追加 |
+| `src/agent_loop/tool_phase.rs` | 変更 | `send_tool_phase_request`（tool_phase.rs:116） | 学習パス追加。送信前（move 前）に `raw_est`/`key` を保持し、response 後に `calibrator.record`。`AppState` アクセス追加 |
+| `docs/session-lifecycle.md` | 変更 | §5 Safety Compaction | 推定方式（chars/3 + 実測補正）の記述へ更新 |
+
+---
+
+## 8. TDD テストリスト
+
+バックエンド（Red→Green→Refactor サイクルごとに1件ずつ追加）：
+
+- **T1**: `UsageCalibrator.record` で `estimated < actual` のとき factor > 1.0 に更新される
+- **T2**: `UsageCalibrator` の EMA が単発スパイクで急激に変動しない（連続 record で漸増）
+- **T3**: `UsageCalibrator` の係数が `[0.5, 3.0]` にクリップされる（極端値入力で上下限）
+- **T4**: `UsageCalibrator.record` が `estimated == 0` または `actual <= 0` を無視する
+- **T5**: `UsageCalibrator.factor` が未計測 key で `DEFAULT_FACTOR` を返す
+- **T6**: `CalibrationKey` が `(request_kind, has_tools)` で異なる係数を保持する（agent_loop と compaction の汚染防止）
+- **T7**: `maybe_compact_messages` が factor 適用で `should_compact` を判定（GLM-5.2 日本語ケースで、factor=2.0 相当で閾値到達することを模擬データで検証）
+- **T8**: compaction 後 target 判定（post check / summary truncation）にも同じ補正式が使われる
+- **T9**: `send_tool_phase_request` で送信前（move 前）に `raw_est`/`key` を計算して保持し、response 受信後に `calibrator.record`（move 後に再計算しない）
+- **T10**: compaction summarizer 経路でも送信前に estimate 保持 → response 後に record（key の `request_kind="compaction"`, `has_tools=false`）
+- **T11**: `usage` が `None` のプロバイダでは record しない（未計測係数 `DEFAULT_FACTOR` のまま）
+- **T12**: `has_tools` が空 tool list で `false` になる（`request.tools.is_some()` ではなく中身の有無で判定）
+
+### 実データによる検証（手動）
+
+- **V1**: `chat_id=18` の実際の `llm_usage_logs.input_tokens` に対し、chars/3 推定値が過小評価（実トークンの半分以下）であることを確認。その上で、factor を適用した推定値が実測の **±30% 以内**に収まることを確認
+- **V2**: factor 収束後（数ターン後）、推定値が実測値に ±20% 以内で追従することを確認
+
+---
+
+## 9. 実装スコープと限界
+
+### 実装する内容
+
+- `UsageCalibrator`（メモリ内、EMA、クリップ [0.5, 3.0]、非永続化）
+- `CalibrationKey { provider, model, request_kind, has_tools }`
+- `maybe_compact_messages` と compaction 後 target 判定で factor 適用
+- 学習パス（`send_tool_phase_request`, `send_summary_request` の2経路、送信前 keep → response 後 record）
+
+### 今回の事故に対する効果と限界
+
+今回の GLM ループ事故の**発生確率を大幅に低下**させる。実測 usage で校正された factor が chars/3 の過小評価を吸収するため、推定が実トークンに近付く。
+
+ただし完全保証ではない。以下の制約がある:
+
+- 補正係数は起動直後 `DEFAULT_FACTOR`（実測蓄積なし）。実測がある provider/model は数ターンで収束する
+- `usage` を返さないプロバイダでは学習が働かず、`DEFAULT_FACTOR` のまま
+
+境界対策: 未計測時から `DEFAULT_FACTOR` を適用し、設定・DB・外部依存を増やさず保守側に倒す。
+
+---
+
+## 10. セキュリティと運用
+
+### セキュリティ
+
+- **外部通信なし**: ローカル tokenizer のダウンロード等は行わない。実測 usage は既存の LLM API レスポンスから取得するもので、追加の通信は発生しない。
+- **秘密情報の不入力**: `CalibrationKey` は provider/model/request_kind/has_tools のみで、プロンプト内容や認証情報は含まない。factor も比率のみで内容は保持しない。
+
+### 運用
+
+- **依存追加なし**: 新規クレートなし。`Cargo.toml` の変更不要。
+- **ビルド時間影響なし**: ローカル tokenizer 等の重い依存を入れないため、ビルド時間・バイナリサイズへの影響はない。
+- **オフライン環境**: 外部リソースに依存しないため、オフラインでも全力で動作する。
+- **プロバイダ互換**: `usage.input_tokens` を返すプロバイダでは実測補正が働く。返さないプロバイダでは `DEFAULT_FACTOR` の保守推定で動作する。
+
+---
+
+## 11. 未解決 / 保留
+
+- **`DEFAULT_FACTOR` の値**: 1.6 で妥当か。実データ（V1）を見て、必要なら同じ定数のみ調整する。
+- **EMA の重み α**: 0.3 で妥当か。収束速度とスパイク耐性のトレードオフを実データで調整。
+- **クリップ範囲 `[0.5, 3.0]`**: 実データで不適切（広すぎる/狭すぎる）なら調整。
+- **`sleep/orchestrator.rs` の `context_tokens`**: `resolve_context_window_tokens` の戻り値（設定値そのもの）を使用している場合は本プランの影響なし。実装修正時に確認。
+- **永続化**: プロセス再起動で factor は未計測状態に戻る。永続 warm start は追加しない。
+
+---
+
+## 12. 動作確認
+
+- 全テスト通過: `cargo test --all-features`
+- Lint / フォーマット: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
+- 型チェック: `cargo check --all-features`
+- 実データ検証: V1（chars/3 推定の過小評価確認 + factor 適用で ±30% 以内）、V2（収束後 ±20% 以内）
+- デッドコード確認: 新規補助関数が本流から使われていることを `rg` で検証
+- 失敗時に戻る Step: 該当する TDD Cycle（§8）へ戻り修正
+
+---
+
+## 13. Plan・仕様書との自己チェック
+
+実装完了後にこの Plan と関連仕様書（`docs/session-lifecycle.md` §5 Safety Compaction）を最初から読み直し、実装・自動テスト・文書が要求した振る舞いと一致しているかを照合する。未実装、過剰実装、テスト不足、仕様書との齟齬を見つけた場合は、該当する TDD Cycle へ戻って修正し、動作確認を再実行してからこの Step を完了する。
+
+- Plan のテストリスト（§8 T1-T12）と各 Cycle が完了条件を満たしている
+- `docs/session-lifecycle.md` §5 の Safety Compaction 振る舞い（What: 推定トークンが閾値に達したら発火）と実装結果が一致している
+- 実装中に変更した設計判断（推定方式の chars/3 + 実測補正、`DEFAULT_FACTOR` の導入）が `docs/session-lifecycle.md` §5 へ反映されている
+- 変更ファイル一覧（§7）、自動テスト一覧（§8）が実際の変更と一致している
+
+---
+
+## 14. PR 作成
+
+- PR タイトル: `feat: calibrate token estimation with observed usage for safety compaction`
+- PR description:
+  - 概要: Safety Compaction のトークン推定（chars/3）に、実測 usage で校正する補正係数を導入。chars/3 の日本語過小評価を吸収し、GLM-5.2 等での compaction 不発火を抑制。外部ダウンロード・設定追加・DB API 追加なし。
+  - テスト: UT（T1-T12）+ 実データ検証（V1, V2）
+  - Close #<issue-number>（該当する場合）
+
+---
+
+## 15. 初回レビューバック
+
+PR 作成後、レビュー生成を待ってから `pr-review-back-workflow` Skill を実行し、未対応のレビューコメントがあれば修正・検証・コミット・push まで完了する。
+
+- 初回待機: `sleep 15m`
+- レビュー対応: `pr-review-back-workflow` Skill を実行する
+- まだレビューが無い場合:
+  - `sleep 5m` して `pr-review-back-workflow` Skill を再実行する
+  - 追加待機と再実行は最大 2 回まで
+- レビューコメントが無い、または最大待機後もレビューが無い場合は、その結果を PR に記録して完了扱いにする
+- レビュー対応で変更した場合は、必要な動作確認を再実行してからコミット・push する
+
+---
+
+## 16. レビュー対応後の再レビューバック
+
+レビュー対応を push した後、追加レビュー生成を待ってから `pr-review-back-workflow` Skill を再実行し、残った指摘や新規指摘があれば同じ品質基準で対応する。
+
+- 対象: §15 でレビュー対応の変更を push した場合
+- 初回待機: `sleep 15m`
+- 再レビュー対応: `pr-review-back-workflow` Skill を実行する
+- まだ追加レビューが無い場合:
+  - `sleep 5m` して `pr-review-back-workflow` Skill を再実行する
+  - 追加待機と再実行は最大 2 回まで
+- 追加レビューコメントが無い、または最大待機後も追加レビューが無い場合は、その結果を PR に記録して完了扱いにする
+- 再レビュー対応で変更した場合は、必要な動作確認を再実行してからコミット・push する

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -179,9 +179,9 @@ compaction は保存の別系統ではなく、「保存前に session を整形
 
 最初の LLM 呼び出し前と、tool result 追加後の次回 LLM 呼び出し前に判定する。推定 prompt tokens が usable context の `compaction_threshold_ratio`（デフォルト 80%）に達したら発火。
 
-推定は bytes-based 近似（`bytes / 3`）をベースに、実測 usage で校正した補正係数を掛ける。system prompt・messages・tool schema を含めて raw estimate を算出し、LLM レスポンスの `usage.input_tokens` が返る経路では `(provider, model, request_kind, has_tools)` 単位の係数を EMA で更新する。
+推定は会話量の概算を出し、LLM レスポンスに含まれる実測 usage で補正する。実測が返る provider では、日本語や tool schema の影響で概算が小さく出る場合も、以後の判定が実際の使用量に近づく。
 
-未計測 key ではコード内定数 `DEFAULT_FACTOR` を使い、起動直後や usage を返さない provider でも過小評価側に倒れにくくする。補正係数はメモリ内のみで保持し、設定・DB 永続化・外部 tokenizer 依存は追加しない。
+まだ実測がない場合は、保守的に少し多めに見積もる。補正値は実行中のメモリだけに保持し、設定や DB には保存しない。外部 tokenizer も使わない。
 
 ### Algorithm
 
@@ -194,7 +194,7 @@ compaction は保存の別系統ではなく、「保存前に session を整形
 | **old** | 古いメッセージ。summary 対象 |
 | **recent** | `compact_keep_recent`（下限）以上の直近メッセージ。最新 user message と tool call/result block を保護 |
 
-**要約入力**: old を text 化。画像は `[image]`、tool call は `[tool_use: ...]`、tool result は要点化（古いものは内容を軽量化）。`compaction_target_ratio` に基づく summarizer budget を超えないよう全文を切り詰める。summary 生成後も補正後推定で target を超える場合は、recent を保護したまま summary 本文をさらに縮める。
+**要約入力**: old を text 化。画像は `[image]`、tool call は `[tool_use: ...]`、tool result は要点化（古いものは内容を軽量化）。`compaction_target_ratio` に基づく summarizer budget を超えないよう全文を切り詰める。summary 生成後も目標サイズを超える場合は、recent を保護したまま summary 本文だけをさらに縮める。
 
 **要約呼び出し**: 専用 system prompt（[system-prompt.md §6](./system-prompt.md#6-compaction-用プロンプト)参照）+ 会話要約要求 + old dump。
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -179,7 +179,9 @@ compaction は保存の別系統ではなく、「保存前に session を整形
 
 最初の LLM 呼び出し前と、tool result 追加後の次回 LLM 呼び出し前に判定する。推定 prompt tokens が usable context の `compaction_threshold_ratio`（デフォルト 80%）に達したら発火。
 
-推定は保守的 chars-based 近似（`chars / 3`）を用い、system prompt・messages・tool schema を含める。過小評価を避けるため、実際の token 量より多めに見積もる。
+推定は bytes-based 近似（`bytes / 3`）をベースに、実測 usage で校正した補正係数を掛ける。system prompt・messages・tool schema を含めて raw estimate を算出し、LLM レスポンスの `usage.input_tokens` が返る経路では `(provider, model, request_kind, has_tools)` 単位の係数を EMA で更新する。
+
+未計測 key ではコード内定数 `DEFAULT_FACTOR` を使い、起動直後や usage を返さない provider でも過小評価側に倒れにくくする。補正係数はメモリ内のみで保持し、設定・DB 永続化・外部 tokenizer 依存は追加しない。
 
 ### Algorithm
 
@@ -192,7 +194,7 @@ compaction は保存の別系統ではなく、「保存前に session を整形
 | **old** | 古いメッセージ。summary 対象 |
 | **recent** | `compact_keep_recent`（下限）以上の直近メッセージ。最新 user message と tool call/result block を保護 |
 
-**要約入力**: old を text 化。画像は `[image]`、tool call は `[tool_use: ...]`、tool result は要点化（古いものは内容を軽量化）。`compaction_target_ratio` に基づく summarizer budget を超えないよう全文を切り詰める。summary 生成後も target を超える場合は、recent を保護したまま summary 本文をさらに縮める。
+**要約入力**: old を text 化。画像は `[image]`、tool call は `[tool_use: ...]`、tool result は要点化（古いものは内容を軽量化）。`compaction_target_ratio` に基づく summarizer budget を超えないよう全文を切り詰める。summary 生成後も補正後推定で target を超える場合は、recent を保護したまま summary 本文をさらに縮める。
 
 **要約呼び出し**: 専用 system prompt（[system-prompt.md §6](./system-prompt.md#6-compaction-用プロンプト)参照）+ 会話要約要求 + old dump。
 

--- a/src/agent_loop/compaction.rs
+++ b/src/agent_loop/compaction.rs
@@ -149,7 +149,7 @@ pub(crate) fn estimate_prompt_tokens(
     (total_chars / CHARS_PER_TOKEN_ESTIMATE).max(1)
 }
 
-pub(crate) fn calibrated_estimate(raw_estimate: usize, factor: f64) -> usize {
+fn calibrated_estimate(raw_estimate: usize, factor: f64) -> usize {
     ((raw_estimate as f64) * factor).ceil().max(1.0) as usize
 }
 
@@ -855,6 +855,7 @@ mod tests {
 
     #[test]
     fn applies_calibration_factor_to_prompt_estimate() {
+        // Act + Assert
         assert_eq!(calibrated_estimate(10, 1.6), 16);
         assert_eq!(calibrated_estimate(1, 0.5), 1);
     }
@@ -901,14 +902,17 @@ mod tests {
 
     #[test]
     fn shrinks_compacted_summary_to_target() {
+        // Arrange
         let recent = vec![Message::text("user", "fresh question")];
         let full = build_compacted_messages(&"summary ".repeat(1000), &recent);
         let minimum = build_compacted_messages("", &recent);
         let target = estimate_prompt_tokens("", &minimum, None) + 10;
 
+        // Act
         let result =
             build_targeted_compacted_messages(&"summary ".repeat(1000), &recent, target, 1.0);
 
+        // Assert
         assert!(estimate_prompt_tokens("", &full, None) > target);
         assert!(estimate_prompt_tokens("", &result, None) <= target);
         assert!(
@@ -925,13 +929,16 @@ mod tests {
 
     #[test]
     fn shrinks_compacted_summary_using_calibrated_estimate() {
+        // Arrange
         let recent = vec![Message::text("user", "fresh question")];
         let minimum = build_compacted_messages("", &recent);
         let target = calibrated_estimate(estimate_prompt_tokens("", &minimum, None), 2.0) + 10;
 
+        // Act
         let result =
             build_targeted_compacted_messages(&"summary ".repeat(1000), &recent, target, 2.0);
 
+        // Assert
         assert!(
             calibrated_estimate(estimate_prompt_tokens("", &result, None), 2.0) <= target,
             "compacted result must fit the calibrated target"
@@ -1563,6 +1570,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn compaction_trigger_uses_calibrated_agent_loop_estimate() {
+        // Arrange
         let dir = tempfile::tempdir().expect("tempdir");
         let provider = RecordingProvider::new(
             vec![Ok(MessagesResponse {
@@ -1591,6 +1599,7 @@ mod tests {
         let usable = usable_context_tokens(10_000);
         assert!(!should_compact(raw, usable, 0.80));
 
+        // Act
         let result = maybe_compact_messages(
             &state,
             &context,
@@ -1606,6 +1615,7 @@ mod tests {
         .await
         .expect("compaction");
 
+        // Assert
         assert!(
             result[0]
                 .content
@@ -1618,6 +1628,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn compaction_summarizer_usage_updates_calibration() {
+        // Arrange
         let dir = tempfile::tempdir().expect("tempdir");
         let provider = RecordingProvider::new(
             vec![
@@ -1667,9 +1678,12 @@ mod tests {
         .await
         .expect("save session");
 
+        // Act
         let reply = process_turn(&state, &context, "fresh question")
             .await
             .expect("process turn");
+
+        // Assert
         assert_eq!(reply, "final answer");
 
         let factor = state

--- a/src/agent_loop/compaction.rs
+++ b/src/agent_loop/compaction.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use crate::agent_loop::SurfaceContext;
 use crate::agent_loop::formatting::{message_to_archive_text, message_to_text, strip_thinking};
 use crate::error::{EgoPulseError, LlmError};
+use crate::llm::calibration::CalibrationKey;
 use crate::llm::{LlmProvider, Message, MessagesResponse};
 use crate::runtime::AppState;
 use tracing::{info, warn};
@@ -41,6 +42,7 @@ const SUMMARIZER_SYSTEM_PROMPT: &str = "You are a helpful summarizer. Summarize 
 pub(crate) struct PromptContext<'a> {
     pub system_prompt: &'a str,
     pub tools_json: Option<&'a str>,
+    pub has_tools: bool,
 }
 
 pub(crate) async fn maybe_compact_messages(
@@ -56,8 +58,11 @@ pub(crate) async fn maybe_compact_messages(
         .config
         .resolve_context_window_tokens(&provider_id, llm.model_name());
     let usable = usable_context_tokens(context_window);
-    let estimated =
+    let raw_estimate =
         estimate_prompt_tokens(prompt_ctx.system_prompt, messages, prompt_ctx.tools_json);
+    let calibration_key = agent_loop_calibration_key(llm.as_ref(), prompt_ctx.has_tools);
+    let factor = state.usage_calibrator.factor(&calibration_key).await;
+    let estimated = calibrated_estimate(raw_estimate, factor);
 
     if !should_compact(estimated, usable, state.config.compaction_threshold_ratio) {
         return Ok(messages.to_vec());
@@ -74,12 +79,15 @@ pub(crate) async fn maybe_compact_messages(
 
     safety_compact(
         state,
-        context,
-        chat_id,
-        messages,
-        llm,
-        usable,
-        state.config.compaction_target_ratio,
+        SafetyCompactInput {
+            context,
+            chat_id,
+            messages,
+            llm,
+            usable,
+            target_ratio: state.config.compaction_target_ratio,
+            calibration_factor: factor,
+        },
     )
     .await
 }
@@ -101,14 +109,22 @@ pub(crate) async fn force_compact(
         .resolve_context_window_tokens(&provider_id, llm.model_name());
     let usable = usable_context_tokens(context_window);
 
+    let factor = state
+        .usage_calibrator
+        .factor(&agent_loop_calibration_key(llm.as_ref(), false))
+        .await;
+
     safety_compact(
         state,
-        context,
-        chat_id,
-        messages,
-        llm,
-        usable,
-        state.config.compaction_target_ratio,
+        SafetyCompactInput {
+            context,
+            chat_id,
+            messages,
+            llm,
+            usable,
+            target_ratio: state.config.compaction_target_ratio,
+            calibration_factor: factor,
+        },
     )
     .await
 }
@@ -131,6 +147,10 @@ pub(crate) fn estimate_prompt_tokens(
         total_chars += tools.len();
     }
     (total_chars / CHARS_PER_TOKEN_ESTIMATE).max(1)
+}
+
+pub(crate) fn calibrated_estimate(raw_estimate: usize, factor: f64) -> usize {
+    ((raw_estimate as f64) * factor).ceil().max(1.0) as usize
 }
 
 pub(crate) fn usable_context_tokens(context_window_tokens: usize) -> usize {
@@ -188,6 +208,17 @@ struct CompactionResultInput<'a> {
     summary: &'a str,
     usable_context: usize,
     target_ratio: f64,
+    calibration_factor: f64,
+}
+
+struct SafetyCompactInput<'a> {
+    context: &'a SurfaceContext,
+    chat_id: i64,
+    messages: &'a [Message],
+    llm: &'a std::sync::Arc<dyn LlmProvider>,
+    usable: usize,
+    target_ratio: f64,
+    calibration_factor: f64,
 }
 
 enum SummarizeOutcome {
@@ -197,44 +228,41 @@ enum SummarizeOutcome {
 
 async fn safety_compact(
     state: &AppState,
-    context: &SurfaceContext,
-    chat_id: i64,
-    messages: &[Message],
-    llm: &std::sync::Arc<dyn crate::llm::LlmProvider>,
-    usable_context: usize,
-    target_ratio: f64,
+    input: SafetyCompactInput<'_>,
 ) -> Result<Vec<Message>, EgoPulseError> {
-    archive_current_conversation(state, context, chat_id, messages).await;
+    archive_current_conversation(state, input.context, input.chat_id, input.messages).await;
 
-    let Some(slices) = select_compaction_slices(messages, state.config.compact_keep_recent) else {
-        return Ok(messages.to_vec());
+    let Some(slices) = select_compaction_slices(input.messages, state.config.compact_keep_recent)
+    else {
+        return Ok(input.messages.to_vec());
     };
 
     let summary = match summarize_old_messages(
         state,
-        context,
-        chat_id,
+        input.context,
+        input.chat_id,
         slices.old_messages,
-        llm,
-        usable_context,
-        target_ratio,
+        input.llm,
+        input.usable,
+        input.target_ratio,
     )
     .await
     {
         SummarizeOutcome::Summary(summary) => summary,
-        SummarizeOutcome::KeepOriginal => return Ok(messages.to_vec()),
+        SummarizeOutcome::KeepOriginal => return Ok(input.messages.to_vec()),
     };
 
     let compacted = build_compaction_result(CompactionResultInput {
-        context,
-        chat_id,
-        llm,
-        original_count: messages.len(),
+        context: input.context,
+        chat_id: input.chat_id,
+        llm: input.llm,
+        original_count: input.messages.len(),
         old_count: slices.old_messages.len(),
         recent_messages: slices.recent_messages,
         summary: &summary,
-        usable_context,
-        target_ratio,
+        usable_context: input.usable,
+        target_ratio: input.target_ratio,
+        calibration_factor: input.calibration_factor,
     });
 
     Ok(compacted)
@@ -286,10 +314,20 @@ async fn summarize_old_messages(
     let mut summary_input = build_summary_input(old_messages, usable_context, target_ratio);
     summary_input = redact_summary_text(&summary_input, state);
     let timeout_secs = state.config.compaction_timeout_secs;
+    let summary_messages = Arc::new(vec![Message::text("user", summary_input)]);
+    let raw_estimate = estimate_prompt_tokens(SUMMARIZER_SYSTEM_PROMPT, &summary_messages, None);
+    let calibration_key =
+        CalibrationKey::new(llm.provider_name(), llm.model_name(), "compaction", false);
 
-    let summary_result = send_summary_request(llm, summary_input, timeout_secs).await;
+    let summary_result = send_summary_request(llm, summary_messages, timeout_secs).await;
     let summary = match summary_result {
         Ok(response) => {
+            if let Some(usage) = &response.usage {
+                state
+                    .usage_calibrator
+                    .record(calibration_key, raw_estimate, usage.input_tokens)
+                    .await;
+            }
             log_summarizer_usage(state, context, chat_id, llm, &response);
             strip_thinking(&response.content)
         }
@@ -324,16 +362,12 @@ enum SummarizeError {
 
 async fn send_summary_request(
     llm: &std::sync::Arc<dyn LlmProvider>,
-    summary_input: String,
+    messages: Arc<Vec<Message>>,
     timeout_secs: u64,
 ) -> Result<MessagesResponse, SummarizeError> {
     tokio::time::timeout(
         std::time::Duration::from_secs(timeout_secs),
-        llm.send_message(
-            SUMMARIZER_SYSTEM_PROMPT,
-            Arc::new(vec![Message::text("user", summary_input)]),
-            None,
-        ),
+        llm.send_message(SUMMARIZER_SYSTEM_PROMPT, messages, None),
     )
     .await
     .map_err(|_| SummarizeError::Timeout)?
@@ -378,7 +412,12 @@ fn log_summarizer_usage(
 
 fn build_compaction_result(input: CompactionResultInput<'_>) -> Vec<Message> {
     let target = compaction_target_tokens(input.usable_context, input.target_ratio);
-    let compacted = build_targeted_compacted_messages(input.summary, input.recent_messages, target);
+    let compacted = build_targeted_compacted_messages(
+        input.summary,
+        input.recent_messages,
+        target,
+        input.calibration_factor,
+    );
 
     let new_count = compacted.len();
     log_compaction_metrics(
@@ -391,7 +430,10 @@ fn build_compaction_result(input: CompactionResultInput<'_>) -> Vec<Message> {
         true,
     );
 
-    let post_tokens = estimate_prompt_tokens("", &compacted, None);
+    let post_tokens = calibrated_estimate(
+        estimate_prompt_tokens("", &compacted, None),
+        input.calibration_factor,
+    );
     if post_tokens > target {
         warn!(
             channel = %input.context.channel,
@@ -410,12 +452,17 @@ fn build_targeted_compacted_messages(
     summary: &str,
     recent_messages: &[Message],
     target_tokens: usize,
+    calibration_factor: f64,
 ) -> Vec<Message> {
     let compacted = build_compacted_messages(summary, recent_messages);
     if target_tokens == 0 {
         return compacted;
     }
-    if estimate_prompt_tokens("", &compacted, None) <= target_tokens {
+    if calibrated_estimate(
+        estimate_prompt_tokens("", &compacted, None),
+        calibration_factor,
+    ) <= target_tokens
+    {
         return compacted;
     }
 
@@ -426,7 +473,11 @@ fn build_targeted_compacted_messages(
         let mid = low + (high - low) / 2;
         let candidate_summary = truncate_summary_for_target(summary, mid);
         let candidate = build_compacted_messages(&candidate_summary, recent_messages);
-        if estimate_prompt_tokens("", &candidate, None) <= target_tokens {
+        if calibrated_estimate(
+            estimate_prompt_tokens("", &candidate, None),
+            calibration_factor,
+        ) <= target_tokens
+        {
             best = Some(candidate);
             low = mid + 1;
         } else if mid == 0 {
@@ -437,6 +488,15 @@ fn build_targeted_compacted_messages(
     }
 
     best.unwrap_or_else(|| build_compacted_messages("", recent_messages))
+}
+
+fn agent_loop_calibration_key(llm: &dyn LlmProvider, has_tools: bool) -> CalibrationKey {
+    CalibrationKey::new(
+        llm.provider_name(),
+        llm.model_name(),
+        "agent_loop",
+        has_tools,
+    )
 }
 
 fn truncate_summary_for_target(summary: &str, max_chars: usize) -> String {
@@ -720,6 +780,7 @@ mod tests {
         RecordingProvider, build_state, cli_context, test_config_with_compaction,
     };
     use crate::error::LlmError;
+    use crate::llm::calibration::{CalibrationKey, DEFAULT_FACTOR};
     use crate::llm::{Message, MessagesResponse, ToolCall};
     use crate::storage::Database;
     use crate::storage::call_blocking;
@@ -793,6 +854,12 @@ mod tests {
     }
 
     #[test]
+    fn applies_calibration_factor_to_prompt_estimate() {
+        assert_eq!(calibrated_estimate(10, 1.6), 16);
+        assert_eq!(calibrated_estimate(1, 0.5), 1);
+    }
+
+    #[test]
     fn targets_configured_compaction_ratio() {
         let usable = 100_000;
         assert_eq!(compaction_target_tokens(usable, 0.40), 40_000);
@@ -839,7 +906,8 @@ mod tests {
         let minimum = build_compacted_messages("", &recent);
         let target = estimate_prompt_tokens("", &minimum, None) + 10;
 
-        let result = build_targeted_compacted_messages(&"summary ".repeat(1000), &recent, target);
+        let result =
+            build_targeted_compacted_messages(&"summary ".repeat(1000), &recent, target, 1.0);
 
         assert!(estimate_prompt_tokens("", &full, None) > target);
         assert!(estimate_prompt_tokens("", &result, None) <= target);
@@ -856,10 +924,25 @@ mod tests {
     }
 
     #[test]
+    fn shrinks_compacted_summary_using_calibrated_estimate() {
+        let recent = vec![Message::text("user", "fresh question")];
+        let minimum = build_compacted_messages("", &recent);
+        let target = calibrated_estimate(estimate_prompt_tokens("", &minimum, None), 2.0) + 10;
+
+        let result =
+            build_targeted_compacted_messages(&"summary ".repeat(1000), &recent, target, 2.0);
+
+        assert!(
+            calibrated_estimate(estimate_prompt_tokens("", &result, None), 2.0) <= target,
+            "compacted result must fit the calibrated target"
+        );
+    }
+
+    #[test]
     fn keeps_protected_recent_when_target_is_impossible() {
         let recent = vec![Message::text("user", "fresh question".repeat(500))];
 
-        let result = build_targeted_compacted_messages(&"summary ".repeat(1000), &recent, 1);
+        let result = build_targeted_compacted_messages(&"summary ".repeat(1000), &recent, 1, 1.0);
 
         assert_eq!(result.last().expect("recent").role, "user");
         assert!(
@@ -1475,5 +1558,129 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
         panic!("compaction usage log was not written within the polling timeout");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn compaction_trigger_uses_calibrated_agent_loop_estimate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "summary text".to_string(),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                usage: None,
+            })],
+            vec![0],
+        );
+        let mut config =
+            test_config_with_compaction(dir.path().to_str().expect("utf8").to_string(), 40, 1);
+        config.default_context_window_tokens = 10_000;
+        config.compaction_threshold_ratio = 0.80;
+        let state = build_state(config, Box::new(provider));
+        let context = cli_context("calibrated-trigger");
+        let llm = state.llm_for_context(&context).expect("llm");
+        let key = CalibrationKey::new("test", "test-model", "agent_loop", false);
+        state.usage_calibrator.record(key, 100, 300).await;
+        let messages = vec![
+            Message::text("user", "old request"),
+            Message::text("assistant", "old answer"),
+            Message::text("user", "x".repeat(3000)),
+        ];
+        let raw = estimate_prompt_tokens("", &messages, None);
+        let usable = usable_context_tokens(10_000);
+        assert!(!should_compact(raw, usable, 0.80));
+
+        let result = maybe_compact_messages(
+            &state,
+            &context,
+            1,
+            &messages,
+            &llm,
+            &PromptContext {
+                system_prompt: "",
+                tools_json: None,
+                has_tools: false,
+            },
+        )
+        .await
+        .expect("compaction");
+
+        assert!(
+            result[0]
+                .content
+                .as_text_lossy()
+                .contains(REFERENCE_ONLY_HEADER),
+            "calibrated estimate should trigger compaction"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn compaction_summarizer_usage_updates_calibration() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![
+                Ok(MessagesResponse {
+                    content: "summary text".to_string(),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    usage: Some(crate::llm::LlmUsage {
+                        input_tokens: 500,
+                        output_tokens: 20,
+                    }),
+                }),
+                Ok(MessagesResponse {
+                    content: "final answer".to_string(),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    usage: None,
+                }),
+            ],
+            vec![0, 0],
+        );
+        let config =
+            test_config_with_compaction(dir.path().to_str().expect("utf8").to_string(), 4, 2);
+        let state = build_state(config, Box::new(provider));
+        let context = cli_context("compaction-calibration");
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:compaction-calibration:agent:default",
+                Some("compaction-calibration"),
+                "cli",
+                "default",
+            )
+        })
+        .await
+        .expect("chat id");
+        let seeded = vec![
+            Message::text("user", "old-user-1"),
+            Message::text("assistant", "old-assistant-1"),
+            Message::text("user", "old-user-2"),
+            Message::text("assistant", "old-assistant-2"),
+        ];
+        let seeded_json = serde_json::to_string(&seeded).expect("seeded json");
+        call_blocking(Arc::clone(&state.db), move |db| {
+            db.save_session(chat_id, &seeded_json)
+        })
+        .await
+        .expect("save session");
+
+        let reply = process_turn(&state, &context, "fresh question")
+            .await
+            .expect("process turn");
+        assert_eq!(reply, "final answer");
+
+        let factor = state
+            .usage_calibrator
+            .factor(&CalibrationKey::new(
+                "test",
+                "test-model",
+                "compaction",
+                false,
+            ))
+            .await;
+        assert!(factor > DEFAULT_FACTOR);
     }
 }

--- a/src/agent_loop/tool_phase.rs
+++ b/src/agent_loop/tool_phase.rs
@@ -723,6 +723,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn send_tool_phase_request_records_usage_calibration_before_payload_move() {
+        // Arrange
         let dir = tempfile::tempdir().expect("tempdir");
         let provider = RecordingProvider::new(
             vec![Ok(MessagesResponse {
@@ -748,6 +749,7 @@ mod tests {
             parameters: serde_json::json!({"type": "object"}),
         }]);
 
+        // Act
         let response = send_tool_phase_request(ToolPhaseRequest {
             state: &state,
             llm: llm.as_ref(),
@@ -767,6 +769,7 @@ mod tests {
         .await
         .expect("tool phase response");
 
+        // Assert
         assert!(matches!(response, ToolPhaseResponse::Final(_)));
         let factor = state
             .usage_calibrator
@@ -783,6 +786,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn send_tool_phase_request_skips_calibration_when_usage_missing() {
+        // Arrange
         let dir = tempfile::tempdir().expect("tempdir");
         let provider = RecordingProvider::new(
             vec![Ok(MessagesResponse {
@@ -800,6 +804,7 @@ mod tests {
         let context = cli_context("usage-calibration-none");
         let llm = state.llm_for_context(&context).expect("llm");
 
+        // Act
         let response = send_tool_phase_request(ToolPhaseRequest {
             state: &state,
             llm: llm.as_ref(),
@@ -819,6 +824,7 @@ mod tests {
         .await
         .expect("tool phase response");
 
+        // Assert
         assert!(matches!(response, ToolPhaseResponse::Final(_)));
         let factor = state
             .usage_calibrator
@@ -835,6 +841,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn send_tool_phase_request_treats_empty_tools_as_no_tools_for_calibration() {
+        // Arrange
         let dir = tempfile::tempdir().expect("tempdir");
         let provider = RecordingProvider::new(
             vec![Ok(MessagesResponse {
@@ -855,6 +862,7 @@ mod tests {
         let context = cli_context("usage-calibration-empty-tools");
         let llm = state.llm_for_context(&context).expect("llm");
 
+        // Act
         let response = send_tool_phase_request(ToolPhaseRequest {
             state: &state,
             llm: llm.as_ref(),
@@ -874,6 +882,7 @@ mod tests {
         .await
         .expect("tool phase response");
 
+        // Assert
         assert!(matches!(response, ToolPhaseResponse::Final(_)));
         let without_tools = state
             .usage_calibrator

--- a/src/agent_loop/tool_phase.rs
+++ b/src/agent_loop/tool_phase.rs
@@ -6,12 +6,14 @@ use futures_util::future::join_all;
 use tracing::warn;
 
 use crate::agent_loop::ConversationScope;
+use crate::agent_loop::compaction::estimate_prompt_tokens;
 use crate::agent_loop::formatting::{
     format_tool_result, message_to_text, sanitize_assistant_response_text,
     summarize_tool_calls_with_content, tool_message_content,
 };
 use crate::channels::utils::text::truncate_by_chars;
 use crate::error::EgoPulseError;
+use crate::llm::calibration::CalibrationKey;
 use crate::llm::{LlmProvider, LlmUsage, Message, MessagesResponse, ToolCall, ToolDefinition};
 use crate::runtime::AppState;
 use crate::storage::call_blocking;
@@ -115,6 +117,27 @@ pub(crate) fn filter_valid_tool_calls(tool_calls: Vec<ToolCall>, log_scope: &str
 pub(crate) async fn send_tool_phase_request(
     request: ToolPhaseRequest<'_>,
 ) -> Result<ToolPhaseResponse, EgoPulseError> {
+    let has_tools = request
+        .tools
+        .as_ref()
+        .is_some_and(|tools| !tools.is_empty());
+    let tools_json = request
+        .tools
+        .as_deref()
+        .filter(|tools| !tools.is_empty())
+        .and_then(|tools| serde_json::to_string(tools).ok());
+    let raw_estimate = estimate_prompt_tokens(
+        request.system_prompt,
+        &request.messages,
+        tools_json.as_deref(),
+    );
+    let calibration_key = CalibrationKey::new(
+        request.llm.provider_name(),
+        request.llm.model_name(),
+        request.request_kind,
+        has_tools,
+    );
+
     let response = request
         .llm
         .send_message_streaming(
@@ -134,6 +157,11 @@ pub(crate) async fn send_tool_phase_request(
         })?;
 
     if let Some(usage) = &response.usage {
+        request
+            .state
+            .usage_calibrator
+            .record(calibration_key, raw_estimate, usage.input_tokens)
+            .await;
         log_llm_usage(
             request.state,
             request.scope,
@@ -354,7 +382,8 @@ mod tests {
     use super::*;
     use crate::agent_loop::process_turn;
     use crate::agent_loop::turn::{RecordingProvider, build_state_with_provider, cli_context};
-    use crate::llm::{Message, MessagesResponse, ToolCall};
+    use crate::llm::calibration::{CalibrationKey, DEFAULT_FACTOR};
+    use crate::llm::{Message, MessagesResponse, ToolCall, ToolDefinition};
     use crate::storage::call_blocking;
 
     fn tool_call(id: &str, name: &str, arguments: serde_json::Value) -> ToolCall {
@@ -689,6 +718,183 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
         panic!("usage log was not written within the polling timeout");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn send_tool_phase_request_records_usage_calibration_before_payload_move() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "hello world".to_string(),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                usage: Some(crate::llm::LlmUsage {
+                    input_tokens: 1_000,
+                    output_tokens: 20,
+                }),
+            })],
+            vec![0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+        let context = cli_context("usage-calibration");
+        let llm = state.llm_for_context(&context).expect("llm");
+        let tools = Arc::new(vec![ToolDefinition {
+            name: "read".to_string(),
+            description: "Read a file".to_string(),
+            parameters: serde_json::json!({"type": "object"}),
+        }]);
+
+        let response = send_tool_phase_request(ToolPhaseRequest {
+            state: &state,
+            llm: llm.as_ref(),
+            system_prompt: "system prompt",
+            messages: Arc::new(vec![Message::text("user", "hello")]),
+            tools: Some(tools),
+            chat_id: 1,
+            caller_channel: "cli",
+            request_kind: "agent_loop",
+            usage_log_failure: "llm usage logging failed",
+            log_scope: "agent_loop",
+            send_failure_log: "LLM send_message failed",
+            iteration: 1,
+            scope: ConversationScope::Normal,
+            on_delta: &ignore_delta,
+        })
+        .await
+        .expect("tool phase response");
+
+        assert!(matches!(response, ToolPhaseResponse::Final(_)));
+        let factor = state
+            .usage_calibrator
+            .factor(&CalibrationKey::new(
+                "test",
+                "test-model",
+                "agent_loop",
+                true,
+            ))
+            .await;
+        assert!(factor > DEFAULT_FACTOR);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn send_tool_phase_request_skips_calibration_when_usage_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "hello world".to_string(),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                usage: None,
+            })],
+            vec![0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+        let context = cli_context("usage-calibration-none");
+        let llm = state.llm_for_context(&context).expect("llm");
+
+        let response = send_tool_phase_request(ToolPhaseRequest {
+            state: &state,
+            llm: llm.as_ref(),
+            system_prompt: "system prompt",
+            messages: Arc::new(vec![Message::text("user", "hello")]),
+            tools: None,
+            chat_id: 1,
+            caller_channel: "cli",
+            request_kind: "agent_loop",
+            usage_log_failure: "llm usage logging failed",
+            log_scope: "agent_loop",
+            send_failure_log: "LLM send_message failed",
+            iteration: 1,
+            scope: ConversationScope::Normal,
+            on_delta: &ignore_delta,
+        })
+        .await
+        .expect("tool phase response");
+
+        assert!(matches!(response, ToolPhaseResponse::Final(_)));
+        let factor = state
+            .usage_calibrator
+            .factor(&CalibrationKey::new(
+                "test",
+                "test-model",
+                "agent_loop",
+                false,
+            ))
+            .await;
+        assert_eq!(factor, DEFAULT_FACTOR);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn send_tool_phase_request_treats_empty_tools_as_no_tools_for_calibration() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "hello world".to_string(),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                usage: Some(crate::llm::LlmUsage {
+                    input_tokens: 1_000,
+                    output_tokens: 20,
+                }),
+            })],
+            vec![0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+        let context = cli_context("usage-calibration-empty-tools");
+        let llm = state.llm_for_context(&context).expect("llm");
+
+        let response = send_tool_phase_request(ToolPhaseRequest {
+            state: &state,
+            llm: llm.as_ref(),
+            system_prompt: "system prompt",
+            messages: Arc::new(vec![Message::text("user", "hello")]),
+            tools: Some(Arc::new(Vec::new())),
+            chat_id: 1,
+            caller_channel: "cli",
+            request_kind: "agent_loop",
+            usage_log_failure: "llm usage logging failed",
+            log_scope: "agent_loop",
+            send_failure_log: "LLM send_message failed",
+            iteration: 1,
+            scope: ConversationScope::Normal,
+            on_delta: &ignore_delta,
+        })
+        .await
+        .expect("tool phase response");
+
+        assert!(matches!(response, ToolPhaseResponse::Final(_)));
+        let without_tools = state
+            .usage_calibrator
+            .factor(&CalibrationKey::new(
+                "test",
+                "test-model",
+                "agent_loop",
+                false,
+            ))
+            .await;
+        let with_tools = state
+            .usage_calibrator
+            .factor(&CalibrationKey::new(
+                "test",
+                "test-model",
+                "agent_loop",
+                true,
+            ))
+            .await;
+        assert!(without_tools > DEFAULT_FACTOR);
+        assert_eq!(with_tools, DEFAULT_FACTOR);
     }
 
     #[tokio::test]

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -254,6 +254,7 @@ impl TurnExecutor<'_> {
             let prompt_ctx = PromptContext {
                 system_prompt: &prepared.system_prompt,
                 tools_json: prepared.tools_json.as_deref(),
+                has_tools: !prepared.tool_defs.is_empty(),
             };
 
             // 段階2: 直接入力を保存し、必要なら直後に会話履歴を圧縮する。

--- a/src/llm/calibration.rs
+++ b/src/llm/calibration.rs
@@ -1,0 +1,157 @@
+//! Runtime calibration for prompt token estimates.
+
+use std::collections::HashMap;
+
+use tokio::sync::RwLock;
+
+const EMA_ALPHA: f64 = 0.3;
+const MIN_FACTOR: f64 = 0.5;
+const MAX_FACTOR: f64 = 3.0;
+
+/// Conservative factor for unmeasured prompt estimates.
+pub(crate) const DEFAULT_FACTOR: f64 = 1.6;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct CalibrationKey {
+    pub(crate) provider: String,
+    pub(crate) model: String,
+    pub(crate) request_kind: &'static str,
+    pub(crate) has_tools: bool,
+}
+
+impl CalibrationKey {
+    pub(crate) fn new(
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        request_kind: &'static str,
+        has_tools: bool,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
+            model: model.into(),
+            request_kind,
+            has_tools,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct UsageCalibrator {
+    factors: RwLock<HashMap<CalibrationKey, f64>>,
+}
+
+impl UsageCalibrator {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) async fn factor(&self, key: &CalibrationKey) -> f64 {
+        self.factors
+            .read()
+            .await
+            .get(key)
+            .copied()
+            .unwrap_or(DEFAULT_FACTOR)
+    }
+
+    pub(crate) async fn record(&self, key: CalibrationKey, estimated: usize, actual: i64) {
+        if estimated == 0 || actual <= 0 {
+            return;
+        }
+
+        let observed = (actual as f64 / estimated as f64).clamp(MIN_FACTOR, MAX_FACTOR);
+        let mut factors = self.factors.write().await;
+        let current = factors.get(&key).copied().unwrap_or(DEFAULT_FACTOR);
+        let updated =
+            (current * (1.0 - EMA_ALPHA) + observed * EMA_ALPHA).clamp(MIN_FACTOR, MAX_FACTOR);
+        factors.insert(key, updated);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(request_kind: &'static str, has_tools: bool) -> CalibrationKey {
+        CalibrationKey::new("provider", "model", request_kind, has_tools)
+    }
+
+    #[tokio::test]
+    async fn record_raises_factor_when_actual_exceeds_estimate() {
+        let calibrator = UsageCalibrator::new();
+        let key = key("agent_loop", true);
+
+        calibrator.record(key.clone(), 100, 200).await;
+
+        assert!(calibrator.factor(&key).await > DEFAULT_FACTOR);
+    }
+
+    #[tokio::test]
+    async fn ema_moves_gradually_toward_repeated_observations() {
+        let calibrator = UsageCalibrator::new();
+        let key = key("agent_loop", true);
+
+        calibrator.record(key.clone(), 100, 300).await;
+        let first = calibrator.factor(&key).await;
+        calibrator.record(key.clone(), 100, 300).await;
+        let second = calibrator.factor(&key).await;
+
+        assert!(first > DEFAULT_FACTOR);
+        assert!(first < MAX_FACTOR);
+        assert!(second > first);
+        assert!(second < MAX_FACTOR);
+    }
+
+    #[tokio::test]
+    async fn record_clips_factor_to_bounds() {
+        let calibrator = UsageCalibrator::new();
+        let upper_key = key("agent_loop", true);
+        let lower_key = key("compaction", false);
+
+        for _ in 0..20 {
+            calibrator.record(upper_key.clone(), 1, 100).await;
+            calibrator.record(lower_key.clone(), 100, 1).await;
+        }
+
+        let upper = calibrator.factor(&upper_key).await;
+        let lower = calibrator.factor(&lower_key).await;
+        assert!(upper <= MAX_FACTOR);
+        assert!(upper > MAX_FACTOR - 0.01);
+        assert!(lower >= MIN_FACTOR);
+        assert!(lower < MIN_FACTOR + 0.01);
+    }
+
+    #[tokio::test]
+    async fn record_ignores_zero_estimate_or_non_positive_actual() {
+        let calibrator = UsageCalibrator::new();
+        let key = key("agent_loop", true);
+
+        calibrator.record(key.clone(), 0, 100).await;
+        calibrator.record(key.clone(), 100, 0).await;
+        calibrator.record(key.clone(), 100, -1).await;
+
+        assert_eq!(calibrator.factor(&key).await, DEFAULT_FACTOR);
+    }
+
+    #[tokio::test]
+    async fn factor_returns_default_for_unmeasured_key() {
+        let calibrator = UsageCalibrator::new();
+
+        assert_eq!(
+            calibrator.factor(&key("agent_loop", true)).await,
+            DEFAULT_FACTOR
+        );
+    }
+
+    #[tokio::test]
+    async fn key_keeps_request_kind_and_tool_shape_separate() {
+        let calibrator = UsageCalibrator::new();
+        let agent_key = key("agent_loop", true);
+        let compaction_key = key("compaction", false);
+
+        calibrator.record(agent_key.clone(), 100, 300).await;
+
+        assert!(calibrator.factor(&agent_key).await > DEFAULT_FACTOR);
+        assert_eq!(calibrator.factor(&compaction_key).await, DEFAULT_FACTOR);
+    }
+}

--- a/src/llm/calibration.rs
+++ b/src/llm/calibration.rs
@@ -11,15 +11,21 @@ const MAX_FACTOR: f64 = 3.0;
 /// Conservative factor for unmeasured prompt estimates.
 pub(crate) const DEFAULT_FACTOR: f64 = 1.6;
 
+/// Identifies a prompt-estimation calibration bucket.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct CalibrationKey {
+    /// LLM provider name.
     pub(crate) provider: String,
+    /// LLM model name.
     pub(crate) model: String,
+    /// Request path that produced the prompt, such as `agent_loop` or `compaction`.
     pub(crate) request_kind: &'static str,
+    /// Whether the request payload included tool definitions.
     pub(crate) has_tools: bool,
 }
 
 impl CalibrationKey {
+    /// Creates a key for one provider/model/request-shape bucket.
     pub(crate) fn new(
         provider: impl Into<String>,
         model: impl Into<String>,
@@ -35,16 +41,19 @@ impl CalibrationKey {
     }
 }
 
+/// Learns correction factors between raw prompt estimates and observed usage.
 #[derive(Default)]
 pub(crate) struct UsageCalibrator {
     factors: RwLock<HashMap<CalibrationKey, f64>>,
 }
 
 impl UsageCalibrator {
+    /// Creates an empty in-memory calibrator.
     pub(crate) fn new() -> Self {
         Self::default()
     }
 
+    /// Returns the current factor for `key`, or [`DEFAULT_FACTOR`] before measurement.
     pub(crate) async fn factor(&self, key: &CalibrationKey) -> f64 {
         self.factors
             .read()
@@ -54,6 +63,7 @@ impl UsageCalibrator {
             .unwrap_or(DEFAULT_FACTOR)
     }
 
+    /// Records an observed input token count for one raw prompt estimate.
     pub(crate) async fn record(&self, key: CalibrationKey, estimated: usize, actual: i64) {
         if estimated == 0 || actual <= 0 {
             return;
@@ -78,24 +88,30 @@ mod tests {
 
     #[tokio::test]
     async fn record_raises_factor_when_actual_exceeds_estimate() {
+        // Arrange
         let calibrator = UsageCalibrator::new();
         let key = key("agent_loop", true);
 
+        // Act
         calibrator.record(key.clone(), 100, 200).await;
 
+        // Assert
         assert!(calibrator.factor(&key).await > DEFAULT_FACTOR);
     }
 
     #[tokio::test]
     async fn ema_moves_gradually_toward_repeated_observations() {
+        // Arrange
         let calibrator = UsageCalibrator::new();
         let key = key("agent_loop", true);
 
+        // Act
         calibrator.record(key.clone(), 100, 300).await;
         let first = calibrator.factor(&key).await;
         calibrator.record(key.clone(), 100, 300).await;
         let second = calibrator.factor(&key).await;
 
+        // Assert
         assert!(first > DEFAULT_FACTOR);
         assert!(first < MAX_FACTOR);
         assert!(second > first);
@@ -104,15 +120,18 @@ mod tests {
 
     #[tokio::test]
     async fn record_clips_factor_to_bounds() {
+        // Arrange
         let calibrator = UsageCalibrator::new();
         let upper_key = key("agent_loop", true);
         let lower_key = key("compaction", false);
 
+        // Act
         for _ in 0..20 {
             calibrator.record(upper_key.clone(), 1, 100).await;
             calibrator.record(lower_key.clone(), 100, 1).await;
         }
 
+        // Assert
         let upper = calibrator.factor(&upper_key).await;
         let lower = calibrator.factor(&lower_key).await;
         assert!(upper <= MAX_FACTOR);
@@ -123,20 +142,25 @@ mod tests {
 
     #[tokio::test]
     async fn record_ignores_zero_estimate_or_non_positive_actual() {
+        // Arrange
         let calibrator = UsageCalibrator::new();
         let key = key("agent_loop", true);
 
+        // Act
         calibrator.record(key.clone(), 0, 100).await;
         calibrator.record(key.clone(), 100, 0).await;
         calibrator.record(key.clone(), 100, -1).await;
 
+        // Assert
         assert_eq!(calibrator.factor(&key).await, DEFAULT_FACTOR);
     }
 
     #[tokio::test]
     async fn factor_returns_default_for_unmeasured_key() {
+        // Arrange
         let calibrator = UsageCalibrator::new();
 
+        // Act + Assert
         assert_eq!(
             calibrator.factor(&key("agent_loop", true)).await,
             DEFAULT_FACTOR
@@ -145,12 +169,15 @@ mod tests {
 
     #[tokio::test]
     async fn key_keeps_request_kind_and_tool_shape_separate() {
+        // Arrange
         let calibrator = UsageCalibrator::new();
         let agent_key = key("agent_loop", true);
         let compaction_key = key("compaction", false);
 
+        // Act
         calibrator.record(agent_key.clone(), 100, 300).await;
 
+        // Assert
         assert!(calibrator.factor(&agent_key).await > DEFAULT_FACTOR);
         assert_eq!(calibrator.factor(&compaction_key).await, DEFAULT_FACTOR);
     }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -3,6 +3,7 @@
 //! OpenAI 互換 Chat Completions API および Responses API へのリクエスト構築・送信・
 //! レスポンス解析を行う。ツールコールに対応する。
 
+pub(crate) mod calibration;
 pub(crate) mod codex_auth;
 mod messages;
 mod openai;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,6 +36,7 @@ use crate::channels::voice::VoiceAdapter;
 use crate::channels::web::WebAdapter;
 use crate::config::Config;
 use crate::error::{ChannelError, EgoPulseError};
+use crate::llm::calibration::UsageCalibrator;
 use crate::llm::{Message, create_provider};
 use crate::memory::MemoryLoader;
 use crate::skills::SkillManager;
@@ -69,6 +70,8 @@ pub struct AppState {
     pub(crate) turn_tracker: Arc<turn_scheduler::TurnTracker>,
     /// In-memory runtime health summary for observability.
     pub(crate) runtime_status: Arc<RuntimeStatus>,
+    /// Learns prompt-token estimate correction factors from observed LLM usage.
+    pub(crate) usage_calibrator: Arc<UsageCalibrator>,
     _sealed: (),
 }
 
@@ -130,6 +133,7 @@ impl AppState {
             turn_scheduler: Arc::new(turn_scheduler::TurnScheduler::new()),
             turn_tracker: Arc::new(turn_scheduler::TurnTracker::new()),
             runtime_status: parts.runtime_status,
+            usage_calibrator: Arc::new(UsageCalibrator::new()),
             _sealed: (),
         }
     }


### PR DESCRIPTION
## 概要
Safety Compaction の token 推定に、実測 `usage.input_tokens` で校正するメモリ内補正係数を追加しました。

- `bytes / 3` の raw estimate に `UsageCalibrator` の factor を適用
- agent loop / compaction summarizer の LLM usage から EMA で factor を更新
- 未計測時は `DEFAULT_FACTOR = 1.6` を使用
- 設定追加・DB API 追加・外部 tokenizer 依存はなし
- compaction 後 target 判定にも同じ補正推定を適用

## テスト
- `cargo fmt --check`
- `cargo check --all-features`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- refactor 後再確認: `cargo test compaction`

## 補足
該当 Issue なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 実測ベースの補正式で自動メッセージ圧縮のトークン推定をハイブリッド化し、より実利用に近い判定を行います。
* **改善**
  * 推定は `bytes/3` 相当から開始し、`provider / model / request_kind / ツール有無` 単位でEMAにより継続校正。未計測時は既定係数で保守的に補正し、圧縮発火・目標サイズ判定に同じ推定を反映します。
* **ドキュメント**
  * 圧縮トークン推定とセッション手順を更新しました。
* **テスト**
  * 係数更新やE2Eの検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->