### PR TITLE
feat: 再起動後も calibration factor を復元し、早すぎるコンパクションを防ぐ

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -357,6 +357,8 @@ CREATE TABLE IF NOT EXISTS llm_usage_logs (
     output_tokens INTEGER NOT NULL,
     total_tokens INTEGER NOT NULL,
     request_kind TEXT NOT NULL DEFAULT 'agent_loop',
+    estimated_tokens INTEGER NOT NULL DEFAULT 0,
+    has_tools INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL
 );
 
@@ -378,10 +380,13 @@ CREATE INDEX IF NOT EXISTS idx_llm_usage_created
 | output_tokens | INTEGER | NOT NULL | 出力トークン数 |
 | total_tokens | INTEGER | NOT NULL | 合計トークン数（input + output） |
 | request_kind | TEXT | NOT NULL DEFAULT 'agent_loop' | リクエスト種別 |
+| estimated_tokens | INTEGER | NOT NULL DEFAULT 0 | 生推定トークン数（chars/3）。補正係数の再構築に使用 |
+| has_tools | INTEGER | NOT NULL DEFAULT 0 | tool 定義を含む payload か（0/1） |
 | created_at | TEXT | NOT NULL | RFC3339 タイムスタンプ |
 
 **操作**:
-- `log_llm_usage(chat_id, caller_channel, provider, model, input_tokens, output_tokens, request_kind)` — INSERT（total_tokens は自動計算）
+- `log_llm_usage(chat_id, caller_channel, provider, model, input_tokens, output_tokens, request_kind, estimated_tokens, has_tools)` — INSERT（total_tokens は自動計算）
+- `load_calibration_observations(limit_per_key)` — 補正係数再構築用の観測を最近 N 件/キー取得（oldest-first）
 - `get_llm_usage_summary(chat_id, since)` — 集計サマリ（requests, input/output/total tokens, last_request_at）
 - `get_llm_usage_by_model(chat_id, since)` — モデル別集計（total_tokens 降順）
 

--- a/docs/plan/plan-accurate-token-estimation.md
+++ b/docs/plan/plan-accurate-token-estimation.md
@@ -321,7 +321,7 @@ persist_user_turn_with_compaction / tool 後 maybe_compact_messages
 
 ## 11. 未解決 / 保留
 
-- **`DEFAULT_FACTOR` の値**: 1.3 に調整。永続化により DEFAULT に頼るのは未知の provider/model の初回のみとなったため、過大だった 1.6 から引き下げた。
+- **`DEFAULT_FACTOR` の値**: 1.3。未知の provider/model の初回ターンのみ適用される。
 - **EMA の重み α**: 0.3 で妥当か。収束速度とスパイク耐性のトレードオフを実データで調整。
 - **クリップ範囲 `[0.5, 3.0]`**: 実データで不適切（広すぎる/狭すぎる）なら調整。
 - **`sleep/orchestrator.rs` の `context_tokens`**: `resolve_context_window_tokens` の戻り値（設定値そのもの）を使用している場合は本プランの影響なし。実装修正時に確認。

--- a/docs/plan/plan-accurate-token-estimation.md
+++ b/docs/plan/plan-accurate-token-estimation.md
@@ -116,7 +116,7 @@ src/llm/
 
 ### 4.1 `UsageCalibrator`（`src/llm/calibration.rs` 新規）
 
-`(provider, model, request_kind, has_tools)` 単位の補正係数をメモリ内で保持する。非永続化（プロセス再起動で未計測状態に戻る）。
+`(provider, model, request_kind, has_tools)` 単位の補正係数をメモリ内で保持する。観測は `llm_usage_logs` に永続化し、起動時に最近 N 件から EMA で再構築する（プロセス再起動後も学習状態が維持される）。
 
 ```rust
 #[derive(Hash, Eq, PartialEq, Clone)]
@@ -151,7 +151,7 @@ impl UsageCalibrator {
 - **EMA（指数移動平均）**: 単発のスパイク（ツール結果が異常に大きい等）で係数が振れるのを防ぐ。
 - **クリップ [0.5, 3.0]**: 係数が極端になると推定が暴走する。下限 0.5（過大評価時の修正）、上限 3.0（過小評価時の修正、今回の日本語ケース相当）。
 - **estimated == 0 を除外**: 推定が 0 の場合は記録しない（ゼロ除算・異常係数防止）。
-- **非永続化**: プロセス再起動で未計測状態に戻る。未計測時は `DEFAULT_FACTOR` を使うため、DB 永続化や起動時 warm start は追加しない。
+- **永続化**: 観測（生推定値と実測 `input_tokens` のペア）は `llm_usage_logs` に保存し、起動時に最近 N 件から EMA で再構築する。これにより再起動後も学習状態が維持され、コールドスタート時の過大 `DEFAULT_FACTOR` による誤発火を防ぐ。
 
 ### 4.2 `estimate_prompt_tokens`（既存、維持）
 
@@ -165,7 +165,7 @@ impl UsageCalibrator {
 
 ```rust
 /// chars/3 の日本語過小評価を未計測時から補う保守係数。
-const DEFAULT_FACTOR: f64 = 1.6;
+const DEFAULT_FACTOR: f64 = 1.3;
 
 fn calibrated_estimate(raw_estimate: usize, factor: f64) -> usize {
     ((raw_estimate as f64) * factor).ceil().max(1.0) as usize
@@ -321,7 +321,7 @@ persist_user_turn_with_compaction / tool 後 maybe_compact_messages
 
 ## 11. 未解決 / 保留
 
-- **`DEFAULT_FACTOR` の値**: 1.6 で妥当か。実データ（V1）を見て、必要なら同じ定数のみ調整する。
+- **`DEFAULT_FACTOR` の値**: 1.3 に調整。永続化により DEFAULT に頼るのは未知の provider/model の初回のみとなったため、過大だった 1.6 から引き下げた。
 - **EMA の重み α**: 0.3 で妥当か。収束速度とスパイク耐性のトレードオフを実データで調整。
 - **クリップ範囲 `[0.5, 3.0]`**: 実データで不適切（広すぎる/狭すぎる）なら調整。
 - **`sleep/orchestrator.rs` の `context_tokens`**: `resolve_context_window_tokens` の戻り値（設定値そのもの）を使用している場合は本プランの影響なし。実装修正時に確認。

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -181,7 +181,7 @@ compaction は保存の別系統ではなく、「保存前に session を整形
 
 推定は会話量の概算を出し、LLM レスポンスに含まれる実測 usage で補正する。実測が返る provider では、日本語や tool schema の影響で概算が小さく出る場合も、以後の判定が実際の使用量に近づく。
 
-まだ実測がない場合は、保守的に少し多めに見積もる。補正値は実行中のメモリだけに保持し、設定や DB には保存しない。外部 tokenizer も使わない。
+まだ実測がない場合（未知の provider/model の初回ターン等）は、保守係数 `DEFAULT_FACTOR`（1.3）を適用して少し多めに見積もる。補正値は `llm_usage_logs` に観測（生推定値 `estimated_tokens` と実測 `input_tokens` のペア）として永続化し、再起動時に最近 N 件から EMA で再構築する。これにより再起動後も学習済みの補正状態が維持され、コールドスタート時の過大 DEFAULT による誤発火を防ぐ。外部 tokenizer は使わない。
 
 ### Algorithm
 

--- a/src/agent_loop/compaction.rs
+++ b/src/agent_loop/compaction.rs
@@ -328,7 +328,7 @@ async fn summarize_old_messages(
                     .record(calibration_key, raw_estimate, usage.input_tokens)
                     .await;
             }
-            log_summarizer_usage(state, context, chat_id, llm, &response);
+            log_summarizer_usage(state, context, chat_id, llm, &response, raw_estimate);
             strip_thinking(&response.content)
         }
         Err(SummarizeError::Provider(error)) => {
@@ -380,6 +380,7 @@ fn log_summarizer_usage(
     chat_id: i64,
     llm: &std::sync::Arc<dyn LlmProvider>,
     response: &MessagesResponse,
+    raw_estimate: usize,
 ) {
     let Some(usage) = &response.usage else {
         return;
@@ -391,6 +392,7 @@ fn log_summarizer_usage(
     let model = llm.model_name().to_string();
     let input_tokens = usage.input_tokens;
     let output_tokens = usage.output_tokens;
+    let estimated_tokens: i64 = raw_estimate.try_into().unwrap_or(0);
     crate::runtime::metrics::inc_llm_tokens_total("input", &provider, input_tokens);
     crate::runtime::metrics::inc_llm_tokens_total("output", &provider, output_tokens);
     tokio::spawn(async move {
@@ -403,6 +405,8 @@ fn log_summarizer_usage(
                 input_tokens,
                 output_tokens,
                 request_kind: "compaction",
+                estimated_tokens,
+                has_tools: false,
             })
         })
         .await

--- a/src/agent_loop/tool_phase.rs
+++ b/src/agent_loop/tool_phase.rs
@@ -170,6 +170,8 @@ pub(crate) async fn send_tool_phase_request(
             request.llm,
             usage,
             request.request_kind,
+            raw_estimate,
+            has_tools,
             request.usage_log_failure,
         );
     }
@@ -242,6 +244,8 @@ pub(crate) fn log_llm_usage(
     llm: &dyn LlmProvider,
     usage: &LlmUsage,
     request_kind: &'static str,
+    raw_estimate: usize,
+    has_tools: bool,
     failure_message: &'static str,
 ) {
     let db = Arc::clone(state.db_for(scope));
@@ -250,6 +254,7 @@ pub(crate) fn log_llm_usage(
     let model = llm.model_name().to_string();
     let input_tokens = usage.input_tokens;
     let output_tokens = usage.output_tokens;
+    let estimated_tokens: i64 = raw_estimate.try_into().unwrap_or(0);
 
     crate::runtime::metrics::inc_llm_tokens_total("input", &provider, input_tokens);
     crate::runtime::metrics::inc_llm_tokens_total("output", &provider, output_tokens);
@@ -264,6 +269,8 @@ pub(crate) fn log_llm_usage(
                 input_tokens,
                 output_tokens,
                 request_kind,
+                estimated_tokens,
+                has_tools,
             })
         })
         .await

--- a/src/llm/calibration.rs
+++ b/src/llm/calibration.rs
@@ -51,6 +51,8 @@ impl CalibrationKey {
 /// Pairs the raw prompt estimate (`estimated_tokens`, chars/3) with the
 /// actual input token count (`input_tokens`) reported by the provider for one
 /// LLM call. The ratio is the measured correction factor for that call.
+/// `created_at` lets the caller merge observations from multiple databases
+/// in true chronological order before replaying the EMA.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CalibrationObservation {
     /// LLM provider name.
@@ -65,6 +67,8 @@ pub(crate) struct CalibrationObservation {
     pub(crate) estimated_tokens: usize,
     /// Actual input token count reported by the provider.
     pub(crate) input_tokens: i64,
+    /// RFC3339 timestamp of the call, used only to order observations.
+    pub(crate) created_at: String,
 }
 
 /// Learns correction factors between raw prompt estimates and observed usage.
@@ -268,6 +272,7 @@ mod tests {
             has_tools,
             estimated_tokens: estimated,
             input_tokens: input,
+            created_at: String::new(),
         }
     }
 

--- a/src/llm/calibration.rs
+++ b/src/llm/calibration.rs
@@ -1,6 +1,6 @@
 //! Runtime calibration for prompt token estimates.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 
 use tokio::sync::RwLock;
 
@@ -9,7 +9,12 @@ const MIN_FACTOR: f64 = 0.5;
 const MAX_FACTOR: f64 = 3.0;
 
 /// Conservative factor for unmeasured prompt estimates.
-pub(crate) const DEFAULT_FACTOR: f64 = 1.6;
+///
+/// Slightly above 1.0 so unknown provider/model combinations over-estimate
+/// until the first observation arrives. Calibration factors reconstructed
+/// from persisted observations replace this default after startup, so it only
+/// applies to the very first turn of a genuinely unseen key.
+pub(crate) const DEFAULT_FACTOR: f64 = 1.3;
 
 /// Identifies a prompt-estimation calibration bucket.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -19,7 +24,7 @@ pub(crate) struct CalibrationKey {
     /// LLM model name.
     pub(crate) model: String,
     /// Request path that produced the prompt, such as `agent_loop` or `compaction`.
-    pub(crate) request_kind: &'static str,
+    pub(crate) request_kind: String,
     /// Whether the request payload included tool definitions.
     pub(crate) has_tools: bool,
 }
@@ -29,16 +34,37 @@ impl CalibrationKey {
     pub(crate) fn new(
         provider: impl Into<String>,
         model: impl Into<String>,
-        request_kind: &'static str,
+        request_kind: impl Into<String>,
         has_tools: bool,
     ) -> Self {
         Self {
             provider: provider.into(),
             model: model.into(),
-            request_kind,
+            request_kind: request_kind.into(),
             has_tools,
         }
     }
+}
+
+/// A persisted observation used to rebuild calibration factors on startup.
+///
+/// Pairs the raw prompt estimate (`estimated_tokens`, chars/3) with the
+/// actual input token count (`input_tokens`) reported by the provider for one
+/// LLM call. The ratio is the measured correction factor for that call.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct CalibrationObservation {
+    /// LLM provider name.
+    pub(crate) provider: String,
+    /// LLM model name.
+    pub(crate) model: String,
+    /// Request path that produced the prompt.
+    pub(crate) request_kind: String,
+    /// Whether the request payload included tool definitions.
+    pub(crate) has_tools: bool,
+    /// Raw prompt estimate (chars / 3) for the call.
+    pub(crate) estimated_tokens: usize,
+    /// Actual input token count reported by the provider.
+    pub(crate) input_tokens: i64,
 }
 
 /// Learns correction factors between raw prompt estimates and observed usage.
@@ -75,6 +101,53 @@ impl UsageCalibrator {
         let updated =
             (current * (1.0 - EMA_ALPHA) + observed * EMA_ALPHA).clamp(MIN_FACTOR, MAX_FACTOR);
         factors.insert(key, updated);
+    }
+
+    /// Rebuilds factors from persisted observations.
+    ///
+    /// `observations` must already be ordered oldest-first within each key
+    /// (the storage layer enforces this). Each key's history is replayed
+    /// through the same EMA used by `record`, so the resulting factors match
+    /// what in-process `record` calls would have produced. This lets restarts
+    /// transparently restore the learned calibration state.
+    ///
+    /// Observations with non-positive `estimated_tokens` or `input_tokens` are
+    /// skipped. All existing in-memory factors are replaced.
+    pub(crate) async fn replay(&self, observations: &[CalibrationObservation]) {
+        let mut grouped: HashMap<CalibrationKey, Vec<(usize, i64)>> = HashMap::new();
+        for obs in observations {
+            if obs.estimated_tokens == 0 || obs.input_tokens <= 0 {
+                continue;
+            }
+            let key = CalibrationKey {
+                provider: obs.provider.clone(),
+                model: obs.model.clone(),
+                request_kind: obs.request_kind.clone(),
+                has_tools: obs.has_tools,
+            };
+            match grouped.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    entry
+                        .get_mut()
+                        .push((obs.estimated_tokens, obs.input_tokens));
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(vec![(obs.estimated_tokens, obs.input_tokens)]);
+                }
+            }
+        }
+
+        let mut factors = self.factors.write().await;
+        factors.clear();
+        for (key, pairs) in grouped {
+            let mut factor = DEFAULT_FACTOR;
+            for (estimated, actual) in pairs {
+                let observed = (actual as f64 / estimated as f64).clamp(MIN_FACTOR, MAX_FACTOR);
+                factor = (factor * (1.0 - EMA_ALPHA) + observed * EMA_ALPHA)
+                    .clamp(MIN_FACTOR, MAX_FACTOR);
+            }
+            factors.insert(key, factor);
+        }
     }
 }
 
@@ -180,5 +253,96 @@ mod tests {
         // Assert
         assert!(calibrator.factor(&agent_key).await > DEFAULT_FACTOR);
         assert_eq!(calibrator.factor(&compaction_key).await, DEFAULT_FACTOR);
+    }
+
+    fn observation(
+        request_kind: &str,
+        has_tools: bool,
+        estimated: usize,
+        input: i64,
+    ) -> CalibrationObservation {
+        CalibrationObservation {
+            provider: "provider".into(),
+            model: "model".into(),
+            request_kind: request_kind.into(),
+            has_tools,
+            estimated_tokens: estimated,
+            input_tokens: input,
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_rebuilds_factor_from_observations() {
+        // Arrange
+        let calibrator = UsageCalibrator::new();
+        let observations = vec![
+            observation("agent_loop", true, 100, 200),
+            observation("agent_loop", true, 100, 300),
+        ];
+
+        // Act
+        calibrator.replay(&observations).await;
+
+        // Assert: converges above DEFAULT_FACTOR toward the observed ratios
+        let factor = calibrator.factor(&key("agent_loop", true)).await;
+        assert!(factor > DEFAULT_FACTOR);
+        assert!(factor < MAX_FACTOR);
+    }
+
+    #[tokio::test]
+    async fn replay_matches_incremental_record_for_same_history() {
+        // Arrange: one calibrator fed via replay, one via incremental record
+        let replayed = UsageCalibrator::new();
+        let incremental = UsageCalibrator::new();
+        let target = key("agent_loop", true);
+        let observations = vec![
+            observation("agent_loop", true, 100, 250),
+            observation("agent_loop", true, 100, 250),
+        ];
+
+        // Act
+        replayed.replay(&observations).await;
+        incremental.record(target.clone(), 100, 250).await;
+        incremental.record(target.clone(), 100, 250).await;
+
+        // Assert: identical history produces identical factor
+        assert_eq!(
+            replayed.factor(&target).await,
+            incremental.factor(&target).await
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_skips_observations_with_non_positive_values() {
+        // Arrange
+        let calibrator = UsageCalibrator::new();
+        let observations = vec![
+            observation("agent_loop", true, 0, 200),
+            observation("agent_loop", true, 100, 0),
+        ];
+
+        // Act
+        calibrator.replay(&observations).await;
+
+        // Assert: no valid observation leaves factor at default
+        assert_eq!(
+            calibrator.factor(&key("agent_loop", true)).await,
+            DEFAULT_FACTOR
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_with_empty_observations_resets_to_default() {
+        // Arrange: seed a learned factor, then replay with nothing
+        let calibrator = UsageCalibrator::new();
+        let target = key("agent_loop", true);
+        calibrator.record(target.clone(), 100, 300).await;
+        assert_ne!(calibrator.factor(&target).await, DEFAULT_FACTOR);
+
+        // Act
+        calibrator.replay(&[]).await;
+
+        // Assert: replay replaces all factors, so the learned value is gone
+        assert_eq!(calibrator.factor(&target).await, DEFAULT_FACTOR);
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -37,7 +37,7 @@ use crate::channels::voice::VoiceAdapter;
 use crate::channels::web::WebAdapter;
 use crate::config::Config;
 use crate::error::{ChannelError, EgoPulseError};
-use crate::llm::calibration::UsageCalibrator;
+use crate::llm::calibration::{CalibrationKey, CalibrationObservation, UsageCalibrator};
 use crate::llm::{Message, create_provider};
 use crate::memory::MemoryLoader;
 use crate::skills::SkillManager;
@@ -186,8 +186,39 @@ impl AppState {
                 Err(e) => warn!(error = %e, "calibration load failed (secret db); using defaults"),
             }
         }
-        observations.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        // Each database already applied the per-key cap; re-cap after merging
+        // so a key present in both databases still replays at most N.
+        Self::cap_observations_per_key(&mut observations, REPLAY_LIMIT_PER_KEY);
         self.usage_calibrator.replay(&observations).await;
+    }
+
+    /// Keeps at most `limit_per_key` observations per [`CalibrationKey`], then
+    /// restores oldest-first order for chronological EMA replay. Applied after
+    /// merging normal and secret observations so a key present in both still
+    /// replays at most N entries.
+    fn cap_observations_per_key(
+        observations: &mut Vec<CalibrationObservation>,
+        limit_per_key: usize,
+    ) {
+        use std::collections::HashMap;
+        observations.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        let mut counts: HashMap<CalibrationKey, usize> = HashMap::new();
+        observations.retain(|o| {
+            let key = CalibrationKey {
+                provider: o.provider.clone(),
+                model: o.model.clone(),
+                request_kind: o.request_kind.clone(),
+                has_tools: o.has_tools,
+            };
+            let count = counts.entry(key).or_insert(0);
+            if *count < limit_per_key {
+                *count += 1;
+                true
+            } else {
+                false
+            }
+        });
+        observations.reverse();
     }
 
     /// Resolves the database and archive root for the given conversation scope.
@@ -1468,6 +1499,37 @@ mod tests {
         let state = build_sleep_app_state_with_path(config, None).expect("build sleep state");
         let snap = state.runtime_status.snapshot();
         assert!(!snap.version.is_empty());
+    }
+
+    #[test]
+    fn cap_observations_per_key_keeps_newest_n_for_shared_keys() {
+        let mk = |created_at: &str, input: i64| CalibrationObservation {
+            provider: "p".into(),
+            model: "m".into(),
+            request_kind: "agent_loop".into(),
+            has_tools: true,
+            estimated_tokens: 100,
+            input_tokens: input,
+            created_at: created_at.into(),
+        };
+        // Simulate two databases each contributing observations for one key,
+        // already individually capped but exceeding N once merged.
+        let mut observations = vec![
+            mk("2026-01-01T00:00:01Z", 1),
+            mk("2026-01-01T00:00:02Z", 2),
+            mk("2026-01-01T00:00:03Z", 3),
+            mk("2026-01-01T00:00:04Z", 4),
+            mk("2026-01-01T00:00:05Z", 5),
+            mk("2026-01-01T00:00:06Z", 6),
+        ];
+
+        AppState::cap_observations_per_key(&mut observations, 3);
+
+        // Assert: only the 3 newest (4, 5, 6), oldest-first
+        assert_eq!(observations.len(), 3);
+        assert_eq!(observations[0].input_tokens, 4);
+        assert_eq!(observations[1].input_tokens, 5);
+        assert_eq!(observations[2].input_tokens, 6);
     }
 
     fn build_sleep_state(dir: &tempfile::TempDir) -> AppState {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 use tokio::task::{JoinError, JoinHandle};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::agent_loop::ConversationScope;
 use crate::agent_loop::soul_agents::SoulAgentsLoader;
@@ -153,6 +153,30 @@ impl AppState {
                 .as_ref()
                 .expect("secret db required but not initialized"),
         }
+    }
+
+    /// Rebuilds calibration factors from persisted usage observations.
+    ///
+    /// Loads recent observations from both normal and secret databases and
+    /// replays them through the calibrator so learned factors survive restarts.
+    /// Load failures fall back to whatever was loaded (possibly empty), leaving
+    /// unmeasured keys at `DEFAULT_FACTOR`.
+    pub(crate) async fn warm_up_calibrator(&self) {
+        const REPLAY_LIMIT_PER_KEY: usize = 30;
+        let mut observations = match self.db.load_calibration_observations(REPLAY_LIMIT_PER_KEY) {
+            Ok(o) => o,
+            Err(e) => {
+                warn!(error = %e, "calibration load failed (normal db); using defaults");
+                Vec::new()
+            }
+        };
+        if let Some(secret_db) = &self.secret_db {
+            match secret_db.load_calibration_observations(REPLAY_LIMIT_PER_KEY) {
+                Ok(o) => observations.extend(o),
+                Err(e) => warn!(error = %e, "calibration load failed (secret db); using defaults"),
+            }
+        }
+        self.usage_calibrator.replay(&observations).await;
     }
 
     /// Resolves the database and archive root for the given conversation scope.
@@ -316,6 +340,7 @@ pub async fn build_app_state_with_path(
         turn_sender,
         runtime_status: Arc::clone(&runtime_status),
     });
+    state.warm_up_calibrator().await;
 
     spawn_agent_turn_worker(state.clone(), turn_receiver);
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -159,11 +159,17 @@ impl AppState {
     ///
     /// Loads recent observations from both normal and secret databases and
     /// replays them through the calibrator so learned factors survive restarts.
-    /// Load failures fall back to whatever was loaded (possibly empty), leaving
-    /// unmeasured keys at `DEFAULT_FACTOR`.
+    /// Observations are merged in chronological order so shared
+    /// [`CalibrationKey`](crate::llm::calibration::CalibrationKey)s replay their
+    /// true history. Load failures fall back to whatever was loaded (possibly
+    /// empty), leaving unmeasured keys at `DEFAULT_FACTOR`.
     pub(crate) async fn warm_up_calibrator(&self) {
         const REPLAY_LIMIT_PER_KEY: usize = 30;
-        let mut observations = match self.db.load_calibration_observations(REPLAY_LIMIT_PER_KEY) {
+        let mut observations = match crate::storage::call_blocking(Arc::clone(&self.db), |db| {
+            db.load_calibration_observations(REPLAY_LIMIT_PER_KEY)
+        })
+        .await
+        {
             Ok(o) => o,
             Err(e) => {
                 warn!(error = %e, "calibration load failed (normal db); using defaults");
@@ -171,11 +177,16 @@ impl AppState {
             }
         };
         if let Some(secret_db) = &self.secret_db {
-            match secret_db.load_calibration_observations(REPLAY_LIMIT_PER_KEY) {
+            match crate::storage::call_blocking(Arc::clone(secret_db), |db| {
+                db.load_calibration_observations(REPLAY_LIMIT_PER_KEY)
+            })
+            .await
+            {
                 Ok(o) => observations.extend(o),
                 Err(e) => warn!(error = %e, "calibration load failed (secret db); using defaults"),
             }
         }
+        observations.sort_by(|a, b| a.created_at.cmp(&b.created_at));
         self.usage_calibrator.replay(&observations).await;
     }
 

--- a/src/sleep/orchestrator.rs
+++ b/src/sleep/orchestrator.rs
@@ -1565,7 +1565,6 @@ async fn finalize_batch(
     {
         if run.input_tokens > 0 || run.output_tokens > 0 {
             let provider_name = ctx.provider.provider_name().to_string();
-            let model_name = ctx.provider.model_name().to_string();
             crate::runtime::metrics::inc_llm_tokens_total(
                 "input",
                 &provider_name,
@@ -1576,24 +1575,9 @@ async fn finalize_batch(
                 &provider_name,
                 run.output_tokens,
             );
-            let db_for_usage = Arc::clone(db);
-            let input_tokens = run.input_tokens;
-            let output_tokens = run.output_tokens;
-            tokio::spawn(async move {
-                let _ = crate::storage::call_blocking(db_for_usage, move |db| {
-                    db.log_llm_usage(&crate::storage::LlmUsageLogEntry {
-                        chat_id: 0,
-                        caller_channel: "sleep_batch",
-                        provider: &provider_name,
-                        model: &model_name,
-                        input_tokens,
-                        output_tokens,
-                        request_kind: "sleep_batch",
-                    })
-                })
-                .await
-                .inspect_err(|e| warn!(error = %e, "sleep batch llm usage logging failed"));
-            });
+            // Per-call usage is logged by each sleep step's LLM call. The
+            // batch-level aggregate has no single prompt estimate to pair
+            // with, so it is not written to llm_usage_logs.
         }
     }
 

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -8,7 +8,7 @@ use crate::error::StorageError;
 ///
 /// スキーマを変更する際はこの値をインクリメントし、
 /// `run_migrations` に対応する `if version < N` ブロックを追加する。
-pub(super) const SCHEMA_VERSION: i64 = 9;
+pub(super) const SCHEMA_VERSION: i64 = 10;
 
 /// `db_meta` に格納されたスキーマバージョンを読み取る。
 ///
@@ -639,6 +639,37 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
         version = 9;
     }
 
+    if version < 10 {
+        let tx = conn.unchecked_transaction()?;
+        // Idempotent: rollback tests re-run migrations on an already-current
+        // schema, so only add the columns when they are still missing.
+        let needs_columns = {
+            let mut stmt = tx.prepare("PRAGMA table_info(llm_usage_logs)")?;
+            let names: Vec<String> = stmt
+                .query_map([], |row| row.get::<_, String>(1))?
+                .collect::<Result<Vec<_>, _>>()?;
+            !names.iter().any(|name| name == "estimated_tokens")
+        };
+        if needs_columns {
+            // Old rows predate the calibration columns and carry no raw prompt
+            // estimate to pair with their input_tokens. Drop them and add the
+            // new columns as NOT NULL rather than maintaining a NULL/fallback
+            // branch.
+            tx.execute_batch(
+                "DELETE FROM llm_usage_logs;
+                 ALTER TABLE llm_usage_logs ADD COLUMN estimated_tokens INTEGER NOT NULL DEFAULT 0;
+                 ALTER TABLE llm_usage_logs ADD COLUMN has_tools INTEGER NOT NULL DEFAULT 0;",
+            )?;
+        }
+        set_schema_version_in_tx(
+            &tx,
+            10,
+            "add estimated_tokens and has_tools to llm_usage_logs for calibration rebuild",
+        )?;
+        tx.commit()?;
+        version = 10;
+    }
+
     debug_assert_eq!(version, SCHEMA_VERSION, "all migrations applied");
     Ok(())
 }
@@ -646,7 +677,7 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
 /// Secret DB のスキーマバージョン。
 ///
 /// `egopulse.db` とは独立して管理する。
-pub(super) const SECRET_SCHEMA_VERSION: i64 = 1;
+pub(super) const SECRET_SCHEMA_VERSION: i64 = 2;
 
 /// Secret DB のマイグレーションを実行する。
 ///
@@ -655,7 +686,7 @@ pub(super) const SECRET_SCHEMA_VERSION: i64 = 1;
 pub(super) fn run_secret_migrations(conn: &Connection) -> Result<(), StorageError> {
     let mut version = schema_version(conn)?;
 
-    if version < SECRET_SCHEMA_VERSION {
+    if version < 1 {
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS chats (
                 chat_id INTEGER PRIMARY KEY,
@@ -716,6 +747,35 @@ pub(super) fn run_secret_migrations(conn: &Connection) -> Result<(), StorageErro
             "initial secret schema: chats, messages, sessions, llm_usage_logs",
         )?;
         version = 1;
+    }
+
+    if version < 2 {
+        // Idempotent: rollback tests re-run migrations on an already-current
+        // schema, so only add the columns when they are still missing.
+        let needs_columns = {
+            let mut stmt = conn.prepare("PRAGMA table_info(llm_usage_logs)")?;
+            let names: Vec<String> = stmt
+                .query_map([], |row| row.get::<_, String>(1))?
+                .collect::<Result<Vec<_>, _>>()?;
+            !names.iter().any(|name| name == "estimated_tokens")
+        };
+        if needs_columns {
+            // Old rows predate the calibration columns and carry no raw prompt
+            // estimate to pair with their input_tokens. Drop them and add the
+            // new columns as NOT NULL rather than maintaining a NULL/fallback
+            // branch.
+            conn.execute_batch(
+                "DELETE FROM llm_usage_logs;
+                 ALTER TABLE llm_usage_logs ADD COLUMN estimated_tokens INTEGER NOT NULL DEFAULT 0;
+                 ALTER TABLE llm_usage_logs ADD COLUMN has_tools INTEGER NOT NULL DEFAULT 0;",
+            )?;
+        }
+        set_schema_version(
+            conn,
+            2,
+            "add estimated_tokens and has_tools to llm_usage_logs for calibration rebuild",
+        )?;
+        version = 2;
     }
 
     debug_assert_eq!(version, SECRET_SCHEMA_VERSION);
@@ -1928,7 +1988,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("version");
-        assert_eq!(version.parse::<i64>().unwrap(), 9);
+        assert_eq!(version.parse::<i64>().unwrap(), super::SCHEMA_VERSION);
 
         // Assert: existing snapshot preserved
         let count: i64 = conn

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -651,13 +651,11 @@ pub(super) fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
             !names.iter().any(|name| name == "estimated_tokens")
         };
         if needs_columns {
-            // Old rows predate the calibration columns and carry no raw prompt
-            // estimate to pair with their input_tokens. Drop them and add the
-            // new columns as NOT NULL rather than maintaining a NULL/fallback
-            // branch.
+            // Existing rows keep DEFAULT 0 and are excluded from calibration
+            // rebuild by the `estimated_tokens > 0` filter, preserving
+            // usage/cost history.
             tx.execute_batch(
-                "DELETE FROM llm_usage_logs;
-                 ALTER TABLE llm_usage_logs ADD COLUMN estimated_tokens INTEGER NOT NULL DEFAULT 0;
+                "ALTER TABLE llm_usage_logs ADD COLUMN estimated_tokens INTEGER NOT NULL DEFAULT 0;
                  ALTER TABLE llm_usage_logs ADD COLUMN has_tools INTEGER NOT NULL DEFAULT 0;",
             )?;
         }
@@ -760,13 +758,11 @@ pub(super) fn run_secret_migrations(conn: &Connection) -> Result<(), StorageErro
             !names.iter().any(|name| name == "estimated_tokens")
         };
         if needs_columns {
-            // Old rows predate the calibration columns and carry no raw prompt
-            // estimate to pair with their input_tokens. Drop them and add the
-            // new columns as NOT NULL rather than maintaining a NULL/fallback
-            // branch.
+            // Existing rows keep DEFAULT 0 and are excluded from calibration
+            // rebuild by the `estimated_tokens > 0` filter, preserving
+            // usage/cost history.
             conn.execute_batch(
-                "DELETE FROM llm_usage_logs;
-                 ALTER TABLE llm_usage_logs ADD COLUMN estimated_tokens INTEGER NOT NULL DEFAULT 0;
+                "ALTER TABLE llm_usage_logs ADD COLUMN estimated_tokens INTEGER NOT NULL DEFAULT 0;
                  ALTER TABLE llm_usage_logs ADD COLUMN has_tools INTEGER NOT NULL DEFAULT 0;",
             )?;
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -505,6 +505,11 @@ pub(crate) struct LlmUsageLogEntry<'a> {
     pub input_tokens: i64,
     pub output_tokens: i64,
     pub request_kind: &'a str,
+    /// Raw prompt estimate (chars / 3) for the call. Used to rebuild
+    /// calibration factors on startup. Required for every row.
+    pub estimated_tokens: i64,
+    /// Whether the request payload included tool definitions.
+    pub has_tools: bool,
 }
 
 const _: () = {

--- a/src/storage/tool.rs
+++ b/src/storage/tool.rs
@@ -154,10 +154,11 @@ impl Database {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Keep the most recent `limit_per_key` per key (rows are DESC), then
-        // reverse each bucket to oldest-first for chronological EMA replay.
-        // `created_at` is only used for the SQL ordering and discarded here.
-        let mut grouped: HashMap<CalibrationKey, Vec<(usize, i64)>> = HashMap::new();
-        for (provider, model, request_kind, has_tools, estimated, input, _created_at) in rows {
+        // reverse each bucket to oldest-first. `created_at` is retained so the
+        // caller can merge observations from multiple databases in true
+        // chronological order before replaying the EMA.
+        let mut grouped: HashMap<CalibrationKey, Vec<(usize, i64, String)>> = HashMap::new();
+        for (provider, model, request_kind, has_tools, estimated, input, created_at) in rows {
             let key = CalibrationKey {
                 provider,
                 model,
@@ -166,14 +167,14 @@ impl Database {
             };
             let bucket = grouped.entry(key).or_default();
             if bucket.len() < limit_per_key {
-                bucket.push((estimated as usize, input));
+                bucket.push((estimated as usize, input, created_at));
             }
         }
 
         let mut out = Vec::new();
         for (key, mut pairs) in grouped {
             pairs.reverse();
-            for (estimated, input) in pairs {
+            for (estimated, input, created_at) in pairs {
                 out.push(CalibrationObservation {
                     provider: key.provider.clone(),
                     model: key.model.clone(),
@@ -181,6 +182,7 @@ impl Database {
                     has_tools: key.has_tools,
                     estimated_tokens: estimated,
                     input_tokens: input,
+                    created_at,
                 });
             }
         }

--- a/src/storage/tool.rs
+++ b/src/storage/tool.rs
@@ -1,8 +1,7 @@
 use rusqlite::params;
-use std::collections::HashMap;
 
 use crate::error::StorageError;
-use crate::llm::calibration::{CalibrationKey, CalibrationObservation};
+use crate::llm::calibration::CalibrationObservation;
 
 use super::{Database, LlmUsageLogEntry, ToolCall};
 
@@ -134,59 +133,41 @@ impl Database {
     ) -> Result<Vec<CalibrationObservation>, StorageError> {
         let conn = self.get_conn()?;
         let mut stmt = conn.prepare_cached(
-            "SELECT provider, model, request_kind, has_tools, estimated_tokens, input_tokens, created_at
-             FROM llm_usage_logs
-             WHERE estimated_tokens > 0 AND input_tokens > 0
+            "WITH ranked AS (
+                 SELECT provider, model, request_kind, has_tools,
+                        estimated_tokens, input_tokens, created_at,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY provider, model, request_kind, has_tools
+                            ORDER BY created_at DESC
+                        ) AS rn
+                 FROM llm_usage_logs
+                 WHERE estimated_tokens > 0 AND input_tokens > 0
+             )
+             SELECT provider, model, request_kind, has_tools,
+                    estimated_tokens, input_tokens, created_at
+             FROM ranked
+             WHERE rn <= ?1
              ORDER BY created_at DESC",
         )?;
-        let rows: Vec<(String, String, String, bool, i64, i64, String)> = stmt
-            .query_map([], |row| {
-                Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get::<_, i64>(3)? != 0,
-                    row.get(4)?,
-                    row.get(5)?,
-                    row.get(6)?,
-                ))
+        let mut observations: Vec<CalibrationObservation> = stmt
+            .query_map(params![limit_per_key as i64], |row| {
+                Ok(CalibrationObservation {
+                    provider: row.get(0)?,
+                    model: row.get(1)?,
+                    request_kind: row.get(2)?,
+                    has_tools: row.get::<_, i64>(3)? != 0,
+                    estimated_tokens: row.get::<_, i64>(4)? as usize,
+                    input_tokens: row.get(5)?,
+                    created_at: row.get(6)?,
+                })
             })?
             .collect::<Result<Vec<_>, _>>()?;
-
-        // Keep the most recent `limit_per_key` per key (rows are DESC), then
-        // reverse each bucket to oldest-first. `created_at` is retained so the
-        // caller can merge observations from multiple databases in true
-        // chronological order before replaying the EMA.
-        let mut grouped: HashMap<CalibrationKey, Vec<(usize, i64, String)>> = HashMap::new();
-        for (provider, model, request_kind, has_tools, estimated, input, created_at) in rows {
-            let key = CalibrationKey {
-                provider,
-                model,
-                request_kind,
-                has_tools,
-            };
-            let bucket = grouped.entry(key).or_default();
-            if bucket.len() < limit_per_key {
-                bucket.push((estimated as usize, input, created_at));
-            }
-        }
-
-        let mut out = Vec::new();
-        for (key, mut pairs) in grouped {
-            pairs.reverse();
-            for (estimated, input, created_at) in pairs {
-                out.push(CalibrationObservation {
-                    provider: key.provider.clone(),
-                    model: key.model.clone(),
-                    request_kind: key.request_kind.clone(),
-                    has_tools: key.has_tools,
-                    estimated_tokens: estimated,
-                    input_tokens: input,
-                    created_at,
-                });
-            }
-        }
-        Ok(out)
+        // SQL returns newest-first; reverse to oldest-first so the calibrator
+        // can replay each key's history chronologically. `created_at` is kept
+        // so callers can merge observations from multiple databases in true
+        // chronological order.
+        observations.reverse();
+        Ok(observations)
     }
 }
 

--- a/src/storage/tool.rs
+++ b/src/storage/tool.rs
@@ -1,6 +1,8 @@
 use rusqlite::params;
+use std::collections::HashMap;
 
 use crate::error::StorageError;
+use crate::llm::calibration::{CalibrationKey, CalibrationObservation};
 
 use super::{Database, LlmUsageLogEntry, ToolCall};
 
@@ -67,8 +69,8 @@ impl Database {
         let created_at = chrono::Utc::now().to_rfc3339();
         conn.execute(
             "INSERT INTO llm_usage_logs
-                (chat_id, caller_channel, provider, model, input_tokens, output_tokens, total_tokens, request_kind, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                (chat_id, caller_channel, provider, model, input_tokens, output_tokens, total_tokens, request_kind, estimated_tokens, has_tools, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 entry.chat_id,
                 entry.caller_channel,
@@ -78,6 +80,8 @@ impl Database {
                 entry.output_tokens,
                 total_tokens,
                 entry.request_kind,
+                entry.estimated_tokens,
+                entry.has_tools,
                 created_at,
             ],
         )?;
@@ -113,7 +117,77 @@ impl Database {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(calls)
     }
+
+    /// Loads recent observations for calibration factor rebuild.
+    ///
+    /// Returns [`CalibrationObservation`]s ordered oldest-first within each
+    /// key, limited to the most recent `limit_per_key` rows per key. Rows with
+    /// non-positive `estimated_tokens` or `input_tokens` are excluded so the
+    /// caller can replay a clean history through the calibrator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] on database connection or query failures.
+    pub(crate) fn load_calibration_observations(
+        &self,
+        limit_per_key: usize,
+    ) -> Result<Vec<CalibrationObservation>, StorageError> {
+        let conn = self.get_conn()?;
+        let mut stmt = conn.prepare_cached(
+            "SELECT provider, model, request_kind, has_tools, estimated_tokens, input_tokens, created_at
+             FROM llm_usage_logs
+             WHERE estimated_tokens > 0 AND input_tokens > 0
+             ORDER BY created_at DESC",
+        )?;
+        let rows: Vec<(String, String, String, bool, i64, i64, String)> = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get::<_, i64>(3)? != 0,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Keep the most recent `limit_per_key` per key (rows are DESC), then
+        // reverse each bucket to oldest-first for chronological EMA replay.
+        // `created_at` is only used for the SQL ordering and discarded here.
+        let mut grouped: HashMap<CalibrationKey, Vec<(usize, i64)>> = HashMap::new();
+        for (provider, model, request_kind, has_tools, estimated, input, _created_at) in rows {
+            let key = CalibrationKey {
+                provider,
+                model,
+                request_kind,
+                has_tools,
+            };
+            let bucket = grouped.entry(key).or_default();
+            if bucket.len() < limit_per_key {
+                bucket.push((estimated as usize, input));
+            }
+        }
+
+        let mut out = Vec::new();
+        for (key, mut pairs) in grouped {
+            pairs.reverse();
+            for (estimated, input) in pairs {
+                out.push(CalibrationObservation {
+                    provider: key.provider.clone(),
+                    model: key.model.clone(),
+                    request_kind: key.request_kind.clone(),
+                    has_tools: key.has_tools,
+                    estimated_tokens: estimated,
+                    input_tokens: input,
+                });
+            }
+        }
+        Ok(out)
+    }
 }
+
 #[cfg(test)]
 impl Database {
     pub(crate) fn get_llm_usage_summary(
@@ -248,6 +322,8 @@ mod tests {
             input_tokens: 100,
             output_tokens: 50,
             request_kind: "agent_loop",
+            estimated_tokens: 0,
+            has_tools: false,
         })
         .expect("log usage");
 
@@ -277,6 +353,8 @@ mod tests {
                 input_tokens: 1,
                 output_tokens: 1,
                 request_kind: kind,
+                estimated_tokens: 0,
+                has_tools: false,
             })
             .expect("log usage");
         }
@@ -293,6 +371,122 @@ mod tests {
         assert_eq!(
             kinds,
             &["agent_loop", "compaction", "sleep_batch", "pulse"].map(|s| s.to_string())
+        );
+    }
+
+    fn log_observation(db: &Database, input_tokens: i64, estimated: i64, has_tools: bool) {
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 1,
+            caller_channel: "test",
+            provider: "p",
+            model: "m",
+            input_tokens,
+            output_tokens: 0,
+            request_kind: "agent_loop",
+            estimated_tokens: estimated,
+            has_tools,
+        })
+        .expect("log usage");
+        // created_at has sub-ms resolution, but a small sleep guarantees a
+        // strictly increasing ordering for the deterministic assertions below.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+
+    #[test]
+    fn load_calibration_observations_returns_persisted_observations_oldest_first() {
+        // Arrange: two observations for the same key, written in order
+        let (db, _dir) = test_db();
+        log_observation(&db, 200, 100, true);
+        log_observation(&db, 300, 100, true);
+
+        // Act
+        let observations = db.load_calibration_observations(30).expect("load");
+
+        // Assert: oldest-first so the calibrator can replay chronologically
+        assert_eq!(observations.len(), 2);
+        assert_eq!(observations[0].input_tokens, 200);
+        assert_eq!(observations[1].input_tokens, 300);
+        assert_eq!(observations[0].estimated_tokens, 100);
+        assert!(observations[0].has_tools);
+        assert_eq!(observations[0].provider, "p");
+        assert_eq!(observations[0].request_kind, "agent_loop");
+    }
+
+    #[test]
+    fn load_calibration_observations_limits_to_most_recent_per_key() {
+        // Arrange: three observations for one key
+        let (db, _dir) = test_db();
+        log_observation(&db, 100, 50, false);
+        log_observation(&db, 200, 50, false);
+        log_observation(&db, 300, 50, false);
+
+        // Act: cap at the two most recent
+        let observations = db.load_calibration_observations(2).expect("load");
+
+        // Assert: only the two newest (200, 300), oldest-first
+        assert_eq!(observations.len(), 2);
+        assert_eq!(observations[0].input_tokens, 200);
+        assert_eq!(observations[1].input_tokens, 300);
+    }
+
+    #[test]
+    fn load_calibration_observations_excludes_rows_with_zero_estimate() {
+        // Arrange: one valid observation and one with a zero estimate
+        let (db, _dir) = test_db();
+        log_observation(&db, 200, 100, true);
+        log_observation(&db, 999, 0, false);
+
+        // Act
+        let observations = db.load_calibration_observations(30).expect("load");
+
+        // Assert: only the row with a positive estimate is returned
+        assert_eq!(observations.len(), 1);
+        assert_eq!(observations[0].input_tokens, 200);
+    }
+
+    #[test]
+    fn load_calibration_observations_keeps_keys_separate() {
+        // Arrange: observations for two distinct keys
+        let (db, _dir) = test_db();
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 1,
+            caller_channel: "test",
+            provider: "p",
+            model: "m",
+            input_tokens: 200,
+            output_tokens: 0,
+            request_kind: "agent_loop",
+            estimated_tokens: 100,
+            has_tools: true,
+        })
+        .expect("log agent_loop");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 1,
+            caller_channel: "test",
+            provider: "p",
+            model: "m",
+            input_tokens: 150,
+            output_tokens: 0,
+            request_kind: "compaction",
+            estimated_tokens: 100,
+            has_tools: false,
+        })
+        .expect("log compaction");
+
+        // Act
+        let observations = db.load_calibration_observations(30).expect("load");
+
+        // Assert: both keys appear, each with its own shape
+        assert_eq!(observations.len(), 2);
+        assert!(
+            observations.iter().any(|o| {
+                o.request_kind == "agent_loop" && o.has_tools && o.input_tokens == 200
+            })
+        );
+        assert!(
+            observations.iter().any(|o| {
+                o.request_kind == "compaction" && !o.has_tools && o.input_tokens == 150
+            })
         );
     }
 }


### PR DESCRIPTION
## 概要

Safety Compaction の補正係数（factor）を `llm_usage_logs` に永続化し、プロセス再起動後に最近の観測から再構築するようにしました。あわせて `DEFAULT_FACTOR` を 1.6 → 1.3 に引き下げ、未知キー初回ターンの過大見積もり帯域を縮小します。

## 背景

昨日、Discord ボット vega（agent lyre, chat_id=25）で明らかに早すぎるオートコンパクションが発火しました。ログ調査の結果、原因は以下でした。

- factor（生推定 chars/3 を実測 usage で校正する係数）は **メモリのみ保持** で、再起動のたびにリセットされていた
- egopulse が `12:14` に再起動 → `12:21` の最初のターンで `DEFAULT_FACTOR=1.6` が適用
- 生推定 98,964 トークン × 1.6 = 158,343 が閾値 153,446（usable 191,808 × 0.8）を **3% 超過** → 不要な発火
- `factor=1.5` なら発火しなかった（148,446 < 153,446）

つまり「再起動リセット + DEFAULT 過大」が直接原因。実測が蓄積されれば EMA で正しい factor に収束しますが、再起動のたびにリセットされるため問題が再発し続けます。

## 変更内容

### 1. 観測の永続化（核心）
- `llm_usage_logs` に `estimated_tokens`（生推定）・`has_tools` を **NOT NULL** で追加（schema v10 / secret v2）
- `record()` と `log_llm_usage()` を統合し、実測 `input_tokens` と同じ行に生推定を保存
- 起動時に `load_calibration_observations(limit_per_key=30)` で各キー最近30件を取得し、`replay()` で EMA 畳み込みして factor を再構築（`warm_up_calibrator`）
- replay は record と同じ EMA（α=0.3, clip [0.5, 3.0]）を使うため、再起動前後で factor が一致

### 2. DEFAULT_FACTOR 1.6 → 1.3
- 永続化により DEFAULT に頼るのは「真に未知の provider/model の初回1ターン」だけになったため、過大だった 1.6 を引き下げ
- vega ケースなら 98,964 × 1.3 = 128,653 < 153,446 で発火しない

### 3. sleep_batch 集計 usage 行の廃止
- `sleep/orchestrator.rs` の `log_llm_usage` は batch 内の複数 LLM 呼び出しの usage **合計値** を1行で記録しており、単一の推定値と対応しなかった
- 単一呼び出しのメタデータ（estimated_tokens）を NOT NULL で統一するため、この集計行の DB 記録を廃止
- `inc_llm_tokens_total`（Prometheus metrics）は維持し、コスト可観測性は残ります

### 後方互換
- **なし**（AGENTS.md「後方互換は負債」に従い新仕様へ一直線）
- 旧行（estimated なし）は DELETE して NOT NULL 追加。NULL/フォールバック分岐は作らない
- マイグレーションは PRAGMA table_info で事前チェックし冪等化（巻き戻し再実行テストに対応）

## テスト

- `calibration.rs`: replay の4テスト（再構築・incremental record との一致・非正値除外・空でリセット）
- `storage/tool.rs`: `load_calibration_observations` の4テスト（oldest-first順序・per-key limit・zero除外・キー分離）
- 既存テスト全通過（1483 + 10）。`cargo fmt` / `cargo clippy -D warnings` クリーン

## ドキュメント

- `docs/session-lifecycle.md` §5: 「メモリのみ保持」→「`llm_usage_logs` に永続化・起動時に再構築」
- `docs/db.md`: `llm_usage_logs` スキーマと操作に新カラムと `load_calibration_observations` を追記
- `docs/plan/plan-accurate-token-estimation.md`: 「非永続化」記述を永続化に、`DEFAULT_FACTOR=1.6`→1.3 に更新

## 確認してほしい点

- `DEFAULT_FACTOR=1.3` で妥当か（1.0 は日本語での chars/3 過小評価リスクがあり不可）
- `warm_up_calibrator` の e2e テストは省略しています（storage + calibration の単体テストで核心をカバー。接着層のため）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 保存済みのLLM使用観測を読み込み、推定補正を再構築
* **変更・改善**
  * LLM使用量ログに推定入力トークン数とツール利用有無を記録
  * 未計測時の既定補正係数を 1.3 に調整
  * 睡眠バッチでの使用量ログの重複記録を削減
<!-- end of auto-generated comment: release notes by coderabbit.ai -->