### PR TITLE
fix(web): WebUI の空バブル（ツール結果プレビュー）を非表示化

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -337,6 +337,8 @@ GET /api/history?session_key=main&limit=100
 
 メッセージの `sender_kind` は `user` / `assistant` / `system`。`message_kind` は `message` / `agent_send` / `system_event` / `tool_call`。`message_kind: "tool_call"` のメッセージはツール実行結果で、`content` に JSON 文字列（`{tool, status, result, input}`）を持ち、WebUI は折りたたみ可能なツールカードとして描画する。ツール呼び出し履歴は `tool_calls` テーブルから時系列順でテキストメッセージにマージされる（LLM コンテキストには含まれない）。
 
+ツール呼び出しを伴うターンでは、`messages` テーブルにエージェントのテキストとツール名を併記したプレビュー（`[tool_call] {name}` 形式）が assistant メッセージとして保存される。これはテキストベースチャネル（TUI / Discord など）の表示用で、WebUI でも発言内容を残すためにそのまま返却される。一方、ツール結果プレビュー（`[tool_result]: ...` / `[tool_error]: ...` 形式）は Markdown でリンク参照定義として解釈されて空描画され、かつ `tool_calls` テーブルの内容と完全重複するため、`GET /api/history` では除外される。
+
 ---
 
 ### 2.6 ストリーミングチャット

--- a/src/agent_loop/formatting.rs
+++ b/src/agent_loop/formatting.rs
@@ -167,11 +167,24 @@ fn render_tool_body(payload: &str, truncate: bool) -> String {
     strip_thinking(payload)
 }
 
+const TOOL_RESULT_PREFIX: &str = "[tool_result]: ";
+const TOOL_ERROR_PREFIX: &str = "[tool_error]: ";
+
+/// Returns `true` when `content` is a tool-result/tool-error preview message
+/// (`[tool_result]: ...` / `[tool_error]: ...`).
+///
+/// These previews are emitted by [`render_tool_message_text`] for text-only
+/// channels. Structured UIs that render tool results from the `tool_calls`
+/// table can use this to skip the duplicate preview.
+pub(crate) fn is_tool_result_preview(content: &str) -> bool {
+    content.starts_with(TOOL_RESULT_PREFIX) || content.starts_with(TOOL_ERROR_PREFIX)
+}
+
 fn tool_message_prefix(message: &Message) -> &'static str {
     if is_tool_error_message(message) {
-        "[tool_error]: "
+        TOOL_ERROR_PREFIX
     } else {
-        "[tool_result]: "
+        TOOL_RESULT_PREFIX
     }
 }
 
@@ -517,5 +530,21 @@ mod tests {
             "sent".to_string(),
         );
         assert_eq!(format_channel_log_message(&msg), "[tool/lyre] sent");
+    }
+
+    #[test]
+    fn is_tool_result_preview_detects_generated_prefixes() {
+        assert!(is_tool_result_preview("[tool_result]: done"));
+        assert!(is_tool_result_preview("[tool_error]: boom"));
+    }
+
+    #[test]
+    fn is_tool_result_preview_rejects_other_messages() {
+        assert!(!is_tool_result_preview("[tool_call] read"));
+        assert!(!is_tool_result_preview(
+            "ファイルを読みます [tool_call] read"
+        ));
+        assert!(!is_tool_result_preview("regular assistant text"));
+        assert!(!is_tool_result_preview(""));
     }
 }

--- a/src/channels/web/sessions.rs
+++ b/src/channels/web/sessions.rs
@@ -8,7 +8,8 @@ use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::storage::call_blocking;
+use crate::agent_loop::formatting::is_tool_result_preview;
+use crate::storage::{SenderKind, call_blocking};
 
 use super::{WebState, web_external_chat_id, web_session_key};
 
@@ -137,8 +138,17 @@ pub(super) async fn get_history(
 
     // Interleave text messages with persisted tool calls by timestamp so the
     // WebUI can render collapsible tool cards inline within the conversation.
+    //
+    // Tool-result/error previews (`[tool_result]: ...` / `[tool_error]: ...`)
+    // are skipped: Markdown parses the bracket-prefix form as a reference
+    // link definition and renders it empty, and the same data is already
+    // exposed via the structured tool cards below.
     let mut entries: Vec<(String, serde_json::Value)> = Vec::new();
     for message in messages {
+        if message.sender_kind == SenderKind::Assistant && is_tool_result_preview(&message.content)
+        {
+            continue;
+        }
         let timestamp = message.timestamp.clone();
         entries.push((
             timestamp,
@@ -390,6 +400,68 @@ mod tests {
         assert_eq!(content["status"], "success");
         assert_eq!(content["result"], "file contents");
         assert_eq!(content["input"]["path"], "a.txt");
+    }
+
+    #[tokio::test]
+    async fn api_history_skips_tool_result_preview_messages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let web_state = test_web_state(&dir);
+        let db = Arc::clone(&web_state.app_state.db);
+
+        let chat_id = insert_web_chat(&db, "web:session-preview:agent:lyre", "lyre");
+
+        // Tool-result/error previews render empty in Markdown (parsed as a
+        // reference link definition) and duplicate the structured tool card,
+        // so they must be filtered out of the WebUI history.
+        db.store_message_only(&StoredMessage::assistant(
+            chat_id,
+            "lyre".to_string(),
+            "[tool_result]: file contents".to_string(),
+        ))
+        .expect("store tool_result preview");
+        db.store_message_only(&StoredMessage::assistant(
+            chat_id,
+            "lyre".to_string(),
+            "[tool_error]: boom".to_string(),
+        ))
+        .expect("store tool_error preview");
+
+        // A tool_call preview that carries user-facing narration stays.
+        db.store_message_only(&StoredMessage::assistant(
+            chat_id,
+            "lyre".to_string(),
+            "読みますね [tool_call] read".to_string(),
+        ))
+        .expect("store tool_call narration");
+
+        // A plain assistant message stays.
+        db.store_message_only(&StoredMessage::assistant(
+            chat_id,
+            "lyre".to_string(),
+            "hello there".to_string(),
+        ))
+        .expect("store plain assistant");
+
+        let query = Query(super::HistoryQuery {
+            session_key: Some(format!("chat:{chat_id}")),
+            limit: None,
+        });
+        let result = get_history(AxumState(web_state), query).await.expect("ok");
+        let body = result.0;
+        let messages = body["messages"].as_array().expect("messages array");
+
+        let contents: Vec<&str> = messages
+            .iter()
+            .map(|m| m["content"].as_str().expect("content string"))
+            .collect();
+
+        assert_eq!(
+            messages.len(),
+            2,
+            "only narration + plain message remain: {contents:?}"
+        );
+        assert!(contents.contains(&"読みますね [tool_call] read"));
+        assert!(contents.contains(&"hello there"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

WebUI で、ツール呼び出し結果が「空のメッセージバブル」として表示される問題を修正します。

## 問題

ツール呼び出しを伴うターンで、ツールカードの前後に**内容が空のメッセージバブル**が表示されることがありました。

### 原因

`agent_loop` はテキストベースチャネル（TUI / Discord など）向けに、ツール結果を `[tool_result]: ...` / `[tool_error]: ...` 形式のプレビュー文字列として `messages` テーブルに assistant メッセージとして保存しています（`render_tool_message_text`）。

このプレビュー文字列は Markdown の**リンク参照定義**（`[label]: url`）構文として解釈されるため、WebUI の MarkdownRenderer（`react-markdown` + `remark-gfm`）でレンダリングすると**完全に空**になります。

実証結果:

| 入力 | レンダリング結果 |
|---|---|
| `[tool_result]: ほげ` | `<div class="markdown-content"></div>` |
| `[tool_error]: ...` | 同様に空 |
| `[tool_call] read` | `<p>[tool_call] read</p>`（リテラル表示） |

加えて、この情報は `tool_calls` テーブルから生成されるツールカードと**完全に重複**していました。

## 修正内容

`GET /api/history` で `messages` を返却する際、`[tool_result]:` / `[tool_error]:` で始まる assistant メッセージをスキップします。

- `agent_loop::formatting::is_tool_result_preview(content)` を新設し、判定ロジックを一元化
- `TOOL_RESULT_PREFIX` / `TOOL_ERROR_PREFIX` 定数を抽出（従来 `tool_message_prefix` にハードコードされていたプレフィックスと同一ソース化）
- `sessions::get_history` のメッセージループで `sender_kind == Assistant && is_tool_result_preview(content)` をスキップ

### 残すもの

ツール呼び出し前のエージェント発言を含む `[tool_call] {name}` 形式のプレビューは、Markdown でもリテラル表示されるため**そのまま返却**します。テキストチャネルの挙動は DB 含めて完全不変です。

## テスト

- `formatting::is_tool_result_preview_*`（検出 / 拒否）
- `sessions::api_history_skips_tool_result_preview_messages`（`[tool_result]:` / `[tool_error]:` が除外され、`[tool_call]` ナレーションと通常メッセージが残ることを検証）

`cargo fmt` / `cargo clippy -D warnings` / `cargo test` / `cargo doc -D warnings` すべてクリア。

## 影響範囲

- WebUI の `/api/history` レスポンスのみ（表示時フィルタ）
- DB スキーマ・テキストチャネル（TUI / Discord / Telegram / CLI）の挙動には影響しません

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * メッセージ履歴に、ツール実行時の不要なプレビュー表示が混ざらないようになりました。
  * 履歴画面で、実際の会話内容だけがより正しく表示されます。
  * ツール呼び出しを含むターンでも、重複して見える内容や空表示になる項目が除外されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->