### PR TITLE
feat(pulse): N日ごとの interval スケジュール kind を追加

### DIFF
--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -321,7 +321,7 @@ pulse:
 | -------------------------- | -------------------------------- |
 | `pulse.enabled`            | Pulse 全体の有効化                     |
 | `pulse.tick_interval`      | due scan の周期（Duration 形式: `30s`, `1m`, `1h`） |
-| `pulse.timezone`           | daily / weekly 判定の timezone      |
+| `pulse.timezone`           | daily / weekly / interval 判定の timezone      |
 
 Temporal Intention の中身は config に置かない。
 それは agent の注意方針なので、`agents/{agent_id}/PULSE.md` に置く。
@@ -330,7 +330,7 @@ Temporal Intention の中身は config に置かない。
 
 # 4. Temporal Intention 仕様
 
-Phase 1 で対応する schedule は3種類のみ。
+Phase 1 で対応する schedule は以下の 4 種類。
 
 ## daily
 
@@ -349,16 +349,46 @@ schedule:
   at: "21:00"
 ```
 
+## interval
+
+`interval_days` 日ごとに発火する。起点は**前回成功した発火日**（`pulse_runs.status = success` の最新 `started_at`）。
+
+```yaml
+schedule:
+  kind: interval
+  interval_days: 3
+  at: "09:00"
+```
+
+`daily` / `weekly` がカレンダー期間固定の絶対基準であるのに対し、`interval` は**意図の達成（=成功）を起点とする相対基準**である。この違いにより、失敗時の扱いが異なる。
+
+### 失敗時の挙動（意図駆動リトライ）
+
+前回成功日を起点にするため、失敗しても起点は更新されず、`interval_days` 経過後は**成功するまで毎日再評価される**。ただし `due_key` が評価日単位で進むため、1 日 1 回まで（翌日リトライ）。
+
+| 日付 | 状態 | due | 備考 |
+|---|---|:---:|---|
+| 07/03 | 成功 | — | `last_success = 07/03` に更新 |
+| 07/04〜05 | skip | ✗ | `07/03 + 3日 = 07/06` 未到 |
+| 07/06 | 発火→**失敗** | ✓ | `last_success` は更新されず `07/03` のまま |
+| 07/07 | 発火→成功 | ✓ | `due_key` が 07/07 に進むため再試行可能 |
+| 07/08〜09 | skip | ✗ | `07/07 + 3日 = 07/10` 未到 |
+| 07/10 | 発火 | ✓ | — |
+
+初回（`last_success = None`）は時刻判定のみで due になる。
+
 ## validation
 
 | 項目                          | 仕様                          |
 | --------------------------- | --------------------------- |
 | `id`                        | agent 内で一意                  |
 | `enabled`                   | `true` / `false`。省略時 `true`。`false` のときその intention の due 判定・実行をスキップする |
-| `schedule.kind`             | `daily` / `weekly` |
+| `schedule.kind`             | `daily` / `weekly` / `interval` |
 | `daily.at`                  | `HH:MM`                     |
 | `weekly.day`                | `mon`〜`sun`                 |
 | `weekly.at`                 | `HH:MM`                     |
+| `interval.interval_days`    | `1` 以上の整数                 |
+| `interval.at`               | `HH:MM`                     |
 | `attention`                 | LLM に渡す注意対象。実行命令ではない        |
 | `default_delivery`          | 省略可能。agent レベルのデフォルト配送先     |
 | `default_delivery.channel`  | `discord` / `telegram` のみ   |
@@ -389,7 +419,7 @@ schedule:
                ▼
 ┌──────────────────────────────┐
 │        Temporal Due Resolver  │
-│ daily / weekly 判定     │
+│ daily / weekly / interval 判定     │
 └──────────────┬───────────────┘
                │ due
                ▼
@@ -438,6 +468,13 @@ weekly:
   今日の曜日 == day
   かつ 今日の日付 + at <= now
   かつ due_key 未実行
+
+interval:
+  今日のローカル日付 >= 前回成功日 + interval_days
+  かつ 今日の日付 + at <= now
+  かつ due_key 未実行
+  ※ 前回成功日 = pulse_runs.status='success' の最新 started_at
+  ※ 前回成功日が無い（初回）場合は日付条件をスキップ（時刻判定のみ）
 ```
 
 ## due_key
@@ -448,6 +485,9 @@ weekly:
 | -------- | -------------------------------------------- |
 | daily    | `lyre:morning_review:2026-05-10`             |
 | weekly   | `kitara:weekly_reflection:2026-W19`          |
+| interval | `lyre:periodic_report:2026-05-10`            |
+
+`interval` の `due_key` は評価日（今日のローカル日付）。前回成功日ではない。これにより、失敗した日は `due_key` が消費され、翌日は別の `due_key` で再評価される（意図駆動リトライ）。
 
 ---
 
@@ -684,7 +724,7 @@ src/
 | ------------------------------ | ----------------------------------------------------- |
 | `pulse` config                 | enabled / tick_interval / timezone |
 | `PULSE.md` front matter parser | Temporal Intention を読む                                |
-| due 判定                         | daily / weekly                                 |
+| due 判定                         | daily / weekly / interval                                 |
 | duplicate 判定                   | `pulse_runs` の `due_key`                              |
 | active turn defer              | agent active 中は起こさない                                  |
 | Home Surface 解決                | agent の最後の会話場所を使う                                     |
@@ -738,7 +778,7 @@ src/
   Attention:
   {attention}
   ```
-  - `Schedule` は `daily 08:00`, `weekly sun 21:00` の形式
+  - `Schedule` は `daily 08:00`, `weekly sun 21:00`, `every 3 days 09:00` の形式
   - `Attention` は PULSE.md の intention 定義そのまま
 - sender_name は `Pulse`、message_kind は `SystemEvent`
 - ユーザーが Pulse 通知に返信すると、通常 turn が文脈（intention の目的・スケジュール・指示内容）を引き継げる

--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -330,7 +330,7 @@ Temporal Intention の中身は config に置かない。
 
 # 4. Temporal Intention 仕様
 
-Phase 1 で対応する schedule は以下の 4 種類。
+対応する schedule は以下の 4 種類。
 
 ## daily
 

--- a/src/pulse/definition.rs
+++ b/src/pulse/definition.rs
@@ -29,8 +29,20 @@ pub(crate) struct TemporalIntention {
 
 #[derive(Clone, Debug)]
 pub(crate) enum TemporalSchedule {
-    Daily { at: String },
-    Weekly { day: String, at: String },
+    Daily {
+        at: String,
+    },
+    Weekly {
+        day: String,
+        at: String,
+    },
+    /// Fire every `interval_days` days, anchored to the most recent successful
+    /// activation. Re-evaluates as due each day once the interval has elapsed
+    /// until a run succeeds; see `docs/pulse.md` §4.
+    Interval {
+        interval_days: u32,
+        at: String,
+    },
 }
 
 #[derive(Debug, Error)]
@@ -82,6 +94,7 @@ struct ScheduleRaw {
     kind: String,
     at: String,
     day: Option<String>,
+    interval_days: Option<u32>,
 }
 
 #[derive(Deserialize)]
@@ -237,6 +250,15 @@ fn validate_and_build_schedule(
                 at: raw.schedule.at.clone(),
             })
         }
+        "interval" => {
+            let interval_days = raw.schedule.interval_days.unwrap_or(0);
+            validate_interval_days(agent_id, &raw.id, interval_days)?;
+            validate_hhmm(agent_id, &raw.id, &raw.schedule.at)?;
+            Ok(TemporalSchedule::Interval {
+                interval_days,
+                at: raw.schedule.at.clone(),
+            })
+        }
         "once" => Err(PulseParseError::InvalidSchedule {
             agent_id: agent_id.to_string(),
             intention_id: raw.id.clone(),
@@ -271,6 +293,21 @@ fn validate_hhmm(agent_id: &str, intention_id: &str, at: &str) -> Result<(), Pul
     Ok(())
 }
 
+fn validate_interval_days(
+    agent_id: &str,
+    intention_id: &str,
+    interval_days: u32,
+) -> Result<(), PulseParseError> {
+    if interval_days == 0 {
+        return Err(PulseParseError::InvalidSchedule {
+            agent_id: agent_id.to_string(),
+            intention_id: intention_id.to_string(),
+            detail: "interval_days must be >= 1".to_string(),
+        });
+    }
+    Ok(())
+}
+
 const VALID_WEEKDAYS: &[&str] = &["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 
 fn validate_weekday(agent_id: &str, intention_id: &str, day: &str) -> Result<(), PulseParseError> {
@@ -298,10 +335,14 @@ fn is_safe_agent_id(id: &str) -> bool {
 /// # Examples
 /// - `Daily { at: "08:00" }` → `"daily 08:00"`
 /// - `Weekly { day: "sun", at: "21:00" }` → `"weekly sun 21:00"`
+/// - `Interval { interval_days: 3, at: "09:00" }` → `"every 3 days 09:00"`
 pub(crate) fn format_schedule(schedule: &TemporalSchedule) -> String {
     match schedule {
         TemporalSchedule::Daily { at } => format!("daily {at}"),
         TemporalSchedule::Weekly { day, at } => format!("weekly {day} {at}"),
+        TemporalSchedule::Interval { interval_days, at } => {
+            format!("every {interval_days} days {at}")
+        }
     }
 }
 
@@ -353,17 +394,24 @@ pub(crate) struct DueCheck {
 ///
 /// `agent_id` identifies the agent for due_key generation.
 /// `now` is the current UTC time.
-/// `timezone` is the IANA timezone for daily/weekly evaluation (e.g. "Asia/Tokyo").
+/// `timezone` is the IANA timezone for daily/weekly/interval evaluation (e.g. "Asia/Tokyo").
+/// `last_success_at` is the most recent successful activation time for this
+/// `(agent_id, intention_id)`. Only `interval` schedules consult it; `daily`
+/// and `weekly` ignore it.
 pub(crate) fn check_due(
     agent_id: &str,
     intention: &TemporalIntention,
     now: DateTime<Utc>,
     timezone: &str,
+    last_success_at: Option<DateTime<Utc>>,
 ) -> DueCheck {
-    let due_key = generate_due_key(agent_id, intention, now, timezone);
+    let due_key = generate_due_key(agent_id, intention, now, timezone, last_success_at);
     let due = match &intention.schedule {
         TemporalSchedule::Daily { at } => is_daily_due(at, now, timezone),
         TemporalSchedule::Weekly { day, at } => is_weekly_due(day, at, now, timezone),
+        TemporalSchedule::Interval { interval_days, at } => {
+            is_interval_due(*interval_days, at, now, timezone, last_success_at)
+        }
     };
     DueCheck { due, due_key }
 }
@@ -371,18 +419,22 @@ pub(crate) fn check_due(
 /// Generate the deduplication key for a given intention at the current evaluation time.
 ///
 /// Format per schedule kind:
-/// - daily:  `{agent_id}:{intention_id}:{YYYY-MM-DD}` (local date)
-/// - weekly: `{agent_id}:{intention_id}:{YYYY-WNN}`   (ISO week)
+/// - daily:    `{agent_id}:{intention_id}:{YYYY-MM-DD}` (local date)
+/// - weekly:   `{agent_id}:{intention_id}:{YYYY-WNN}`   (ISO week)
+/// - interval: `{agent_id}:{intention_id}:{YYYY-MM-DD}` (local evaluation date;
+///   advances each day so a failed run can be retried on the next day while
+///   the interval window remains open)
 pub(crate) fn generate_due_key(
     agent_id: &str,
     intention: &TemporalIntention,
     now: DateTime<Utc>,
     timezone: &str,
+    _last_success_at: Option<DateTime<Utc>>,
 ) -> String {
     let tz: Tz = timezone.parse().unwrap_or(Tz::UTC);
+    let local_now = now.with_timezone(&tz);
     match &intention.schedule {
-        TemporalSchedule::Daily { .. } => {
-            let local_now = now.with_timezone(&tz);
+        TemporalSchedule::Daily { .. } | TemporalSchedule::Interval { .. } => {
             format!(
                 "{agent_id}:{}:{}",
                 intention.id,
@@ -390,7 +442,6 @@ pub(crate) fn generate_due_key(
             )
         }
         TemporalSchedule::Weekly { .. } => {
-            let local_now = now.with_timezone(&tz);
             let iso = local_now.iso_week();
             format!(
                 "{agent_id}:{}:{}-W{:02}",
@@ -465,6 +516,42 @@ fn is_weekly_due(day: &str, at: &str, now: DateTime<Utc>, timezone: &str) -> boo
     is_daily_due(at, now, timezone)
 }
 
+/// Evaluate interval schedule: fire when the local date has reached
+/// `last_success_date + interval_days`, then delegate to the daily time
+/// check.
+///
+/// - `last_success_at = None` (first activation): only the time-of-day check applies.
+/// - Once due, the same condition stays true on subsequent days until a run
+///   succeeds, because `last_success_at` only advances on success. The
+///   per-day deduplication is handled by the `due_key` (local evaluation
+///   date), so a failed run is retried on the following day.
+fn is_interval_due(
+    interval_days: u32,
+    at: &str,
+    now: DateTime<Utc>,
+    timezone: &str,
+    last_success_at: Option<DateTime<Utc>>,
+) -> bool {
+    let tz: Tz = match timezone.parse() {
+        Ok(tz) => tz,
+        Err(e) => {
+            tracing::warn!("invalid timezone \"{timezone}\": {e}");
+            return false;
+        }
+    };
+
+    let local_today = now.with_timezone(&tz).date_naive();
+    if let Some(last_success) = last_success_at {
+        let target_date = last_success.with_timezone(&tz).date_naive()
+            + chrono::Duration::days(interval_days as i64);
+        if local_today < target_date {
+            return false;
+        }
+    }
+
+    is_daily_due(at, now, timezone)
+}
+
 /// Parse a `HH:MM` time string into a [`NaiveTime`].
 fn parse_hhmm(at: &str) -> Option<NaiveTime> {
     NaiveTime::parse_from_str(at, "%H:%M").ok()
@@ -503,6 +590,15 @@ mod tests {
             at: "21:00".to_string(),
         };
         assert_eq!(format_schedule(&schedule), "weekly sun 21:00");
+    }
+
+    #[test]
+    fn format_schedule_interval() {
+        let schedule = TemporalSchedule::Interval {
+            interval_days: 3,
+            at: "09:00".to_string(),
+        };
+        assert_eq!(format_schedule(&schedule), "every 3 days 09:00");
     }
 
     fn valid_pulse_md() -> String {
@@ -592,6 +688,76 @@ body
         assert!(
             matches!(err, PulseParseError::InvalidSchedule { ref intention_id, .. } if intention_id == "event_check"),
             "expected InvalidSchedule for once, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_interval_intention() {
+        let content = "\
+---
+version: 1
+intentions:
+  - id: periodic_report
+    schedule:
+      kind: interval
+      interval_days: 3
+      at: \"09:00\"
+    attention: test
+---
+
+body
+";
+        let result = parse_pulse_definition(content).expect("should parse");
+        assert_eq!(result.intentions.len(), 1);
+        assert!(matches!(
+            &result.intentions[0].schedule,
+            TemporalSchedule::Interval { interval_days, at }
+                if *interval_days == 3 && at == "09:00"
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_zero_interval_days() {
+        let content = "\
+---
+version: 1
+intentions:
+  - id: periodic_report
+    schedule:
+      kind: interval
+      interval_days: 0
+      at: \"09:00\"
+    attention: test
+---
+
+body
+";
+        let err = parse_pulse_definition(content).unwrap_err();
+        assert!(
+            matches!(err, PulseParseError::InvalidSchedule { ref intention_id, .. } if intention_id == "periodic_report"),
+            "expected InvalidSchedule for interval_days=0, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_interval_with_missing_interval_days() {
+        let content = "\
+---
+version: 1
+intentions:
+  - id: periodic_report
+    schedule:
+      kind: interval
+      at: \"09:00\"
+    attention: test
+---
+
+body
+";
+        let err = parse_pulse_definition(content).unwrap_err();
+        assert!(
+            matches!(err, PulseParseError::InvalidSchedule { ref intention_id, .. } if intention_id == "periodic_report"),
+            "missing interval_days should be rejected, got: {err}"
         );
     }
 
@@ -762,6 +928,19 @@ body
         }
     }
 
+    fn make_interval(interval_days: u32, at: &str) -> TemporalIntention {
+        TemporalIntention {
+            id: "test_intention".to_string(),
+            enabled: true,
+            schedule: TemporalSchedule::Interval {
+                interval_days,
+                at: at.to_string(),
+            },
+            attention: String::new(),
+            delivery: None,
+        }
+    }
+
     fn utc(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> DateTime<Utc> {
         Utc.with_ymd_and_hms(y, mo, d, h, mi, s).unwrap()
     }
@@ -770,7 +949,7 @@ body
     fn daily_due_after_local_time() {
         let intention = make_daily("09:00");
         let now = utc(2026, 5, 10, 0, 1, 0);
-        let result = check_due("lyre", &intention, now, "Asia/Tokyo");
+        let result = check_due("lyre", &intention, now, "Asia/Tokyo", None);
         assert!(result.due);
     }
 
@@ -778,7 +957,7 @@ body
     fn daily_not_due_before_local_time() {
         let intention = make_daily("09:00");
         let now = utc(2026, 5, 9, 23, 59, 0);
-        let result = check_due("lyre", &intention, now, "Asia/Tokyo");
+        let result = check_due("lyre", &intention, now, "Asia/Tokyo", None);
         assert!(!result.due);
     }
 
@@ -786,9 +965,9 @@ body
     fn weekly_due_only_on_matching_day() {
         let intention = make_weekly("sun", "21:00");
         let sunday = utc(2026, 5, 10, 12, 1, 0);
-        assert!(check_due("lyre", &intention, sunday, "Asia/Tokyo").due);
+        assert!(check_due("lyre", &intention, sunday, "Asia/Tokyo", None).due);
         let saturday = utc(2026, 5, 9, 12, 1, 0);
-        assert!(!check_due("lyre", &intention, saturday, "Asia/Tokyo").due);
+        assert!(!check_due("lyre", &intention, saturday, "Asia/Tokyo", None).due);
     }
 
     #[test]
@@ -803,7 +982,7 @@ body
             delivery: None,
         };
         let now = utc(2026, 5, 10, 0, 0, 0);
-        let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo");
+        let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo", None);
         assert_eq!(key, "lyre:morning_review:2026-05-10");
     }
 
@@ -820,15 +999,167 @@ body
             delivery: None,
         };
         let now = utc(2026, 5, 10, 12, 0, 0);
-        let key = generate_due_key("kitara", &intention, now, "Asia/Tokyo");
+        let key = generate_due_key("kitara", &intention, now, "Asia/Tokyo", None);
         assert_eq!(key, "kitara:weekly_reflection:2026-W19");
+    }
+
+    // --- interval schedule tests ---
+
+    #[test]
+    fn interval_due_on_first_run_without_last_success() {
+        // interval=3, at=09:00 JST. last_success=None → only time-of-day applies.
+        let intention = make_interval(3, "09:00");
+        let before = utc(2026, 7, 5, 23, 59, 0); // 08:59 JST
+        assert!(!check_due("lyre", &intention, before, "Asia/Tokyo", None).due);
+        let after = utc(2026, 7, 6, 0, 1, 0); // 09:01 JST
+        assert!(check_due("lyre", &intention, after, "Asia/Tokyo", None).due);
+    }
+
+    #[test]
+    fn interval_not_due_before_interval_elapsed() {
+        // last_success = 2026-07-03 09:01 JST, interval=3 → next target = 2026-07-06
+        let intention = make_interval(3, "09:00");
+        let last_success = utc(2026, 7, 3, 0, 1, 0); // 2026-07-03 09:01 JST
+
+        // 2026-07-05 09:01 JST: interval not yet elapsed → not due
+        let within_interval = utc(2026, 7, 5, 0, 1, 0);
+        assert!(
+            !check_due(
+                "lyre",
+                &intention,
+                within_interval,
+                "Asia/Tokyo",
+                Some(last_success)
+            )
+            .due
+        );
+    }
+
+    #[test]
+    fn interval_due_on_target_day_after_last_success() {
+        // last_success = 2026-07-03 09:01 JST, interval=3 → target = 2026-07-06
+        let intention = make_interval(3, "09:00");
+        let last_success = utc(2026, 7, 3, 0, 1, 0); // 2026-07-03 09:01 JST
+
+        // 2026-07-06 08:59 JST: target day but before at → not due
+        let before_at = utc(2026, 7, 5, 23, 59, 0);
+        assert!(
+            !check_due(
+                "lyre",
+                &intention,
+                before_at,
+                "Asia/Tokyo",
+                Some(last_success)
+            )
+            .due
+        );
+
+        // 2026-07-06 09:01 JST: due
+        let on_target = utc(2026, 7, 6, 0, 1, 0);
+        assert!(
+            check_due(
+                "lyre",
+                &intention,
+                on_target,
+                "Asia/Tokyo",
+                Some(last_success)
+            )
+            .due
+        );
+    }
+
+    #[test]
+    fn interval_remains_due_each_day_until_success() {
+        // Failure recovery: last_success stays at 2026-07-03, so every day
+        // from 2026-07-06 onward is due (one run per day via due_key).
+        let intention = make_interval(3, "09:00");
+        let last_success = utc(2026, 7, 3, 0, 1, 0);
+
+        // 2026-07-06 09:01 JST (target day)
+        assert!(
+            check_due(
+                "lyre",
+                &intention,
+                utc(2026, 7, 6, 0, 1, 0),
+                "Asia/Tokyo",
+                Some(last_success)
+            )
+            .due
+        );
+        // 2026-07-07 09:01 JST (still past target, last_success unchanged)
+        assert!(
+            check_due(
+                "lyre",
+                &intention,
+                utc(2026, 7, 7, 0, 1, 0),
+                "Asia/Tokyo",
+                Some(last_success)
+            )
+            .due
+        );
+    }
+
+    #[test]
+    fn interval_due_advances_when_last_success_passes_target() {
+        // A success on 2026-07-06 shifts the next target to 2026-07-09.
+        let intention = make_interval(3, "09:00");
+        let last_success = utc(2026, 7, 6, 0, 1, 0); // success on target day
+
+        // 2026-07-08 09:01 JST: new interval not yet elapsed → not due
+        assert!(
+            !check_due(
+                "lyre",
+                &intention,
+                utc(2026, 7, 8, 0, 1, 0),
+                "Asia/Tokyo",
+                Some(last_success)
+            )
+            .due
+        );
+        // 2026-07-09 09:01 JST: new target reached → due
+        assert!(
+            check_due(
+                "lyre",
+                &intention,
+                utc(2026, 7, 9, 0, 1, 0),
+                "Asia/Tokyo",
+                Some(last_success)
+            )
+            .due
+        );
+    }
+
+    #[test]
+    fn due_key_interval_uses_local_evaluation_date() {
+        let intention = make_interval(3, "09:00");
+        let now = utc(2026, 7, 6, 0, 0, 0); // 2026-07-06 09:00 JST
+        let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo", None);
+        assert_eq!(key, "lyre:test_intention:2026-07-06");
+
+        // due_key advances each day regardless of last_success, enabling
+        // next-day retry after a failure.
+        let next_day = utc(2026, 7, 7, 0, 0, 0);
+        let key = generate_due_key(
+            "lyre",
+            &intention,
+            next_day,
+            "Asia/Tokyo",
+            Some(utc(2026, 7, 6, 0, 0, 0)),
+        );
+        assert_eq!(key, "lyre:test_intention:2026-07-07");
     }
 
     #[test]
     fn due_resolver_handles_dst_gap_and_fold() {
         let gap_intention = make_daily("02:30");
         let now_after_gap = utc(2026, 3, 8, 7, 30, 0);
-        let result = check_due("test", &gap_intention, now_after_gap, "America/New_York");
+        let result = check_due(
+            "test",
+            &gap_intention,
+            now_after_gap,
+            "America/New_York",
+            None,
+        );
         assert!(
             !result.due,
             "intention at 02:30 should not be due during DST gap"
@@ -842,6 +1173,7 @@ body
             &fold_intention,
             now_after_earlier,
             "America/New_York",
+            None,
         );
         assert!(result.due);
 
@@ -851,6 +1183,7 @@ body
             &fold_intention,
             now_before_earlier,
             "America/New_York",
+            None,
         );
         assert!(!result.due);
     }

--- a/src/pulse/definition.rs
+++ b/src/pulse/definition.rs
@@ -405,7 +405,7 @@ pub(crate) fn check_due(
     timezone: &str,
     last_success_at: Option<DateTime<Utc>>,
 ) -> DueCheck {
-    let due_key = generate_due_key(agent_id, intention, now, timezone, last_success_at);
+    let due_key = generate_due_key(agent_id, intention, now, timezone);
     let due = match &intention.schedule {
         TemporalSchedule::Daily { at } => is_daily_due(at, now, timezone),
         TemporalSchedule::Weekly { day, at } => is_weekly_due(day, at, now, timezone),
@@ -429,7 +429,6 @@ pub(crate) fn generate_due_key(
     intention: &TemporalIntention,
     now: DateTime<Utc>,
     timezone: &str,
-    _last_success_at: Option<DateTime<Utc>>,
 ) -> String {
     let tz: Tz = timezone.parse().unwrap_or(Tz::UTC);
     let local_now = now.with_timezone(&tz);
@@ -982,7 +981,7 @@ body
             delivery: None,
         };
         let now = utc(2026, 5, 10, 0, 0, 0);
-        let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo", None);
+        let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo");
         assert_eq!(key, "lyre:morning_review:2026-05-10");
     }
 
@@ -999,7 +998,7 @@ body
             delivery: None,
         };
         let now = utc(2026, 5, 10, 12, 0, 0);
-        let key = generate_due_key("kitara", &intention, now, "Asia/Tokyo", None);
+        let key = generate_due_key("kitara", &intention, now, "Asia/Tokyo");
         assert_eq!(key, "kitara:weekly_reflection:2026-W19");
     }
 
@@ -1133,19 +1132,13 @@ body
     fn due_key_interval_uses_local_evaluation_date() {
         let intention = make_interval(3, "09:00");
         let now = utc(2026, 7, 6, 0, 0, 0); // 2026-07-06 09:00 JST
-        let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo", None);
+        let key = generate_due_key("lyre", &intention, now, "Asia/Tokyo");
         assert_eq!(key, "lyre:test_intention:2026-07-06");
 
-        // due_key advances each day regardless of last_success, enabling
-        // next-day retry after a failure.
+        // due_key advances each evaluation day, enabling a next-day retry
+        // after a failed run within the same open interval window.
         let next_day = utc(2026, 7, 7, 0, 0, 0);
-        let key = generate_due_key(
-            "lyre",
-            &intention,
-            next_day,
-            "Asia/Tokyo",
-            Some(utc(2026, 7, 6, 0, 0, 0)),
-        );
+        let key = generate_due_key("lyre", &intention, next_day, "Asia/Tokyo");
         assert_eq!(key, "lyre:test_intention:2026-07-07");
     }
 

--- a/src/pulse/scheduler.rs
+++ b/src/pulse/scheduler.rs
@@ -160,7 +160,23 @@ async fn process_intention_with_activation_timeout(
     }
 
     // 2. Check due
-    let due_check = super::definition::check_due(agent_id_str, intention, now, timezone);
+    //    `interval` schedules anchor on the last successful activation, so we
+    //    fetch it before evaluating. `daily`/`weekly` ignore this value.
+    let last_success_at =
+        match load_last_success_started_at(&state.db, agent_id_str, &intention.id).await {
+            Ok(dt) => dt,
+            Err(e) => {
+                warn!(
+                    agent_id = agent_id_str,
+                    intention_id = %intention.id,
+                    error = %e,
+                    "pulse scan: failed to load last_success_at, skipping intention"
+                );
+                return;
+            }
+        };
+    let due_check =
+        super::definition::check_due(agent_id_str, intention, now, timezone, last_success_at);
     if !due_check.due {
         return;
     }
@@ -375,6 +391,22 @@ async fn load_recent_messages(db: &Arc<Database>, chat_id: i64) -> Vec<String> {
     .unwrap_or_default()
 }
 
+/// Load the most recent successful activation time for `(agent_id,
+/// intention_id)`. Used to evaluate `interval` schedules relative to the
+/// last success; `daily`/`weekly` intentions ignore the result.
+async fn load_last_success_started_at(
+    db: &Arc<Database>,
+    agent_id: &str,
+    intention_id: &str,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, crate::error::StorageError> {
+    let agent_id = agent_id.to_string();
+    let intention_id = intention_id.to_string();
+    crate::storage::call_blocking(Arc::clone(db), move |db| {
+        db.get_last_success_started_at(&agent_id, &intention_id)
+    })
+    .await
+}
+
 /// Run the pulse scheduler tick loop.
 ///
 /// Sleeps for the configured tick interval between scans.
@@ -466,6 +498,52 @@ intentions:
 Some notes.
 "
         .to_string()
+    }
+
+    fn valid_interval_pulse_md() -> String {
+        "\
+---
+version: 1
+intentions:
+  - id: periodic_report
+    schedule:
+      kind: interval
+      interval_days: 3
+      at: \"00:00\"
+    attention: Periodic report.
+---
+
+# Notes
+Some notes.
+"
+        .to_string()
+    }
+
+    /// Inserts a terminal `success` pulse_run with an explicit `started_at`,
+    /// bypassing the running→success lifecycle. Used to simulate a past
+    /// successful activation when testing `interval` schedules.
+    fn insert_success_run(
+        db: &Arc<Database>,
+        id: &str,
+        agent_id: &str,
+        intention_id: &str,
+        started_at: &str,
+    ) {
+        let conn = db.get_conn().expect("pool");
+        conn.execute(
+            "INSERT INTO pulse_runs
+                 (id, agent_id, intention_id, due_key, chat_id, message_id,
+                  status, started_at, finished_at, output_kind, output_text, error_message)
+             VALUES (?1, ?2, ?3, ?4, NULL, NULL, 'success', ?5, ?5, 'silent', 'PULSE_OK', NULL)",
+            rusqlite::params![
+                id,
+                agent_id,
+                intention_id,
+                format!("{agent_id}:{intention_id}:past"),
+                started_at
+            ],
+        )
+        .expect("insert success run");
     }
 
     fn count_agent_runs(db: &Arc<Database>, agent_id: &str) -> usize {
@@ -617,6 +695,102 @@ body
             count_agent_runs(&state.db, "agent-b"),
             1,
             "agent-b should have 1 run"
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_runs_interval_intention_on_first_scan() {
+        // Arrange: no prior success → first activation should fire immediately
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_pulse_state(
+            &dir,
+            enabled_pulse_config(),
+            vec![("default", &valid_interval_pulse_md())],
+        );
+
+        let _chat = state
+            .db
+            .resolve_or_create_chat_id("discord", "discord:123", None, "dm", "default")
+            .expect("chat");
+
+        // Act
+        run_pulse_scan(&state).await;
+
+        // Assert
+        assert_eq!(
+            count_agent_runs(&state.db, "default"),
+            1,
+            "first interval scan should fire once"
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_skips_interval_intention_within_window() {
+        // Arrange: a success 1 day ago, interval=3 → window not yet elapsed
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_pulse_state(
+            &dir,
+            enabled_pulse_config(),
+            vec![("default", &valid_interval_pulse_md())],
+        );
+
+        let _chat = state
+            .db
+            .resolve_or_create_chat_id("discord", "discord:123", None, "dm", "default")
+            .expect("chat");
+
+        let one_day_ago = (chrono::Utc::now() - chrono::Duration::days(1)).to_rfc3339();
+        insert_success_run(
+            &state.db,
+            "past-success",
+            "default",
+            "periodic_report",
+            &one_day_ago,
+        );
+
+        // Act
+        run_pulse_scan(&state).await;
+
+        // Assert: no new run created (only the pre-inserted success remains)
+        assert_eq!(
+            count_agent_runs(&state.db, "default"),
+            1,
+            "should not fire within the interval window after a success"
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_fires_interval_intention_after_window_elapsed() {
+        // Arrange: a success 5 days ago, interval=3 → window elapsed → due
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_pulse_state(
+            &dir,
+            enabled_pulse_config(),
+            vec![("default", &valid_interval_pulse_md())],
+        );
+
+        let _chat = state
+            .db
+            .resolve_or_create_chat_id("discord", "discord:123", None, "dm", "default")
+            .expect("chat");
+
+        let five_days_ago = (chrono::Utc::now() - chrono::Duration::days(5)).to_rfc3339();
+        insert_success_run(
+            &state.db,
+            "past-success",
+            "default",
+            "periodic_report",
+            &five_days_ago,
+        );
+
+        // Act
+        run_pulse_scan(&state).await;
+
+        // Assert: a new run is created on top of the pre-inserted one
+        assert_eq!(
+            count_agent_runs(&state.db, "default"),
+            2,
+            "should fire once the interval window has elapsed"
         );
     }
 

--- a/src/pulse/scheduler.rs
+++ b/src/pulse/scheduler.rs
@@ -160,9 +160,13 @@ async fn process_intention_with_activation_timeout(
     }
 
     // 2. Check due
-    //    `interval` schedules anchor on the last successful activation, so we
-    //    fetch it before evaluating. `daily`/`weekly` ignore this value.
-    let last_success_at =
+    //    `interval` schedules anchor on the most recent successful activation,
+    //    so we fetch it only for that schedule kind. `daily`/`weekly` never
+    //    consult this value and must not be affected by a fetch failure.
+    let last_success_at = if matches!(
+        intention.schedule,
+        super::definition::TemporalSchedule::Interval { .. }
+    ) {
         match load_last_success_started_at(&state.db, agent_id_str, &intention.id).await {
             Ok(dt) => dt,
             Err(e) => {
@@ -174,7 +178,10 @@ async fn process_intention_with_activation_timeout(
                 );
                 return;
             }
-        };
+        }
+    } else {
+        None
+    };
     let due_check =
         super::definition::check_due(agent_id_str, intention, now, timezone, last_success_at);
     if !due_check.due {

--- a/src/storage/pulse.rs
+++ b/src/storage/pulse.rs
@@ -215,9 +215,16 @@ impl Database {
                 |row| row.get(0),
             )
             .optional()?;
-        Ok(raw
-            .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
-            .map(|dt| dt.with_timezone(&chrono::Utc)))
+        raw.map(|s| {
+            chrono::DateTime::parse_from_rfc3339(&s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| {
+                    StorageError::InvalidAsset(format!(
+                        "corrupt pulse_run started_at value {s:?}: {e}"
+                    ))
+                })
+        })
+        .transpose()
     }
 
     /// Returns `true` when any record exists for `(agent_id, intention_id,
@@ -771,6 +778,32 @@ mod tests {
             db.get_last_success_started_at("agent-a", "int-9")
                 .expect("query")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn get_last_success_started_at_surfaces_corrupt_timestamp_as_error() {
+        let (db, _dir) = test_db();
+
+        // Arrange: a success row whose started_at is not a valid RFC3339 value.
+        // Must not be silently coerced to None, because interval schedules
+        // would then treat the intention as "never succeeded" and fire
+        // immediately (duplicate / unintended activation).
+        insert_terminal_pulse_run(
+            &db,
+            "run-corrupt",
+            "agent-a",
+            "int-1",
+            "2025-01-01",
+            "not-a-valid-timestamp",
+            PulseRunStatus::Success,
+        );
+
+        let result = db.get_last_success_started_at("agent-a", "int-1");
+
+        assert!(
+            matches!(result, Err(StorageError::InvalidAsset(_))),
+            "corrupt started_at should surface as InvalidAsset, got: {result:?}"
         );
     }
 

--- a/src/storage/pulse.rs
+++ b/src/storage/pulse.rs
@@ -186,6 +186,40 @@ impl Database {
         Ok(())
     }
 
+    /// Returns the `started_at` timestamp of the most recent `success` pulse
+    /// run for `(agent_id, intention_id)`, or `None` when no successful run
+    /// exists.
+    ///
+    /// Used by the Pulse scheduler to evaluate `interval` schedules relative
+    /// to the last successful activation (see `docs/pulse.md` §4).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] on database connection or query execution
+    /// failures.
+    pub(crate) fn get_last_success_started_at(
+        &self,
+        agent_id: &str,
+        intention_id: &str,
+    ) -> Result<Option<chrono::DateTime<chrono::Utc>>, StorageError> {
+        use rusqlite::OptionalExtension;
+
+        let conn = self.get_conn()?;
+        let raw: Option<String> = conn
+            .query_row(
+                "SELECT started_at FROM pulse_runs
+                 WHERE agent_id = ?1 AND intention_id = ?2 AND status = ?3
+                 ORDER BY started_at DESC
+                 LIMIT 1",
+                params![agent_id, intention_id, PulseRunStatus::Success.to_string()],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(raw
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc)))
+    }
+
     /// Returns `true` when any record exists for `(agent_id, intention_id,
     /// due_key)`, regardless of status.
     ///
@@ -320,6 +354,36 @@ mod tests {
     ) {
         db.try_create_pulse_run(id, agent_id, intention_id, due_key)
             .expect("create pulse run");
+    }
+
+    /// Inserts a pulse run row with an explicit `started_at` and terminal
+    /// `status`, bypassing the `Running` lifecycle. Used to verify
+    /// `get_last_success_started_at` ordering deterministically.
+    fn insert_terminal_pulse_run(
+        db: &Database,
+        id: &str,
+        agent_id: &str,
+        intention_id: &str,
+        due_key: &str,
+        started_at: &str,
+        status: PulseRunStatus,
+    ) {
+        let conn = db.get_conn().expect("conn");
+        conn.execute(
+            "INSERT INTO pulse_runs
+                 (id, agent_id, intention_id, due_key, chat_id, message_id,
+                  status, started_at, finished_at, output_kind, output_text, error_message)
+             VALUES (?1, ?2, ?3, ?4, NULL, NULL, ?5, ?6, ?6, NULL, NULL, NULL)",
+            params![
+                id,
+                agent_id,
+                intention_id,
+                due_key,
+                status.to_string(),
+                started_at
+            ],
+        )
+        .expect("insert terminal pulse run");
     }
 
     #[test]
@@ -560,6 +624,154 @@ mod tests {
 
         // Assert
         assert_eq!(reaped, 0, "empty DB should return 0");
+    }
+
+    // -----------------------------------------------------------------------
+    // get_last_success_started_at
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_last_success_started_at_returns_none_when_no_runs() {
+        let (db, _dir) = test_db();
+
+        let result = db
+            .get_last_success_started_at("agent-a", "int-1")
+            .expect("query");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_last_success_started_at_ignores_non_success_rows() {
+        let (db, _dir) = test_db();
+
+        // Arrange: only running / failed / skipped rows exist
+        create_test_pulse_run(&db, "run-r", "agent-a", "int-1", "2025-01-01");
+        insert_terminal_pulse_run(
+            &db,
+            "run-f",
+            "agent-a",
+            "int-1",
+            "2025-01-02",
+            "2025-01-02T00:00:00Z",
+            PulseRunStatus::Failed,
+        );
+        insert_terminal_pulse_run(
+            &db,
+            "run-k",
+            "agent-a",
+            "int-1",
+            "2025-01-03",
+            "2025-01-03T00:00:00Z",
+            PulseRunStatus::Skipped,
+        );
+
+        let result = db
+            .get_last_success_started_at("agent-a", "int-1")
+            .expect("query");
+
+        assert!(result.is_none(), "non-success rows must not be considered");
+    }
+
+    #[test]
+    fn get_last_success_started_at_returns_latest_success_started_at() {
+        let (db, _dir) = test_db();
+
+        // Arrange: two success runs, the later one must win
+        insert_terminal_pulse_run(
+            &db,
+            "run-old",
+            "agent-a",
+            "int-1",
+            "2025-01-01",
+            "2025-01-01T09:00:00Z",
+            PulseRunStatus::Success,
+        );
+        insert_terminal_pulse_run(
+            &db,
+            "run-new",
+            "agent-a",
+            "int-1",
+            "2025-01-05",
+            "2025-01-05T09:00:00Z",
+            PulseRunStatus::Success,
+        );
+        // A newer failed run must NOT shadow the older success
+        insert_terminal_pulse_run(
+            &db,
+            "run-failed",
+            "agent-a",
+            "int-1",
+            "2025-01-06",
+            "2025-01-06T09:00:00Z",
+            PulseRunStatus::Failed,
+        );
+
+        let result = db
+            .get_last_success_started_at("agent-a", "int-1")
+            .expect("query");
+
+        let expected = chrono::DateTime::parse_from_rfc3339("2025-01-05T09:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn get_last_success_started_at_scopes_to_agent_and_intention() {
+        let (db, _dir) = test_db();
+
+        insert_terminal_pulse_run(
+            &db,
+            "run-a",
+            "agent-a",
+            "int-1",
+            "2025-01-01",
+            "2025-01-01T09:00:00Z",
+            PulseRunStatus::Success,
+        );
+        insert_terminal_pulse_run(
+            &db,
+            "run-b",
+            "agent-b",
+            "int-1",
+            "2025-01-02",
+            "2025-01-02T09:00:00Z",
+            PulseRunStatus::Success,
+        );
+        insert_terminal_pulse_run(
+            &db,
+            "run-c",
+            "agent-a",
+            "int-2",
+            "2025-01-03",
+            "2025-01-03T09:00:00Z",
+            PulseRunStatus::Success,
+        );
+
+        assert_eq!(
+            db.get_last_success_started_at("agent-a", "int-1")
+                .expect("query"),
+            Some(
+                chrono::DateTime::parse_from_rfc3339("2025-01-01T09:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc)
+            )
+        );
+        assert_eq!(
+            db.get_last_success_started_at("agent-b", "int-1")
+                .expect("query"),
+            Some(
+                chrono::DateTime::parse_from_rfc3339("2025-01-02T09:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc)
+            )
+        );
+        assert!(
+            db.get_last_success_started_at("agent-a", "int-9")
+                .expect("query")
+                .is_none()
+        );
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

Pulse のスケジュールに `interval` kind を追加し、「N日ごと」の柔軟な指定を可能にします。既存の `daily` / `weekly` はカレンダー固定の絶対基準でしたが、`interval` は **前回成功した発火日を起点とする相対基準** を導入します。

## 背景

現状の Pulse スケジュールは `daily` / `weekly` の2種類のみで、「3日ごと」「10日ごと」のような N日間隔指定ができませんでした。DB バックアップ（`db.backup.interval_days`）のような間隔指定を Pulse でも導入したい、という要件です。

## 設計

### 意味論（daily/weekly との違い）

| kind | 基準 | 失敗時 |
|---|---|---|
| daily / weekly | カレンダー期間（絶対） | その期間はスキップ、次の期間まで待つ |
| interval | 前回成功日（相対） | 起点が更新されないため、翌日以降も due 判定が続き **成功するまで毎日1回リトライ** |

Pulse の第一原則「Cron ではなく Temporal Intention として扱う」「失敗は未達成の意図」に合致する設計です。

### due 判定 / due_key

- **due 条件**: `今日のローカル日付 >= 前回成功日 + interval_days` かつ `HH:MM` 過ぎた（初回は時刻判定のみ）
- **due_key**: `{agent_id}:{intention_id}:{評価日}`（前回成功日ではなく評価日）。これにより失敗翌日のリトライが可能（due_key が毎日進むため重複防止に引っかからない）

### 失敗時リカバリのタイムライン（interval_days=3 の例）

| 日付 | 状態 | due | 備考 |
|---|---|:---:|---|
| 07/03 | 成功 | — | `last_success = 07/03` に更新 |
| 07/04〜05 | skip | ✗ | `07/03 + 3日 = 07/06` 未到 |
| 07/06 | 発火→失敗 | ✓ | `last_success` は `07/03` のまま |
| 07/07 | 発火→成功 | ✓ | due_key が 07/07 に進むため再試行可能 |
| 07/08〜09 | skip | ✗ | `07/07 + 3日 = 07/10` 未到 |

## PULSE.md 記述例

```yaml
intentions:
  - id: periodic_report
    schedule:
      kind: interval
      interval_days: 3
      at: "09:00"
    attention: 3日ごとの定期レポート。
```

## 変更内容

- **`src/storage/pulse.rs`**: `Database::get_last_success_started_at()` 追加（`status='success'` の最新 `started_at` を取得）
- **`src/pulse/definition.rs`**: `TemporalSchedule::Interval` バリアント追加、`check_due` / `generate_due_key` に `last_success_at` 引数追加（`daily`/`weekly` は無視）、`is_interval_due` 追加、`interval_days >= 1` のバリデーション
- **`src/pulse/scheduler.rs`**: `process_intention` で due 判定前に `last_success_at` を取得して渡す
- **`docs/pulse.md`**: §4 に `interval` 仕様と失敗時タイムライン、§6 Due Resolver、§14 スコープを更新

## 確認

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`（1432 tests passed）
- [x] 単体テスト: interval パース / due 判定 / due_key / 失敗リカバリ / window 経過
- [x] 統合テスト: scheduler で初回発火 / window 内 skip / window 経過後に発火

## 影響範囲

- DB マイグレーション不要（`pulse_runs` テーブル構造不変、`due_key` は文字列）
- Config（`egopulse.config.yaml`）変更不要（スケジュール種別は PULSE.md 側の責務）
- 既存 `daily` / `weekly` の PULSE.md は無変更で動作（後方互換）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * スケジュール種別に `interval` を追加し、`every N days HH:MM` 形式で表示・設定できるようになりました。
  * `interval` は前回の成功時刻を基準に、一定日数ごとに判定されます。

* **不具合修正**
  * 失敗後も毎日再判定され、成功するまで通知対象になり続ける動作を反映しました。
  * 重複判定キーや表示ルールを `interval` に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->