### PR TITLE
fix: LLMプロバイダのストリーミング実装によるnarration復旧

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
+ "bytes",
  "chrono",
  "chrono-tz",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
+bytes = "1"
 chrono = "0.4"
 chrono-tz = "0.10"
 clap = { version = "4.6", features = ["derive"] }

--- a/docs/openai-codex.md
+++ b/docs/openai-codex.md
@@ -75,7 +75,7 @@ tools がある場合:
 
 | Event | 扱い |
 |---|---|
-| `response.output_text.delta` | text 差分として連結 |
+| `response.output_text.delta` | text 差分として連結しつつ `on_delta` で即時転送（ツール進捗の narration 表示用） |
 | `response.output_text.done` | 完成 text として採用 |
 | `response.output_item.done` | `item` を `ResponsesOutputItem` として parse |
 | `response.completed` / `response.done` | final response として保持 |

--- a/src/agent_loop/session.rs
+++ b/src/agent_loop/session.rs
@@ -377,6 +377,17 @@ mod tests {
                 usage: None,
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     fn test_config(state_root: String) -> Config {

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -1074,6 +1074,17 @@ impl crate::llm::LlmProvider for FakeProvider {
         Ok(locked.remove(0))
     }
 
+    async fn send_message_streaming(
+        &self,
+        system: &str,
+        messages: Arc<Vec<Message>>,
+        tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+        on_delta: &(dyn Fn(String) + Send + Sync),
+    ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+        let _ = on_delta;
+        self.send_message(system, messages, tools).await
+    }
+
     fn provider_name(&self) -> &str {
         "test"
     }
@@ -1093,6 +1104,17 @@ impl crate::llm::LlmProvider for FailingProvider {
         _tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
     ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
         Err(crate::error::LlmError::InvalidResponse("boom".to_string()))
+    }
+
+    async fn send_message_streaming(
+        &self,
+        system: &str,
+        messages: Arc<Vec<Message>>,
+        tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+        on_delta: &(dyn Fn(String) + Send + Sync),
+    ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+        let _ = on_delta;
+        self.send_message(system, messages, tools).await
     }
 
     fn provider_name(&self) -> &str {
@@ -1126,6 +1148,17 @@ impl crate::llm::LlmProvider for RecordingProvider {
             tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         }
         self.responses.lock().expect("responses").remove(0)
+    }
+
+    async fn send_message_streaming(
+        &self,
+        system: &str,
+        messages: Arc<Vec<Message>>,
+        tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+        on_delta: &(dyn Fn(String) + Send + Sync),
+    ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+        let _ = on_delta;
+        self.send_message(system, messages, tools).await
     }
 
     fn provider_name(&self) -> &str {

--- a/src/agent_loop/turn.rs
+++ b/src/agent_loop/turn.rs
@@ -2536,4 +2536,195 @@ mod tests {
             );
         }
     }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: real OpenAiProvider streaming → coordinator narration
+    // -----------------------------------------------------------------------
+
+    #[derive(Default, Clone)]
+    struct NarrationCalls {
+        begins: Vec<String>,
+        updates: Vec<String>,
+        closes: usize,
+    }
+
+    struct NarrationSink {
+        calls: Arc<Mutex<NarrationCalls>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::channels::adapter::ToolProgressSink for NarrationSink {
+        async fn begin(
+            &self,
+            _external_chat_id: &str,
+            body: &str,
+        ) -> Result<Box<dyn crate::channels::adapter::ToolProgressHandle>, String> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .begins
+                .push(body.to_string());
+            Ok(Box::new(NarrationHandle {
+                calls: Arc::clone(&self.calls),
+            }))
+        }
+    }
+
+    struct NarrationHandle {
+        calls: Arc<Mutex<NarrationCalls>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::channels::adapter::ToolProgressHandle for NarrationHandle {
+        async fn update(&mut self, body: &str) -> Result<(), String> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .updates
+                .push(body.to_string());
+            Ok(())
+        }
+
+        async fn close(self: Box<Self>) -> Result<(), String> {
+            self.calls.lock().expect("calls lock").closes += 1;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn provider_streaming_drives_coordinator_narration() {
+        use std::time::Duration;
+
+        use crate::channels::adapter::ToolProgressSink;
+        use crate::config::ResolvedLlmConfig;
+        use crate::llm::OpenAiProvider;
+        use crate::runtime::tool_progress::ToolProgressCoordinator;
+
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Arrange: a wiremock SSE server returning two sequential responses.
+        let server = MockServer::start().await;
+
+        // 1st request only: narration deltas + a read tool call.
+        // Mounted first so insertion-order precedence picks it before the fallback.
+        let tool_args = serde_json::json!({"path": "note.txt"}).to_string();
+        let sse_first = [
+            format!(
+                "data: {}\n\n",
+                serde_json::json!({"choices":[{"delta":{"content":"ファイルを"}}]})
+            ),
+            format!(
+                "data: {}\n\n",
+                serde_json::json!({"choices":[{"delta":{"content":"確認します"}}]})
+            ),
+            format!(
+                "data: {}\n\n",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-narration","type":"function","function":{"name":"read","arguments":tool_args}}]}}]})
+            ),
+            "data: [DONE]\n\n".to_string(),
+        ]
+        .concat();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_first, "text/event-stream"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Fallback (2nd+ request): final answer, no tool calls.
+        let sse_final = [
+            format!(
+                "data: {}\n\n",
+                serde_json::json!({"choices":[{"delta":{"content":"読み取りが完了しました。"}}]})
+            ),
+            "data: [DONE]\n\n".to_string(),
+        ]
+        .concat();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_final, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        // Build a *real* OpenAiProvider pointed at the wiremock server.
+        let provider = OpenAiProvider::new(&ResolvedLlmConfig {
+            provider: "test".to_string(),
+            label: "Test".to_string(),
+            base_url: format!("{}/v1", server.uri()),
+            api_key: Some(secrecy::SecretString::new(
+                "sk-test".to_string().into_boxed_str(),
+            )),
+            model: "gpt-4o-mini".to_string(),
+        })
+        .expect("provider");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+
+        // Workspace file the `read` tool will open.
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
+        std::fs::create_dir_all(&workspace).expect("workspace dir");
+        std::fs::write(workspace.join("note.txt"), "hello world").expect("write note");
+
+        // Bridge agent-loop events into a ToolProgressCoordinator with a mock sink.
+        let calls = Arc::new(Mutex::new(NarrationCalls::default()));
+        let sink: Arc<dyn ToolProgressSink> = Arc::new(NarrationSink {
+            calls: Arc::clone(&calls),
+        });
+        let (evt_tx, evt_rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
+        let coordinator = ToolProgressCoordinator::with_timings(
+            Some(sink),
+            "discord:1:agent:default".to_string(),
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+        );
+        let coord_handle = tokio::spawn(coordinator.run(evt_rx));
+
+        // Act: run a full turn through the real OpenAiProvider. Each event
+        // is forwarded to the coordinator. Dropping the closure on return
+        // closes the channel, signalling EOF to the coordinator.
+        let reply = process_turn_with_events(
+            &state,
+            &cli_context("narration-e2e"),
+            "please read note.txt",
+            move |event| {
+                let _ = evt_tx.send(event);
+            },
+        )
+        .await
+        .expect("process turn");
+
+        // Wait for the coordinator to drain and close.
+        let () = coord_handle.await.expect("coordinator join");
+
+        // Assert: the posted progress body contains the narration (💬) before
+        // the tool line (... read), proving the provider→Delta→coordinator path.
+        let snapshot = calls.lock().expect("calls").clone();
+        assert!(
+            snapshot.closes >= 1,
+            "coordinator should have closed the progress message"
+        );
+        let body = snapshot
+            .begins
+            .first()
+            .or_else(|| snapshot.updates.last())
+            .expect("at least one progress body");
+        assert!(
+            body.contains("💬 ファイルを確認します"),
+            "narration missing from body: {body}"
+        );
+        assert!(body.contains("... read"), "tool line missing: {body}");
+        let narration_idx = body.find('💬').expect("narration position");
+        let tool_idx = body.find("... read").expect("tool position");
+        assert!(
+            narration_idx < tool_idx,
+            "narration must precede tool: {body}"
+        );
+        assert!(!reply.is_empty(), "turn should produce a final response");
+    }
 }

--- a/src/channels/web/agents.rs
+++ b/src/channels/web/agents.rs
@@ -67,6 +67,17 @@ mod tests {
         ) -> Result<MessagesResponse, LlmError> {
             panic!("handler tests should not call LLM")
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     fn test_web_state(dir: &tempfile::TempDir) -> WebState {

--- a/src/channels/web/sessions.rs
+++ b/src/channels/web/sessions.rs
@@ -263,6 +263,17 @@ mod tests {
         ) -> Result<MessagesResponse, LlmError> {
             panic!("handler tests should not call LLM")
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     fn test_web_state(dir: &tempfile::TempDir) -> WebState {

--- a/src/channels/web/sleep.rs
+++ b/src/channels/web/sleep.rs
@@ -200,6 +200,17 @@ mod tests {
         ) -> Result<MessagesResponse, LlmError> {
             panic!("handler tests should not call LLM")
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     fn test_web_state(dir: &tempfile::TempDir) -> WebState {

--- a/src/channels/web/ws.rs
+++ b/src/channels/web/ws.rs
@@ -734,6 +734,17 @@ mod tests {
                 usage: None,
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<LlmMessage>>,
+            tools: Option<Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     fn test_web_state(dir: &tempfile::TempDir) -> WebState {

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod codex_auth;
 mod messages;
 mod openai;
 mod responses;
+mod sse;
 
 use std::sync::Arc;
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -168,10 +168,7 @@ pub(crate) trait LlmProvider: Send + Sync {
         messages: Arc<Vec<Message>>,
         tools: Option<Arc<Vec<ToolDefinition>>>,
         on_delta: &(dyn Fn(String) + Send + Sync),
-    ) -> Result<MessagesResponse, LlmError> {
-        let _ = on_delta;
-        self.send_message(system, messages, tools).await
-    }
+    ) -> Result<MessagesResponse, LlmError>;
 }
 
 /// Create the default LLM provider based on the resolved request-time configuration.
@@ -722,6 +719,17 @@ mod tests {
                 let _ = tools;
                 unreachable!()
             }
+
+            async fn send_message_streaming(
+                &self,
+                _system: &str,
+                _messages: Arc<Vec<Message>>,
+                tools: Option<Arc<Vec<ToolDefinition>>>,
+                on_delta: &(dyn Fn(String) + Send + Sync),
+            ) -> Result<MessagesResponse, LlmError> {
+                let _ = (tools, on_delta);
+                unreachable!()
+            }
         }
 
         let stub = StubProvider;
@@ -755,6 +763,16 @@ mod tests {
                 _system: &str,
                 _messages: Arc<Vec<Message>>,
                 _tools: Option<Arc<Vec<ToolDefinition>>>,
+            ) -> Result<MessagesResponse, LlmError> {
+                unreachable!()
+            }
+
+            async fn send_message_streaming(
+                &self,
+                _system: &str,
+                _messages: Arc<Vec<Message>>,
+                _tools: Option<Arc<Vec<ToolDefinition>>>,
+                _on_delta: &(dyn Fn(String) + Send + Sync),
             ) -> Result<MessagesResponse, LlmError> {
                 unreachable!()
             }

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -205,6 +205,82 @@ impl OpenAiProvider {
             retry_after_secs,
         }
     }
+
+    async fn stream_responses_api(
+        &self,
+        system: &str,
+        messages: Arc<Vec<Message>>,
+        tools: Option<Arc<Vec<ToolDefinition>>>,
+        on_delta: &(dyn Fn(String) + Send + Sync),
+    ) -> Result<MessagesResponse, LlmError> {
+        let url = format!("{}/responses", self.base_url.trim_end_matches('/'));
+        let mut body = build_responses_request_body(
+            &self.model,
+            system,
+            &messages,
+            tools.as_deref().map(|arc| arc.as_slice()),
+        );
+        body["stream"] = serde_json::Value::Bool(true);
+
+        let response = self
+            .http
+            .post(url)
+            .headers(self.build_headers()?)
+            .json(&body)
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let retry_after = parse_retry_after(response.headers());
+            return Err(Self::api_error(
+                status,
+                response.text().await.unwrap_or_default(),
+                retry_after,
+            ));
+        }
+
+        let mut accumulator = ResponsesAccumulator::new();
+        let mut data_stream = crate::llm::sse::data_lines(response.bytes_stream());
+        while let Some(payload) = data_stream.next().await {
+            if accumulator.process_event(&payload, on_delta) {
+                break;
+            }
+        }
+        accumulator.finish()
+    }
+
+    async fn stream_codex_responses(
+        &self,
+        system: &str,
+        messages: Arc<Vec<Message>>,
+        tools: Option<Arc<Vec<ToolDefinition>>>,
+        on_delta: &(dyn Fn(String) + Send + Sync),
+    ) -> Result<MessagesResponse, LlmError> {
+        crate::llm::codex_auth::refresh_if_needed(&self.http).await;
+
+        let url = format!("{}/responses", self.base_url.trim_end_matches('/'));
+        let mut body = build_responses_request_body(
+            &self.model,
+            system,
+            &messages,
+            tools.as_deref().map(|arc| arc.as_slice()),
+        );
+        body["store"] = serde_json::Value::Bool(false);
+        body["stream"] = serde_json::Value::Bool(true);
+
+        let text = self.send_codex_with_retry(&url, &body).await?;
+
+        let mut accumulator = ResponsesAccumulator::new();
+        for line in text.lines() {
+            let Some(payload) = crate::llm::sse::data_payload(line.trim()) else {
+                continue;
+            };
+            if accumulator.process_event(payload, on_delta) {
+                break;
+            }
+        }
+        accumulator.finish()
+    }
 }
 
 fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<u64> {
@@ -283,12 +359,14 @@ impl LlmProvider for OpenAiProvider {
         on_delta: &(dyn Fn(String) + Send + Sync),
     ) -> Result<MessagesResponse, LlmError> {
         if self.is_codex {
-            let _ = on_delta;
-            return self.send_message(system, messages, tools).await;
+            return self
+                .stream_codex_responses(system, messages, tools, on_delta)
+                .await;
         }
         if should_use_responses_api(&messages) {
-            let _ = on_delta;
-            return self.send_message(system, messages, tools).await;
+            return self
+                .stream_responses_api(system, messages, tools, on_delta)
+                .await;
         }
 
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
@@ -455,7 +533,9 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::config::ResolvedLlmConfig;
-    use crate::llm::{LlmProvider, LlmUsage, Message, ToolCall};
+    use crate::llm::{
+        LlmProvider, LlmUsage, Message, MessageContent, MessageContentPart, ToolCall,
+    };
 
     use super::OpenAiProvider;
 
@@ -632,6 +712,132 @@ mod tests {
                 name: "list".to_string(),
                 arguments: serde_json::json!({}),
             }]
+        );
+    }
+
+    fn multimodal_message() -> Arc<Vec<Message>> {
+        Arc::new(vec![Message {
+            role: "user".to_string(),
+            content: MessageContent::parts(vec![
+                MessageContentPart::InputText {
+                    text: "describe this image".to_string(),
+                },
+                MessageContentPart::InputImage {
+                    image_url: "data:image/png;base64,AAAA".to_string(),
+                    detail: Some("auto".to_string()),
+                },
+            ]),
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+        }])
+    }
+
+    #[tokio::test]
+    async fn streams_responses_api_text_deltas_via_on_delta() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ファイルを\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"確認します\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ファイルを確認します\"}]}],\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = OpenAiProvider::new(&config(
+            "gpt-4o-mini",
+            format!("{}/v1", server.uri()),
+            Some("sk-test"),
+        ))
+        .expect("provider");
+
+        let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recorded_for_closure = Arc::clone(&recorded);
+        let on_delta = move |delta: String| {
+            recorded_for_closure
+                .lock()
+                .expect("on_delta lock poisoned")
+                .push(delta);
+        };
+
+        let response = provider
+            .send_message_streaming("", multimodal_message(), None, &on_delta)
+            .await
+            .expect("response");
+
+        assert_eq!(
+            recorded.lock().expect("lock poisoned").as_slice(),
+            ["ファイルを".to_string(), "確認します".to_string()]
+        );
+        assert_eq!(response.content, "ファイルを確認します");
+        assert_eq!(
+            response.usage,
+            Some(LlmUsage {
+                input_tokens: 10,
+                output_tokens: 5,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn streams_codex_text_deltas_via_on_delta() {
+        let codex_dir = tempfile::tempdir().expect("tempdir");
+        let _env =
+            crate::test_env::EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "test-codex-token")
+                .also_set("CODEX_HOME", codex_dir.path());
+        crate::llm::codex_auth::clear_auth_cache();
+
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"thinking\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\" carefully\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":7}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let codex_config = ResolvedLlmConfig {
+            provider: "openai-codex".to_string(),
+            label: "Codex".to_string(),
+            base_url: format!("{}/v1", server.uri()),
+            api_key: None,
+            model: "gpt-5.3-codex".to_string(),
+        };
+        let provider = OpenAiProvider::new(&codex_config).expect("provider");
+
+        let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recorded_for_closure = Arc::clone(&recorded);
+        let on_delta = move |delta: String| {
+            recorded_for_closure
+                .lock()
+                .expect("on_delta lock poisoned")
+                .push(delta);
+        };
+
+        let response = provider
+            .send_message_streaming("", message("hello"), None, &on_delta)
+            .await
+            .expect("response");
+
+        assert_eq!(
+            recorded.lock().expect("lock poisoned").as_slice(),
+            ["thinking".to_string(), " carefully".to_string()]
+        );
+        assert_eq!(response.content, "thinking carefully");
+        assert_eq!(
+            response.usage,
+            Some(LlmUsage {
+                input_tokens: 3,
+                output_tokens: 7,
+            })
         );
     }
 }

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -79,11 +79,9 @@ impl OpenAiProvider {
         }
 
         if self.is_codex {
-            return self
-                .send_codex_with_retry(&url, &body)
-                .await
-                .and_then(|text| parse_codex_responses_payload(&text))
-                .and_then(parse_responses_response);
+            let response = self.send_codex_with_retry(&url, &body).await?;
+            let text = response.text().await.map_err(LlmError::RequestFailed)?;
+            return parse_codex_responses_payload(&text).and_then(parse_responses_response);
         }
 
         let response = self
@@ -110,14 +108,16 @@ impl OpenAiProvider {
 
     /// Sends a Codex request with exponential-backoff retry on 429 responses.
     ///
-    /// On success, returns the raw response text (which may be plain JSON or SSE).
-    /// On non-429 failure, attempts to extract a structured error message from the
-    /// response body before returning.
+    /// On success, returns the streaming `reqwest::Response` so callers can
+    /// either consume the body as text (non-stream path) or iterate its
+    /// `bytes_stream` for incremental delta emission (stream path).
+    /// On non-429 failure, attempts to extract a structured error message from
+    /// the response body before returning.
     async fn send_codex_with_retry(
         &self,
         url: &str,
         body: &serde_json::Value,
-    ) -> Result<String, LlmError> {
+    ) -> Result<reqwest::Response, LlmError> {
         let max_retries: u32 = 3;
         let mut retries = 0u32;
 
@@ -132,7 +132,7 @@ impl OpenAiProvider {
 
             let status = response.status();
             if status.is_success() {
-                return response.text().await.map_err(LlmError::RequestFailed);
+                return Ok(response);
             }
 
             if status.as_u16() == 429 && retries < max_retries {
@@ -268,14 +268,12 @@ impl OpenAiProvider {
         body["store"] = serde_json::Value::Bool(false);
         body["stream"] = serde_json::Value::Bool(true);
 
-        let text = self.send_codex_with_retry(&url, &body).await?;
+        let response = self.send_codex_with_retry(&url, &body).await?;
 
         let mut accumulator = ResponsesAccumulator::new();
-        for line in text.lines() {
-            let Some(payload) = crate::llm::sse::data_payload(line.trim()) else {
-                continue;
-            };
-            if accumulator.process_event(payload, on_delta) {
+        let mut data_stream = crate::llm::sse::data_lines(response.bytes_stream());
+        while let Some(payload) = data_stream.next().await {
+            if accumulator.process_event(&payload, on_delta) {
                 break;
             }
         }

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -1,5 +1,6 @@
 use super::*;
 use super::{messages::*, responses::*};
+use futures_util::StreamExt;
 use reqwest::StatusCode;
 use reqwest::header::HeaderName;
 use std::sync::Arc;
@@ -280,8 +281,49 @@ impl LlmProvider for OpenAiProvider {
         tools: Option<Arc<Vec<ToolDefinition>>>,
         on_delta: &(dyn Fn(String) + Send + Sync),
     ) -> Result<MessagesResponse, LlmError> {
-        let _ = on_delta;
-        self.send_message(system, messages, tools).await
+        if self.is_codex {
+            let _ = on_delta;
+            return self.send_message(system, messages, tools).await;
+        }
+        if should_use_responses_api(&messages) {
+            let _ = on_delta;
+            return self.send_message(system, messages, tools).await;
+        }
+
+        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+        let headers = self.build_headers()?;
+        let body = build_request_body(
+            &self.model,
+            system,
+            &messages,
+            tools.as_deref().map(|arc| arc.as_slice()),
+            Some(true),
+            should_preserve_reasoning_content(&self.provider, &self.base_url, &self.model),
+        );
+
+        let response = self
+            .http
+            .post(url)
+            .headers(headers)
+            .json(&body)
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let retry_after = parse_retry_after(response.headers());
+            return Err(Self::api_error(
+                status,
+                response.text().await.unwrap_or_default(),
+                retry_after,
+            ));
+        }
+
+        let mut accumulator = ChatCompletionAccumulator::new();
+        let mut data_stream = crate::llm::sse::data_lines(response.bytes_stream());
+        while let Some(payload) = data_stream.next().await {
+            accumulator.process_chunk(&payload, on_delta);
+        }
+        accumulator.finish()
     }
 }
 
@@ -300,4 +342,143 @@ fn is_deepseek_base_url(base_url: &str) -> bool {
         .ok()
         .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
         .is_some_and(|host| host == "deepseek.com" || host.ends_with(".deepseek.com"))
+}
+
+fn parse_chat_completion_usage(usage: &serde_json::Value) -> Option<LlmUsage> {
+    let prompt_tokens = usage.get("prompt_tokens").and_then(|v| v.as_i64())?;
+    let completion_tokens = usage.get("completion_tokens").and_then(|v| v.as_i64())?;
+    Some(LlmUsage {
+        input_tokens: prompt_tokens,
+        output_tokens: completion_tokens,
+    })
+}
+
+struct ChatCompletionAccumulator {
+    content: String,
+    reasoning_content: Option<String>,
+    usage: Option<LlmUsage>,
+}
+
+impl ChatCompletionAccumulator {
+    fn new() -> Self {
+        Self {
+            content: String::new(),
+            reasoning_content: None,
+            usage: None,
+        }
+    }
+
+    fn process_chunk(&mut self, payload: &str, on_delta: &dyn Fn(String)) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+            tracing::warn!("skipping malformed SSE data line");
+            return;
+        };
+        if let Some(delta) = value
+            .get("choices")
+            .and_then(|choices| choices.get(0))
+            .and_then(|choice| choice.get("delta"))
+        {
+            if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    on_delta(text.to_string());
+                }
+                self.content.push_str(text);
+            }
+            if let Some(reasoning) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
+                match &mut self.reasoning_content {
+                    Some(existing) => existing.push_str(reasoning),
+                    None => self.reasoning_content = Some(reasoning.to_string()),
+                }
+            }
+        }
+        if let Some(usage_value) = value.get("usage") {
+            self.usage = parse_chat_completion_usage(usage_value);
+        }
+    }
+
+    fn finish(self) -> Result<MessagesResponse, LlmError> {
+        assemble_response(self.content, self.reasoning_content, Vec::new(), self.usage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::config::ResolvedLlmConfig;
+    use crate::llm::{LlmProvider, LlmUsage, Message};
+
+    use super::OpenAiProvider;
+
+    fn config(model: &str, base_url: String, api_key: Option<&str>) -> ResolvedLlmConfig {
+        ResolvedLlmConfig {
+            provider: "test".to_string(),
+            label: "Test".to_string(),
+            base_url,
+            api_key: api_key
+                .map(|value| secrecy::SecretString::new(value.to_string().into_boxed_str())),
+            model: model.to_string(),
+        }
+    }
+
+    fn message(content: &str) -> Arc<Vec<Message>> {
+        Arc::new(vec![Message::text("user", content)])
+    }
+
+    #[tokio::test]
+    async fn streams_chat_completions_text_deltas_via_on_delta() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"ファイルを\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"確認します\",\"reasoning_content\":\"考えている\"}}]}\n\n",
+            "data: {\"choices\":[]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
+            "data: [DONE]\n\n",
+            "garbage line\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = OpenAiProvider::new(&config(
+            "gpt-4o-mini",
+            format!("{}/v1", server.uri()),
+            Some("sk-test"),
+        ))
+        .expect("provider");
+
+        let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recorded_for_closure = Arc::clone(&recorded);
+        let on_delta = move |delta: String| {
+            recorded_for_closure
+                .lock()
+                .expect("on_delta lock poisoned")
+                .push(delta);
+        };
+
+        let response = provider
+            .send_message_streaming("", message("hello"), None, &on_delta)
+            .await
+            .expect("response");
+
+        assert_eq!(
+            recorded.lock().expect("lock poisoned").as_slice(),
+            ["ファイルを".to_string(), "確認します".to_string()]
+        );
+        assert_eq!(response.content, "ファイルを確認します");
+        assert_eq!(response.reasoning_content.as_deref(), Some("考えている"));
+        assert_eq!(
+            response.usage,
+            Some(LlmUsage {
+                input_tokens: 10,
+                output_tokens: 5,
+            })
+        );
+        assert!(response.tool_calls.is_empty());
+    }
 }

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -3,6 +3,7 @@ use super::{messages::*, responses::*};
 use futures_util::StreamExt;
 use reqwest::StatusCode;
 use reqwest::header::HeaderName;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 const REQUEST_TIMEOUT_SECS: u64 = 300;
@@ -356,6 +357,7 @@ fn parse_chat_completion_usage(usage: &serde_json::Value) -> Option<LlmUsage> {
 struct ChatCompletionAccumulator {
     content: String,
     reasoning_content: Option<String>,
+    tool_calls: BTreeMap<usize, StreamingToolCall>,
     usage: Option<LlmUsage>,
 }
 
@@ -364,6 +366,7 @@ impl ChatCompletionAccumulator {
         Self {
             content: String::new(),
             reasoning_content: None,
+            tool_calls: BTreeMap::new(),
             usage: None,
         }
     }
@@ -390,15 +393,58 @@ impl ChatCompletionAccumulator {
                     None => self.reasoning_content = Some(reasoning.to_string()),
                 }
             }
+            if let Some(tool_calls) = delta.get("tool_calls").and_then(|v| v.as_array()) {
+                for entry in tool_calls {
+                    self.ingest_tool_call_delta(entry);
+                }
+            }
         }
         if let Some(usage_value) = value.get("usage") {
             self.usage = parse_chat_completion_usage(usage_value);
         }
     }
 
-    fn finish(self) -> Result<MessagesResponse, LlmError> {
-        assemble_response(self.content, self.reasoning_content, Vec::new(), self.usage)
+    fn ingest_tool_call_delta(&mut self, entry: &serde_json::Value) {
+        let Some(index) = entry.get("index").and_then(|v| v.as_u64()) else {
+            return;
+        };
+        let slot = self.tool_calls.entry(index as usize).or_default();
+        if let Some(id) = entry.get("id").and_then(|v| v.as_str()) {
+            slot.id = Some(id.to_string());
+        }
+        if let Some(function) = entry.get("function") {
+            if let Some(name) = function.get("name").and_then(|v| v.as_str()) {
+                slot.name = Some(name.to_string());
+            }
+            if let Some(arguments) = function.get("arguments").and_then(|v| v.as_str()) {
+                slot.arguments.push_str(arguments);
+            }
+        }
     }
+
+    fn finish(self) -> Result<MessagesResponse, LlmError> {
+        let tool_calls = self
+            .tool_calls
+            .into_values()
+            .map(|slot| {
+                let name = slot.name.unwrap_or_default();
+                let arguments = parse_tool_arguments(&slot.arguments, &name)?;
+                Ok(ToolCall {
+                    id: slot.id.unwrap_or_default(),
+                    name,
+                    arguments,
+                })
+            })
+            .collect::<Result<Vec<_>, LlmError>>()?;
+        assemble_response(self.content, self.reasoning_content, tool_calls, self.usage)
+    }
+}
+
+#[derive(Default)]
+struct StreamingToolCall {
+    id: Option<String>,
+    name: Option<String>,
+    arguments: String,
 }
 
 #[cfg(test)]
@@ -409,7 +455,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::config::ResolvedLlmConfig;
-    use crate::llm::{LlmProvider, LlmUsage, Message};
+    use crate::llm::{LlmProvider, LlmUsage, Message, ToolCall};
 
     use super::OpenAiProvider;
 
@@ -480,5 +526,112 @@ mod tests {
             })
         );
         assert!(response.tool_calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn accumulates_streaming_tool_calls_by_index_in_order() {
+        let server = MockServer::start().await;
+        // index:1 arguments arrive before index:0 finishes, yet the result
+        // must be ordered [0, 1].
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_b\",\"type\":\"function\",\"function\":{\"name\":\"grep\",\"arguments\":\"\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"{\\\"pattern\\\":\\\"foo\\\"}\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"README.md\\\"}\"}}]}}]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":2}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = OpenAiProvider::new(&config(
+            "gpt-4o-mini",
+            format!("{}/v1", server.uri()),
+            Some("sk-test"),
+        ))
+        .expect("provider");
+
+        let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recorded_for_closure = Arc::clone(&recorded);
+        let on_delta = move |delta: String| {
+            recorded_for_closure
+                .lock()
+                .expect("on_delta lock poisoned")
+                .push(delta);
+        };
+
+        let response = provider
+            .send_message_streaming("", message("use tools"), None, &on_delta)
+            .await
+            .expect("response");
+
+        assert_eq!(
+            response.tool_calls,
+            vec![
+                ToolCall {
+                    id: "call_a".to_string(),
+                    name: "read".to_string(),
+                    arguments: serde_json::json!({"path": "README.md"}),
+                },
+                ToolCall {
+                    id: "call_b".to_string(),
+                    name: "grep".to_string(),
+                    arguments: serde_json::json!({"pattern": "foo"}),
+                },
+            ]
+        );
+        assert!(response.content.is_empty());
+        assert!(recorded.lock().expect("lock poisoned").is_empty());
+    }
+
+    #[tokio::test]
+    async fn no_delta_when_content_empty_tool_only() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_x\",\"type\":\"function\",\"function\":{\"name\":\"list\",\"arguments\":\"{}\"}}]}}]}\n\n",
+            "data: {\"choices\":[]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = OpenAiProvider::new(&config(
+            "gpt-4o-mini",
+            format!("{}/v1", server.uri()),
+            Some("sk-test"),
+        ))
+        .expect("provider");
+
+        let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recorded_for_closure = Arc::clone(&recorded);
+        let on_delta = move |delta: String| {
+            recorded_for_closure
+                .lock()
+                .expect("on_delta lock poisoned")
+                .push(delta);
+        };
+
+        let response = provider
+            .send_message_streaming("", message("tool only"), None, &on_delta)
+            .await
+            .expect("response");
+
+        assert!(recorded.lock().expect("lock poisoned").is_empty());
+        assert!(response.content.is_empty());
+        assert_eq!(
+            response.tool_calls,
+            vec![ToolCall {
+                id: "call_x".to_string(),
+                name: "list".to_string(),
+                arguments: serde_json::json!({}),
+            }]
+        );
     }
 }

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -272,6 +272,17 @@ impl LlmProvider for OpenAiProvider {
         let body: OpenAiResponse = response.json().await?;
         parse_openai_response(body)
     }
+
+    async fn send_message_streaming(
+        &self,
+        system: &str,
+        messages: Arc<Vec<Message>>,
+        tools: Option<Arc<Vec<ToolDefinition>>>,
+        on_delta: &(dyn Fn(String) + Send + Sync),
+    ) -> Result<MessagesResponse, LlmError> {
+        let _ = on_delta;
+        self.send_message(system, messages, tools).await
+    }
 }
 
 pub(crate) fn should_preserve_reasoning_content(

--- a/src/llm/responses.rs
+++ b/src/llm/responses.rs
@@ -300,17 +300,20 @@ impl ResponsesAccumulator {
             return false;
         };
 
-        if let Some(item_value) = value.get_mut("item")
+        let event_type = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        // Only the `done` item is complete; `added` carries an in_progress
+        // partial item that would duplicate the finalized one.
+        if event_type.as_deref() == Some("response.output_item.done")
+            && let Some(item_value) = value.get_mut("item")
             && let Ok(item) = serde_json::from_value::<ResponsesOutputItem>(item_value.take())
             && !matches!(item, ResponsesOutputItem::Ignored)
         {
             self.streamed_items.push(item);
         }
-
-        let event_type = value
-            .get("type")
-            .and_then(|v| v.as_str())
-            .map(str::to_string);
 
         match event_type.as_deref() {
             Some("response.output_text.delta") => {
@@ -880,6 +883,26 @@ data: {"type":"response.completed","response":{"status":"completed","output":[],
         let parsed = parse_codex_responses_payload(item).expect("item");
         let resp = parse_responses_response(parsed).expect("resp");
         assert_eq!(resp.content, "item-content");
+    }
+
+    #[test]
+    fn dedupes_output_item_across_added_and_done_events() {
+        let payload = r#"
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"get_weather","arguments":"{}"}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"get_weather","arguments":"{}"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":2}}}
+"#;
+
+        let parsed = parse_codex_responses_payload(payload).expect("payload");
+        let response = parse_responses_response(parsed).expect("response");
+
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].name, "get_weather");
     }
 
     #[test]

--- a/src/llm/responses.rs
+++ b/src/llm/responses.rs
@@ -251,100 +251,157 @@ pub(crate) fn parse_codex_responses_payload(text: &str) -> Result<ResponsesApiRe
     if let Ok(parsed) = serde_json::from_str::<ResponsesApiResponse>(text) {
         return Ok(parsed);
     }
-    let mut last_response: Option<ResponsesApiResponse> = None;
-    let mut streamed_text = String::with_capacity(8192);
-    let mut streamed_items = Vec::with_capacity(32);
 
+    let mut accumulator = ResponsesAccumulator::new();
     for line in text.lines() {
-        let line = line.trim();
-        if !line.starts_with("data:") {
+        let Some(payload) = crate::llm::sse::data_payload(line.trim()) else {
             continue;
+        };
+        if accumulator.process_event(payload, &|_| {}) {
+            break;
         }
-        let payload = line.trim_start_matches("data:").trim();
-        if payload.is_empty() || payload == "[DONE]" {
-            continue;
+    }
+
+    accumulator.into_api_response().map_err(|_| {
+        LlmError::InvalidResponse(format!(
+            "Failed to parse Codex response payload. Body: {}",
+            preview_body(text)
+        ))
+    })
+}
+
+/// Accumulates Responses API SSE events into a final [`ResponsesApiResponse`].
+///
+/// Shared by the non-stream Codex path ([`parse_codex_responses_payload`]) and
+/// the streaming Responses/Codex paths in `send_message_streaming` to keep
+/// delta extraction and final response assembly consistent.
+pub(crate) struct ResponsesAccumulator {
+    streamed_text: String,
+    streamed_items: Vec<ResponsesOutputItem>,
+    last_response: Option<ResponsesApiResponse>,
+}
+
+impl ResponsesAccumulator {
+    pub(crate) fn new() -> Self {
+        Self {
+            streamed_text: String::with_capacity(8192),
+            streamed_items: Vec::with_capacity(32),
+            last_response: None,
         }
+    }
+
+    /// Processes one SSE `data:` payload (JSON text without the `data:` prefix).
+    ///
+    /// Calls `on_delta` for each `response.output_text.delta` event. Returns
+    /// `true` when a terminal event (`response.completed` / `response.done`)
+    /// carrying a valid `response` object has been consumed.
+    pub(crate) fn process_event(&mut self, payload: &str, on_delta: &dyn Fn(String)) -> bool {
         let Ok(mut value) = serde_json::from_str::<serde_json::Value>(payload) else {
-            continue;
+            return false;
         };
 
         if let Some(item_value) = value.get_mut("item")
             && let Ok(item) = serde_json::from_value::<ResponsesOutputItem>(item_value.take())
             && !matches!(item, ResponsesOutputItem::Ignored)
         {
-            streamed_items.push(item);
+            self.streamed_items.push(item);
         }
 
-        let event_type = value.get("type").and_then(|v| v.as_str()).map(String::from);
+        let event_type = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
         match event_type.as_deref() {
             Some("response.output_text.delta") => {
                 if let Some(delta) = value.get("delta").and_then(|v| v.as_str()) {
-                    streamed_text.push_str(delta);
+                    on_delta(delta.to_string());
+                    self.streamed_text.push_str(delta);
                 }
             }
             Some("response.output_text.done") => {
                 if let Some(done_text) = value.get("text").and_then(|v| v.as_str())
                     && !done_text.is_empty()
                 {
-                    streamed_text.clear();
-                    streamed_text.push_str(done_text);
+                    self.streamed_text.clear();
+                    self.streamed_text.push_str(done_text);
                 }
             }
             _ => {}
         }
 
-        if let Some(response_value) = value.get_mut("response") {
-            if let Ok(parsed) =
+        if let Some(response_value) = value.get_mut("response")
+            && let Ok(parsed) =
                 serde_json::from_value::<ResponsesApiResponse>(response_value.take())
+        {
+            self.last_response = Some(parsed);
+            if event_type.as_deref() == Some("response.done")
+                || event_type.as_deref() == Some("response.completed")
             {
-                last_response = Some(parsed);
-                if event_type.as_deref() == Some("response.done")
-                    || event_type.as_deref() == Some("response.completed")
-                {
-                    break;
-                }
+                return true;
             }
         }
+
+        false
     }
 
-    if let Some(mut response) = last_response {
-        if response.output.is_empty() {
-            if !streamed_items.is_empty() {
-                response.output = streamed_items;
-            } else if !streamed_text.trim().is_empty() {
-                response.output.push(ResponsesOutputItem::Message {
+    /// Assembles the final [`ResponsesApiResponse`] from accumulated state.
+    ///
+    /// Prefers the `response` object from a terminal event. Falls back to
+    /// streamed text/items when the terminal response had empty output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::InvalidResponse`] when no response or streamed data
+    /// was accumulated.
+    pub(crate) fn into_api_response(self) -> Result<ResponsesApiResponse, LlmError> {
+        if let Some(mut response) = self.last_response {
+            if response.output.is_empty() {
+                if !self.streamed_items.is_empty() {
+                    response.output = self.streamed_items;
+                } else if !self.streamed_text.trim().is_empty() {
+                    response.output.push(ResponsesOutputItem::Message {
+                        role: Some("assistant".to_string()),
+                        content: vec![ResponsesOutputPart::OutputText {
+                            text: self.streamed_text,
+                        }],
+                    });
+                }
+            }
+            return Ok(response);
+        }
+
+        if !self.streamed_items.is_empty() || !self.streamed_text.trim().is_empty() {
+            let mut output = self.streamed_items;
+            if output.is_empty() {
+                output.push(ResponsesOutputItem::Message {
                     role: Some("assistant".to_string()),
                     content: vec![ResponsesOutputPart::OutputText {
-                        text: streamed_text,
+                        text: self.streamed_text,
                     }],
                 });
             }
-        }
-        return Ok(response);
-    }
-
-    if !streamed_items.is_empty() || !streamed_text.trim().is_empty() {
-        let mut output = streamed_items;
-        if output.is_empty() {
-            output.push(ResponsesOutputItem::Message {
-                role: Some("assistant".to_string()),
-                content: vec![ResponsesOutputPart::OutputText {
-                    text: streamed_text,
-                }],
+            return Ok(ResponsesApiResponse {
+                status: Some("completed".to_string()),
+                output,
+                usage: None,
+                incomplete_details: None,
             });
         }
-        return Ok(ResponsesApiResponse {
-            status: Some("completed".to_string()),
-            output,
-            usage: None,
-            incomplete_details: None,
-        });
+
+        Err(LlmError::InvalidResponse(
+            "no response data in Responses API stream".to_string(),
+        ))
     }
 
-    Err(LlmError::InvalidResponse(format!(
-        "Failed to parse Codex response payload. Body: {}",
-        preview_body(text)
-    )))
+    /// Convenience: assembles and parses the final response in one call.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::into_api_response`] and [`parse_responses_response`].
+    pub(crate) fn finish(self) -> Result<MessagesResponse, LlmError> {
+        parse_responses_response(self.into_api_response()?)
+    }
 }
 
 pub(crate) fn preview_body(body: &str) -> String {

--- a/src/llm/responses.rs
+++ b/src/llm/responses.rs
@@ -1,28 +1,50 @@
 use super::*;
 
 pub(crate) fn parse_openai_response(body: OpenAiResponse) -> Result<MessagesResponse, LlmError> {
-    let usage = body.usage;
     let choice = body
         .choices
         .into_iter()
         .next()
         .ok_or_else(|| LlmError::InvalidResponse("choices[0] missing".to_string()))?;
-    let mut tool_calls = choice
+    let tool_calls = choice
         .message
         .tool_calls
         .unwrap_or_default()
         .into_iter()
         .map(parse_tool_call)
         .collect::<Result<Vec<_>, _>>()?;
-
-    let mut content = extract_text(
+    let content = extract_text(
         choice
             .message
             .content
             .unwrap_or(OpenAiMessageContent::Text(String::new())),
     );
     let reasoning_content = choice.message.reasoning_content;
+    let usage = body.usage.and_then(|u| {
+        u.prompt_tokens
+            .zip(u.completion_tokens)
+            .map(|(pt, ct)| LlmUsage {
+                input_tokens: pt,
+                output_tokens: ct,
+            })
+    });
 
+    assemble_response(content, reasoning_content, tool_calls, usage)
+}
+
+/// Assembles the final `MessagesResponse` from accumulated Chat Completions
+/// fields, applying raw tool-use rescue when structured tool calls are absent.
+///
+/// Shared by the non-stream JSON path (`parse_openai_response`) and the SSE
+/// stream path (`ChatCompletionAccumulator`) to keep both consistent.
+pub(super) fn assemble_response(
+    content: String,
+    reasoning_content: Option<String>,
+    tool_calls: Vec<ToolCall>,
+    usage: Option<LlmUsage>,
+) -> Result<MessagesResponse, LlmError> {
+    let mut content = content.trim().to_string();
+    let mut tool_calls = tool_calls;
     if tool_calls.is_empty()
         && let Some((rescued_calls, stripped_content)) = rescue_raw_tool_calls(&content)
     {
@@ -40,14 +62,7 @@ pub(crate) fn parse_openai_response(body: OpenAiResponse) -> Result<MessagesResp
         content,
         reasoning_content,
         tool_calls,
-        usage: usage.and_then(|u| {
-            u.prompt_tokens
-                .zip(u.completion_tokens)
-                .map(|(pt, ct)| LlmUsage {
-                    input_tokens: pt,
-                    output_tokens: ct,
-                })
-        }),
+        usage,
     })
 }
 
@@ -166,7 +181,10 @@ fn extract_response_content_part(part: ResponsesOutputPart) -> Option<String> {
     }
 }
 
-fn parse_tool_arguments(arguments: &str, name: &str) -> Result<serde_json::Value, LlmError> {
+pub(super) fn parse_tool_arguments(
+    arguments: &str,
+    name: &str,
+) -> Result<serde_json::Value, LlmError> {
     if arguments.trim().is_empty() {
         return Ok(serde_json::json!({}));
     }

--- a/src/llm/responses.rs
+++ b/src/llm/responses.rs
@@ -262,9 +262,9 @@ pub(crate) fn parse_codex_responses_payload(text: &str) -> Result<ResponsesApiRe
         }
     }
 
-    accumulator.into_api_response().map_err(|_| {
+    accumulator.into_api_response().map_err(|error| {
         LlmError::InvalidResponse(format!(
-            "Failed to parse Codex response payload. Body: {}",
+            "Failed to parse Codex response payload ({error}). Body: {}",
             preview_body(text)
         ))
     })
@@ -275,14 +275,14 @@ pub(crate) fn parse_codex_responses_payload(text: &str) -> Result<ResponsesApiRe
 /// Shared by the non-stream Codex path ([`parse_codex_responses_payload`]) and
 /// the streaming Responses/Codex paths in `send_message_streaming` to keep
 /// delta extraction and final response assembly consistent.
-pub(crate) struct ResponsesAccumulator {
+pub(super) struct ResponsesAccumulator {
     streamed_text: String,
     streamed_items: Vec<ResponsesOutputItem>,
     last_response: Option<ResponsesApiResponse>,
 }
 
 impl ResponsesAccumulator {
-    pub(crate) fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             streamed_text: String::with_capacity(8192),
             streamed_items: Vec::with_capacity(32),
@@ -295,7 +295,7 @@ impl ResponsesAccumulator {
     /// Calls `on_delta` for each `response.output_text.delta` event. Returns
     /// `true` when a terminal event (`response.completed` / `response.done`)
     /// carrying a valid `response` object has been consumed.
-    pub(crate) fn process_event(&mut self, payload: &str, on_delta: &dyn Fn(String)) -> bool {
+    pub(super) fn process_event(&mut self, payload: &str, on_delta: &dyn Fn(String)) -> bool {
         let Ok(mut value) = serde_json::from_str::<serde_json::Value>(payload) else {
             return false;
         };
@@ -357,7 +357,7 @@ impl ResponsesAccumulator {
     ///
     /// Returns [`LlmError::InvalidResponse`] when no response or streamed data
     /// was accumulated.
-    pub(crate) fn into_api_response(self) -> Result<ResponsesApiResponse, LlmError> {
+    pub(super) fn into_api_response(self) -> Result<ResponsesApiResponse, LlmError> {
         if let Some(mut response) = self.last_response {
             if response.output.is_empty() {
                 if !self.streamed_items.is_empty() {
@@ -402,7 +402,7 @@ impl ResponsesAccumulator {
     /// # Errors
     ///
     /// See [`Self::into_api_response`] and [`parse_responses_response`].
-    pub(crate) fn finish(self) -> Result<MessagesResponse, LlmError> {
+    pub(super) fn finish(self) -> Result<MessagesResponse, LlmError> {
         parse_responses_response(self.into_api_response()?)
     }
 }

--- a/src/llm/sse.rs
+++ b/src/llm/sse.rs
@@ -34,23 +34,26 @@ where
             while let Some(newline) = buffer.find('\n') {
                 let line: String = buffer.drain(..=newline).collect();
                 if let Some(payload) = data_payload(line.trim()) {
-                    yield payload;
+                    yield payload.to_string();
                 }
             }
         }
         if let Some(payload) = data_payload(buffer.trim()) {
-            yield payload;
+            yield payload.to_string();
         }
     };
     produced.boxed()
 }
 
-fn data_payload(line: &str) -> Option<String> {
+/// Extracts the JSON payload from a single SSE `data:` line.
+///
+/// Returns `None` for blank payloads, `[DONE]` markers, and non-`data:` lines.
+pub(crate) fn data_payload(line: &str) -> Option<&str> {
     let payload = line.strip_prefix("data:")?.trim();
     if payload.is_empty() || payload == "[DONE]" {
         return None;
     }
-    Some(payload.to_string())
+    Some(payload)
 }
 
 #[cfg(test)]

--- a/src/llm/sse.rs
+++ b/src/llm/sse.rs
@@ -16,7 +16,7 @@ use futures_util::stream::BoxStream;
 /// Bytes are accumulated raw and lines are decoded individually so that a
 /// multibyte UTF-8 character bisected by a TCP segment boundary is reassembled
 /// rather than dropped.
-pub(crate) fn data_lines<S>(stream: S) -> BoxStream<'static, String>
+pub(super) fn data_lines<S>(stream: S) -> BoxStream<'static, String>
 where
     S: futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 {
@@ -53,7 +53,7 @@ where
 /// Extracts the JSON payload from a single SSE `data:` line.
 ///
 /// Returns `None` for blank payloads, `[DONE]` markers, and non-`data:` lines.
-pub(crate) fn data_payload(line: &str) -> Option<&str> {
+pub(super) fn data_payload(line: &str) -> Option<&str> {
     let payload = line.strip_prefix("data:")?.trim();
     if payload.is_empty() || payload == "[DONE]" {
         return None;

--- a/src/llm/sse.rs
+++ b/src/llm/sse.rs
@@ -12,33 +12,38 @@ use futures_util::stream::BoxStream;
 ///
 /// Each yielded `String` is the JSON text following `data:`. Stream item
 /// errors are logged and treated as end-of-stream.
+///
+/// Bytes are accumulated raw and lines are decoded individually so that a
+/// multibyte UTF-8 character bisected by a TCP segment boundary is reassembled
+/// rather than dropped.
 pub(crate) fn data_lines<S>(stream: S) -> BoxStream<'static, String>
 where
     S: futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 {
     let produced = stream! {
         let mut stream = stream.boxed();
-        let mut buffer = String::new();
+        let mut buffer: Vec<u8> = Vec::new();
         while let Some(chunk) = stream.next().await {
             let Ok(chunk) = chunk else {
                 tracing::warn!("SSE stream chunk error, stopping consumption");
                 break;
             };
-            match std::str::from_utf8(chunk.as_ref()) {
-                Ok(text) => buffer.push_str(text),
-                Err(_) => {
-                    tracing::warn!("non-UTF-8 chunk in SSE stream, skipping");
-                    continue;
-                }
-            }
-            while let Some(newline) = buffer.find('\n') {
-                let line: String = buffer.drain(..=newline).collect();
-                if let Some(payload) = data_payload(line.trim()) {
-                    yield payload.to_string();
+            buffer.extend_from_slice(chunk.as_ref());
+            while let Some(newline) = buffer.iter().position(|&b| b == b'\n') {
+                let line_bytes: Vec<u8> = buffer.drain(..=newline).collect();
+                match std::str::from_utf8(&line_bytes) {
+                    Ok(line) => {
+                        if let Some(payload) = data_payload(line.trim()) {
+                            yield payload.to_string();
+                        }
+                    }
+                    Err(_) => tracing::warn!("non-UTF-8 line in SSE stream, skipping"),
                 }
             }
         }
-        if let Some(payload) = data_payload(buffer.trim()) {
+        if let Ok(line) = std::str::from_utf8(&buffer)
+            && let Some(payload) = data_payload(line.trim())
+        {
             yield payload.to_string();
         }
     };
@@ -99,6 +104,25 @@ mod tests {
     async fn flushes_trailing_line_without_newline() {
         let mut lines = data_lines(stream::iter([chunk(b"data: tail")]));
         assert_eq!(lines.next().await.as_deref(), Some("tail"));
+        assert_eq!(lines.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn reassembles_multibyte_char_split_across_chunks() {
+        // Split the SSE line `data: {"a":"ファイル"}\n\n` at a byte offset
+        // that falls inside the 3-byte sequence of フ (U+30D5), simulating a
+        // TCP segment boundary that bisects a multibyte UTF-8 character.
+        let full = "data: {\"a\":\"ファイル\"}\n\n";
+        let bytes = full.as_bytes();
+        let char_start = full.find('フ').expect("フ present");
+        let split_at = char_start + 1;
+
+        let mut lines = data_lines(stream::iter([
+            chunk(&bytes[..split_at]),
+            chunk(&bytes[split_at..]),
+        ]));
+
+        assert_eq!(lines.next().await.as_deref(), Some(r#"{"a":"ファイル"}"#));
         assert_eq!(lines.next().await, None);
     }
 }

--- a/src/llm/sse.rs
+++ b/src/llm/sse.rs
@@ -1,0 +1,101 @@
+//! SSE line parser for streaming LLM responses.
+//!
+//! Reassembles `data:` lines split across TCP segment boundaries and yields
+//! each complete payload, skipping blank lines, `[DONE]`, and malformed input.
+
+use async_stream::stream;
+use bytes::Bytes;
+use futures_util::StreamExt;
+use futures_util::stream::BoxStream;
+
+/// Filters a `bytes_stream` into complete SSE `data:` payloads.
+///
+/// Each yielded `String` is the JSON text following `data:`. Stream item
+/// errors are logged and treated as end-of-stream.
+pub(crate) fn data_lines<S>(stream: S) -> BoxStream<'static, String>
+where
+    S: futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+{
+    let produced = stream! {
+        let mut stream = stream.boxed();
+        let mut buffer = String::new();
+        while let Some(chunk) = stream.next().await {
+            let Ok(chunk) = chunk else {
+                tracing::warn!("SSE stream chunk error, stopping consumption");
+                break;
+            };
+            match std::str::from_utf8(chunk.as_ref()) {
+                Ok(text) => buffer.push_str(text),
+                Err(_) => {
+                    tracing::warn!("non-UTF-8 chunk in SSE stream, skipping");
+                    continue;
+                }
+            }
+            while let Some(newline) = buffer.find('\n') {
+                let line: String = buffer.drain(..=newline).collect();
+                if let Some(payload) = data_payload(line.trim()) {
+                    yield payload;
+                }
+            }
+        }
+        if let Some(payload) = data_payload(buffer.trim()) {
+            yield payload;
+        }
+    };
+    produced.boxed()
+}
+
+fn data_payload(line: &str) -> Option<String> {
+    let payload = line.strip_prefix("data:")?.trim();
+    if payload.is_empty() || payload == "[DONE]" {
+        return None;
+    }
+    Some(payload.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures_util::StreamExt;
+    use futures_util::stream;
+
+    use super::data_lines;
+
+    fn chunk(bytes: &[u8]) -> Result<Bytes, reqwest::Error> {
+        Ok(Bytes::copy_from_slice(bytes))
+    }
+
+    #[tokio::test]
+    async fn yields_data_payloads_in_order() {
+        let body = "data: {\"a\":1}\n\ndata: {\"a\":2}\n\ndata: [DONE]\n\n";
+        let mut lines = data_lines(stream::iter([chunk(body.as_bytes())]));
+
+        assert_eq!(lines.next().await.as_deref(), Some(r#"{"a":1}"#));
+        assert_eq!(lines.next().await.as_deref(), Some(r#"{"a":2}"#));
+        assert_eq!(lines.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn reassembles_line_split_across_chunks() {
+        let mut lines = data_lines(stream::iter([chunk(b"data: {\"par"), chunk(b"t\":1}\n\n")]));
+
+        assert_eq!(lines.next().await.as_deref(), Some(r#"{"part":1}"#));
+        assert_eq!(lines.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn skips_blank_done_and_non_data_lines() {
+        let body = "event: ping\n\ngarbage\ndata: ok\n\ndata: [DONE]\n\n: comment\n";
+        let mut lines = data_lines(stream::iter([chunk(body.as_bytes())]));
+
+        assert_eq!(lines.next().await.as_deref(), Some("ok"));
+        assert_eq!(lines.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn flushes_trailing_line_without_newline() {
+        let mut lines = data_lines(stream::iter([chunk(b"data: tail")]));
+        assert_eq!(lines.next().await.as_deref(), Some("tail"));
+        assert_eq!(lines.next().await, None);
+    }
+}

--- a/src/pulse/scheduler.rs
+++ b/src/pulse/scheduler.rs
@@ -937,6 +937,17 @@ body
                 }),
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: std::sync::Arc<Vec<crate::llm::Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     #[tokio::test]
@@ -1091,6 +1102,17 @@ intentions:
         ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
             std::future::pending().await
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: std::sync::Arc<Vec<crate::llm::Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     struct PanickingLlm;
@@ -1112,6 +1134,17 @@ intentions:
             _tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
         ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
             panic!("panicking-mock-llm: boom from send_message")
+        }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: std::sync::Arc<Vec<crate::llm::Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1257,6 +1257,17 @@ mod tests {
                 usage: None,
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: std::sync::Arc<Vec<crate::llm::Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     struct StubFailingProvider;
@@ -1278,6 +1289,17 @@ mod tests {
             Err(crate::error::LlmError::InvalidResponse(
                 "stub failure".to_string(),
             ))
+        }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: std::sync::Arc<Vec<crate::llm::Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
         }
     }
 

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -832,6 +832,17 @@ mod tests {
                 usage: None,
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     fn build_test_state() -> (AppState, tempfile::TempDir) {

--- a/src/sleep/orchestrator.rs
+++ b/src/sleep/orchestrator.rs
@@ -1883,6 +1883,17 @@ mod tests {
                 },
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<Arc<Vec<ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     fn test_db() -> (Database, tempfile::TempDir) {
@@ -2335,6 +2346,17 @@ mod tests {
                 usage: None,
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<Arc<Vec<ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     #[tokio::test]
@@ -2444,6 +2466,17 @@ mod tests {
                     output_tokens,
                 }),
             })
+        }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: Arc<Vec<Message>>,
+            tools: Option<Arc<Vec<ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
         }
     }
 

--- a/src/sleep/scheduler.rs
+++ b/src/sleep/scheduler.rs
@@ -634,6 +634,17 @@ mod tests {
                 }),
             })
         }
+
+        async fn send_message_streaming(
+            &self,
+            system: &str,
+            messages: std::sync::Arc<Vec<crate::llm::Message>>,
+            tools: Option<std::sync::Arc<Vec<crate::llm::ToolDefinition>>>,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
+            let _ = on_delta;
+            self.send_message(system, messages, tools).await
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 概要

ツール実行前にエージェントが発する一言（narration）が Discord/Telegram に表示されない不具合を修正。

**根本原因**: `OpenAiProvider` が `send_message_streaming` を実装しておらず、トレイトのデフォルト実装（`on_delta` を黙殺して非ストリーム `send_message` へ fallback）に依存していたため、`AgentEvent::Delta` が一度も発火していなかった。narration は `Delta` → `ToolProgressCoordinator::pending_narration` → `💬 <text>` の経路にのみ依存するため、起点が繋がらないと機能全体が死んでいた。

## 設計方針（C 案：両必須化 ＋ 内部共有コア）

- `LlmProvider` トレイトの `send_message` / `send_message_streaming` を**両方必須化**（デフォルト削除）。オーバーライド忘れの silent 死をコンパイル時に排除。
- `OpenAiProvider::send_message`（非ストリーム JSON）は既存パス保護のため温存。local/OpenRouter/DeepSeek 等の互換エンドポイント対応と既存呼び出し（pulse/sleep 等）は影響ゼロ。
- `send_message_streaming` を Chat Completions / Responses API / Codex の全パスで真のSSE実装（`bytes_stream()` 逐次消費・`on_delta` 即時転送）。
- 内部共有コア（`ChatCompletionAccumulator` / `ResponsesAccumulator` / `assemble_response`・`parse_tool_arguments` の `pub(super)` 化）で両パスの乖離を抑制。
- usage は互換性優先で best-effort（`stream_options` は送らない・欠落時 `None`）。reasoning_content は蓄積して維持（DeepSeek 互換の What 不変）。

## 検証

- `cargo fmt --check` / `cargo check --all-targets` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test`（1498 passed）/ `cargo doc` すべて緑
- wiremock-backed **実 `OpenAiProvider`** による end-to-end テスト追加（`provider_streaming_drives_coordinator_narration`）。モックプロバイダでなく実プロバイダ経路で、`Delta` → coordinator の `💬` 描画まで結合ギャップなしを証明。

## テスト

新規10件（SSE パーサ単体4 + Chat Completions ストリーミング3 + Responses/Codex ストリーミング2 + end-to-end1）。既存テスト全緑（振る舞い不変・回帰なし）。

Plan: `docs/plan/plan-llm-provider-streaming.md`（Codex レビュー3巡で設計を確定）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLMのストリーミング（SSE）処理を強化し、通常テキスト・推論内容・ツール呼び出しを段階的に反映できるようになりました。
  * OpenAI互換のストリーミングを、通常/Responses/Codexの経路に応じて適切に処理します。
* **Bug Fixes**
  * ツール進捗のナレーション表示が、ツール行表示より前に反映されるよう改善しました。
  * チャンク分割や末尾改行がない場合でも受信を安定化しました。
* **Documentation**
  * ストリーミング時の進捗（ナレーション）に関する注意点を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->